### PR TITLE
Enable stricter compiler warnings

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -16,7 +16,9 @@ jobs:
           submodules: recursive  # fetch submodules
 
       - name: Ensure submodules are updated
-        run: git submodule update --init --recursive
+        run: |
+            sudo apt-get install g++ clang libelf-dev libc6-dev-i386 libdw-dev
+            git submodule update --init --recursive
 
       - name: Run Makefile build
         run: make all

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ INCLUDES := -I$(OUTPUT) \
 # Compiler flags
 CLANG_BPF_SYS_INCLUDES := $(shell $(CLANG) -v -E - </dev/null 2>&1 | \
     sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
-CXXFLAGS := -g -O2 -D__TARGET_ARCH_$(ARCH) $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES)
+CXXFLAGS := -g -O2 -Wall -Wextra -Wno-unused-function -Wno-address-of-packed-member -D__TARGET_ARCH_$(ARCH) $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES)
 LIBS := $(LIBBPF_OBJ) -lelf -ldw -lz -ldl
 
 # Build verbosity control
@@ -154,7 +154,7 @@ $(OUTPUT)/%.o: $(OSDTRACE_SRC)/%.cc $(OSDTRACE_SRC)/*.h $(OUTPUT)/%.skel.h | $(O
 	$(Q)$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 # Special rule for dwarf_parser.o since it doesn't need a skel.h
-$(OUTPUT)/dwarf_parser.o: $(OSDTRACE_SRC)/dwarf_parser.cc $(OSDTRACE_SRC)/*.h | $(OUTPUT) $(LIBBPF_OBJ)
+$(OUTPUT)/dwarf_parser.o: $(OSDTRACE_SRC)/dwarf_parser.cc $(OUTPUT)/osdtrace.skel.h $(OSDTRACE_SRC)/*.h | $(OUTPUT) $(LIBBPF_OBJ)
 	$(call msg,CXX,$@)
 	$(Q)$(CXX) $(CXXFLAGS) -c -o $@ $<
 

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -60,7 +60,6 @@ class DwarfParser {
 
   ~DwarfParser();
   void add_module(std::string);
-  void print_die(Dwarf_Die *);
   bool die_has_loclist(Dwarf_Die *);
   bool has_loclist();
   Dwarf_Die *resolve_typedecl(Dwarf_Die *);

--- a/src/kfstrace.bpf.c
+++ b/src/kfstrace.bpf.c
@@ -453,7 +453,6 @@ int trace_prepare_send_request(struct pt_regs *ctx)
 
     struct ceph_mds_session *session = (struct ceph_mds_session *)PT_REGS_PARM1(ctx);
     struct ceph_mds_request *req = (struct ceph_mds_request *)PT_REGS_PARM2(ctx);
-    bool drop_cap_releases = (bool)PT_REGS_PARM3(ctx);
 
     if (!req) {
         bpf_printk("MDS PREPARE_SEND: req is NULL\n");

--- a/src/kfstrace.cc
+++ b/src/kfstrace.cc
@@ -85,6 +85,7 @@ static volatile bool exiting = false;
 
 static void sig_handler(int sig)
 {
+    (void)sig;
     exiting = true;
 }
 
@@ -157,12 +158,13 @@ static std::string format_ops(const kernel_trace_event* event)
 
 static int handle_event(void *ctx, void *data, size_t data_sz)
 {
+    (void)ctx;
     const struct kernel_trace_event *event = (const struct kernel_trace_event *)data;
     struct tm *tm;
     char ts[32];
     char acting_set[256] = "";
     time_t t;
-    int pos = 0;
+    size_t pos = 0;
 
     if (data_sz < sizeof(*event)) {
         fprintf(stderr, "Invalid event size: %zu (expected >= %zu)\n", data_sz, sizeof(*event));
@@ -179,9 +181,9 @@ static int handle_event(void *ctx, void *data, size_t data_sz)
         for (unsigned int i = 0; i < event->acting_size && i < CEPH_PG_MAX_SIZE; i++) {
             if (i > 0)
                 pos += snprintf(acting_set + pos, sizeof(acting_set) - pos, ",");
-            pos += snprintf(acting_set + pos, sizeof(acting_set) - pos, "%u", 
+            pos += snprintf(acting_set + pos, sizeof(acting_set) - pos, "%u",
                            event->acting_osds[i]);
-            if (pos >= sizeof(acting_set) - 1) break;
+            if (pos >= sizeof(acting_set)) break;
         }
         snprintf(acting_set + pos, sizeof(acting_set) - pos, "]");
     } else {
@@ -221,6 +223,7 @@ static int handle_event(void *ctx, void *data, size_t data_sz)
 
 static int handle_mds_event(void *ctx, void *data, size_t data_sz)
 {
+    (void)ctx;
     const struct mds_trace_event *event = (const struct mds_trace_event *)data;
     struct tm *tm;
     char ts[32];

--- a/src/osdtrace.bpf.c
+++ b/src/osdtrace.bpf.c
@@ -386,6 +386,7 @@ int uprobe_submit_transaction(struct pt_regs *ctx) {
 // BlueStore::queue_transactions
 SEC("uprobe")
 int uprobe_queue_transactions(struct pt_regs *ctx) {
+  (void)ctx;
   bpf_printk("Entered into uprobe_queue_transactions\n");
   __u64 ptid = bpf_get_current_pid_tgid();
   struct op_k *key = bpf_map_lookup_elem(&ptid_opk, &ptid);
@@ -410,6 +411,7 @@ int uprobe_queue_transactions(struct pt_regs *ctx) {
 // BlueStore::_do_write
 SEC("uprobe")
 int uprobe_do_write(struct pt_regs *ctx) {
+  (void)ctx;
   bpf_printk("Entered into uprobe_do_write\n");
   __u64 ptid = bpf_get_current_pid_tgid();
   struct op_k *key = bpf_map_lookup_elem(&ptid_opk, &ptid);
@@ -604,7 +606,7 @@ int uprobe_log_op_stats(struct pt_regs *ctx) {
         "uprobe_log_op_stats, no previous op info, owner %lld, tid %lld\n",
         key.owner, key.tid);
   }
-end:
+
   bpf_map_delete_elem(&ops, &key);
   return 0;
 }

--- a/src/radostrace.bpf.c
+++ b/src/radostrace.bpf.c
@@ -230,7 +230,7 @@ int uprobe_send_op(struct pt_regs *ctx) {
   val->ops_size &= 3;
   val->offset = 0;
   val->length = 0;
-  for (int i = 0; i  < 3; ++i) {
+  for (__u32 i = 0; i  < 3; ++i) {
     if (i < val->ops_size) {
       bpf_probe_read_user(&(val->ops[i]), sizeof(val->ops[i]), (void *)m_start); 
       if (ceph_osd_op_extent(val->ops[i])){

--- a/src/radostrace.cc
+++ b/src/radostrace.cc
@@ -221,6 +221,8 @@ int digitnum(int x) {
 }
 
 static int handle_event(void *ctx, void *data, size_t size) {
+    (void)ctx;
+    (void)size;
     struct client_op_v * op_v = (struct client_op_v *)data;
     std::stringstream ss;
     ss << std::hex << op_v->m_seed;
@@ -282,7 +284,7 @@ static int handle_event(void *ctx, void *data, size_t size) {
     std::stringstream ops_list;
     bool print_offset_length = false;
     ops_list << "[";
-    for (int i = 0; i < op_v->ops_size; ++i) {
+    for (__u32 i = 0; i < op_v->ops_size; ++i) {
         if (i) ops_list << " ";
         if (ceph_osd_op_extent(op_v->ops[i])) {
             ops_list << ceph_osd_op_str(op_v->ops[i]);


### PR DESCRIPTION
 
- Enable stricter gcc warnings and fix reported issues
- Fix a Makefile dependency to enable parallel build (e.g., make -j4)
