### PR TITLE
Use basename as module key instead of full path

### DIFF
--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -29,6 +29,7 @@ extern "C" {
 #include "bpf_ceph_types.h"
 #include "dwarf_parser.h"
 #include "version_utils.h"
+#include "utils.h"
 
 #define MAX_CNT 100000ll
 #define MAX_OSD 4000
@@ -1118,7 +1119,8 @@ int parse_args(int argc, char **argv) {
 }
 
 void fill_map_hprobes(std::string mod_path, DwarfParser &dwarfparser, struct bpf_map *hprobes) {
-  auto &func2vf = dwarfparser.mod_func2vf[mod_path];
+  std::string mod_basename = get_basename(mod_path);
+  auto &func2vf = dwarfparser.mod_func2vf[mod_basename];
   for (auto x : func2vf) {
     std::string funcname = x.first;
     int key_idx = func_id[funcname];
@@ -1152,7 +1154,8 @@ int attach_uprobe(struct osdtrace_bpf *skel,
     pid_path = "/proc/" + std::to_string(process_id) + "/root/" + path;
   }
 
-  auto &func2pc = dp.mod_func2pc[path];
+  std::string path_basename = get_basename(path);
+  auto &func2pc = dp.mod_func2pc[path_basename];
   size_t func_addr = func2pc[funcname];
   if (v > 0)
       funcname = funcname + "_v" + std::to_string(v); 
@@ -1176,7 +1179,8 @@ int attach_retuprobe(struct osdtrace_bpf *skel,
 	           std::string path,
 		   std::string funcname,
 		   int v = 0) {
-  auto &func2pc = dp.mod_func2pc[path];
+  std::string path_basename = get_basename(path);
+  auto &func2pc = dp.mod_func2pc[path_basename];
   size_t func_addr = func2pc[funcname];
   if (v > 0)
       funcname = funcname + "_v" + std::to_string(v); 

--- a/src/radostrace.cc
+++ b/src/radostrace.cc
@@ -36,6 +36,7 @@ extern "C" {
 #include "bpf_ceph_types.h"
 #include "dwarf_parser.h"
 #include "version_utils.h"
+#include "utils.h"
 
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
@@ -99,7 +100,8 @@ const char * ceph_osd_op_str(int opc) {
 }
 
 void fill_map_hprobes(std::string mod_path, DwarfParser &dwarfparser, struct bpf_map *hprobes) {
-  auto &func2vf = dwarfparser.mod_func2vf[mod_path];
+  std::string mod_basename = get_basename(mod_path);
+  auto &func2vf = dwarfparser.mod_func2vf[mod_basename];
   for (auto x : func2vf) {
     std::string funcname = x.first;
     int key_idx = func_id[funcname];
@@ -153,7 +155,8 @@ int attach_uprobe(struct radostrace_bpf *skel,
     pid_path = "/proc/" + std::to_string(process_id) + "/root" + path;
   }
 
-  auto &func2pc = dp.mod_func2pc[path];
+  std::string path_basename = get_basename(path);
+  auto &func2pc = dp.mod_func2pc[path_basename];
   size_t func_addr = func2pc[funcname];
   if (v > 0)
       funcname = funcname + "_v" + std::to_string(v);
@@ -188,7 +191,8 @@ int attach_retuprobe(struct radostrace_bpf *skel,
     pid_path = "/proc/" + std::to_string(process_id) + "/root" + path;
   }
 
-  auto &func2pc = dp.mod_func2pc[path];
+  std::string path_basename = get_basename(path);
+  auto &func2pc = dp.mod_func2pc[path_basename];
   size_t func_addr = func2pc[funcname];
   if (v > 0)
       funcname = funcname + "_v" + std::to_string(v);

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,13 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <string>
+
+// Extract basename from a file path (e.g., "/usr/bin/ceph-osd" -> "ceph-osd")
+inline std::string get_basename(const std::string& path) {
+    size_t pos = path.find_last_of('/');
+    return (pos != std::string::npos) ? path.substr(pos + 1) : path;
+}
+
+#endif // UTILS_H
+


### PR DESCRIPTION
Store and retrieve DWARF data using basename (e.g., "ceph-osd")
rather than full path (e.g., "/usr/bin/ceph-osd"). This resolves
path mismatch issues in container/snap environments.

import_from_json includes backward compatibility for legacy JSON files with full paths.