### PR TITLE
radostrace: use BPF global variable to define SIZE/OFFSETS instead of…

### DIFF
--- a/src/bpf_ceph_types.h
+++ b/src/bpf_ceph_types.h
@@ -15,17 +15,10 @@
 #define CEPH_OSD_FLAG_READ 0x0010
 #define CEPH_OSD_FLAG_WRITE 0x0020
 
-#define CEPH_OSD_OP_SIZE 152 // see OSDOp
-//#define CEPH_OSD_OP_UNION_OFFSET 12 // refer ceph_osd_op
-#define CEPH_OSD_OP_EXTENT_OFFSET_OFFSET 6 // refer ceph_osd_op
-#define CEPH_OSD_OP_EXTENT_LENGTH_OFFSET 14 // refer ceph_osd_op
-
-#define CEPH_OSD_OP_CLS_CLASS_OFFSET 6
-#define CEPH_OSD_OP_CLS_METHOD_OFFSET 7
-
-#define CEPH_OSD_OP_BUFFER_CARRIAGE_OFFSET 96 //offset from the start of OSDOp 
-#define CEPH_OSD_OP_BUFFER_RAW_OFFSET 8  //offset in the ptr_node (_carriage)
-#define CEPH_OSD_OP_BUFFER_DATA_OFFSET 32 // offset in the raw 
+/* Note: CEPH_OSD_OP_* struct offset constants are now defined as global variables
+ * in radostrace.bpf.c and set by userspace via skel->rodata-> before BPF load.
+ * This allows runtime configuration of struct offsets for different Ceph versions.
+ */ 
 
 static const __u8 flag_queued_for_pg=1 << 0;
 static const __u8 flag_reached_pg =  1 << 1;

--- a/src/radostrace.bpf.c
+++ b/src/radostrace.bpf.c
@@ -29,6 +29,16 @@ struct {
   __uint(max_entries, 8192);
 } hprobes SEC(".maps");
 
+/* Global variables for struct offsets - set by userspace before loading */
+const volatile __u32 CEPH_OSD_OP_SIZE = 0;
+const volatile __u32 CEPH_OSD_OP_EXTENT_OFFSET_OFFSET = 0;
+const volatile __u32 CEPH_OSD_OP_EXTENT_LENGTH_OFFSET = 0;
+const volatile __u32 CEPH_OSD_OP_CLS_CLASS_OFFSET = 0;
+const volatile __u32 CEPH_OSD_OP_CLS_METHOD_OFFSET = 0;
+const volatile __u32 CEPH_OSD_OP_BUFFER_CARRIAGE_OFFSET = 0;
+const volatile __u32 CEPH_OSD_OP_BUFFER_RAW_OFFSET = 0;
+const volatile __u32 CEPH_OSD_OP_BUFFER_DATA_OFFSET = 0;
+
 void initialize_value(struct client_op_k key) {
   struct client_op_v val;
   memset(&val, 0, sizeof(val));

--- a/src/version_utils.h
+++ b/src/version_utils.h
@@ -79,4 +79,22 @@ bool check_process_executable_deleted(int pid, const std::string& exe_name);
  */
 bool check_executable_deleted(int process_id, const std::string& exe_name);
 
+/**
+ * Check if the Ceph version is squid (19.2.0) or above.
+ * Parses version strings from dpkg (e.g., "19.2.0-0ubuntu0.22.04.1")
+ * or rpm (e.g., "2:19.2.0-1.el9") formats.
+ *
+ * @param version The version string from get_package_version()
+ * @return true if version >= 19.2.0, false otherwise
+ */
+bool is_ceph_version_squid_or_above(const std::string& version);
+
+/**
+ * Get the version string from a DWARF JSON file.
+ *
+ * @param json_file The path to the JSON file
+ * @return The version string, or empty string if not found or error
+ */
+std::string get_version_from_json(const std::string& json_file);
+
 #endif // VERSION_UTILS_H


### PR DESCRIPTION
… MICROS

            Fix bug when extracting OSDOp in ceph version >= 19.2.0