### PR TITLE
Fix dangling pointer in resolve_typedecl

### DIFF
--- a/src/dwarf_parser.cc
+++ b/src/dwarf_parser.cc
@@ -85,9 +85,9 @@ Dwarf_Die *DwarfParser::resolve_typedecl(Dwarf_Die *type) {
   string type_name = cache_type_prefix(type) + string(name);
 
   for (auto &p : global_type_cache) {
-    auto cus = p.second;
+    auto &cus = p.second;
     for (auto i = cus.begin(); i != cus.end(); ++i) {
-      auto v = (*i).second;
+      auto &v = (*i).second;
       if (v.find(type_name) != v.end()) return &(v[type_name]);
     }
   }


### PR DESCRIPTION
Use references instead of copies for local variables `cus` and `v` in the global_type_cache lookup loop. The previous code returned a pointer to a local copy that would be destroyed on scope exit, causing undefined behavior when the caller dereferenced it.

# Test env

Ubuntu 24.04.4 LTS (Noble), deployed via Juju on MAAS
ceph-osd 19.2.3-0ubuntu0.24.04.3 with debug symbols (ceph-osd-dbgsym)
cephtrace built from upstream taodd/cephtrace (commit cb8fa91)

# Reproduce

## Before patch
```shell
$ sudo ./osdtrace -j /tmp/osd_dwarf.json
# completes normally

$ sudo MALLOC_PERTURB_=165 ./osdtrace -j /tmp/osd_dwarf.json
Segmentation fault (core dumped)
# exit code 139
``` 

## After patch
```shell
$ sudo MALLOC_PERTURB_=165 ./osdtrace -j /tmp/osd_dwarf.json
# completes normally
```

Thanks

