### PR TITLE
Fix dangling pointer from putenv() with stack buffer

### DIFF
--- a/src/dwarf_parser.cc
+++ b/src/dwarf_parser.cc
@@ -766,8 +766,7 @@ static int handle_module(Dwfl_Module *dwflmod, void **userdata,
 int DwarfParser::parse() {
   if(getenv("DEBUGINFOD_URLS") == NULL) {
     //If the DEBUGINFOD_URLS is not set, set it to https://debuginfod.ubuntu.com as default
-    char envs[] = "DEBUGINFOD_URLS=https://debuginfod.ubuntu.com";
-    putenv(envs);
+    setenv("DEBUGINFOD_URLS", "https://debuginfod.ubuntu.com", 0);
   }
 
   for (auto dwfl: dwfls) {


### PR DESCRIPTION
putenv() does not copy the string; it inserts the pointer directly into the environment array (POSIX, glibc >= 2.1.2). Passing a local char[] to putenv() causes a dangling pointer when the function returns and the stack frame is reclaimed (SEI CERT C POS34-C violation).

Replace putenv() with setenv(), which copies the value internally.