### PR TITLE
Fix acting[] array out-of-bounds access in radostrace

### DIFF
--- a/src/bpf_ceph_types.h
+++ b/src/bpf_ceph_types.h
@@ -12,6 +12,8 @@
 #define MSG_OSD_EC_READ 110
 #define MSG_OSD_EC_READ_REPLY 111
 
+#define MAX_ACTING 16
+
 #define CEPH_OSD_FLAG_READ 0x0010
 #define CEPH_OSD_FLAG_WRITE 0x0020
 
@@ -54,7 +56,7 @@ struct client_op_v {
   char object_name[128];
   __u64 m_pool;
   __u32 m_seed;
-  int acting[6];
+  int acting[MAX_ACTING];
   __u64 offset;
   __u64 length;
   __u16 ops[3];

--- a/src/radostrace.bpf.c
+++ b/src/radostrace.bpf.c
@@ -320,7 +320,7 @@ int uprobe_finish_op(struct pt_regs *ctx) {
   opv->finish_stamp = bpf_ktime_get_boot_ns();
   opv->pid = get_pid();
   // submit to ringbuf
-  struct client_op_v *e = bpf_ringbuf_reserve(&rb, sizeof(struct op_v), 0);
+  struct client_op_v *e = bpf_ringbuf_reserve(&rb, sizeof(struct client_op_v), 0);
   if (NULL == e) {
     return 0;
   }

--- a/src/radostrace.bpf.c
+++ b/src/radostrace.bpf.c
@@ -39,10 +39,10 @@ const volatile __u32 CEPH_OSD_OP_BUFFER_CARRIAGE_OFFSET = 0;
 const volatile __u32 CEPH_OSD_OP_BUFFER_RAW_OFFSET = 0;
 const volatile __u32 CEPH_OSD_OP_BUFFER_DATA_OFFSET = 0;
 
+static struct client_op_v zero_val = {};
+
 void initialize_value(struct client_op_k key) {
-  struct client_op_v val;
-  memset(&val, 0, sizeof(val));
-  bpf_map_update_elem(&ops, &key, &val, 0);
+  bpf_map_update_elem(&ops, &key, &zero_val, 0);
 }
 
 SEC("uprobe")
@@ -198,7 +198,7 @@ int uprobe_send_op(struct pt_regs *ctx) {
     return 0;
   }
 
-  for (int i = 0 ; i < 8; ++i) {
+  for (int i = 0 ; i < MAX_ACTING; ++i) {
     val->acting[i] = -1;
     if (M_start < m_finish) {
 	bpf_probe_read_user(&(val->acting[i]), sizeof(int), (void *)M_start);

--- a/src/radostrace.cc
+++ b/src/radostrace.cc
@@ -282,7 +282,7 @@ static int handle_event(void *ctx, void *data, size_t size) {
     acting_osd_list << "[";
     {
         bool first = true;
-        for (int i = 0; i < 8; ++i) {
+        for (int i = 0; i < MAX_ACTING; ++i) {
             if (op_v->acting[i] < 0) break;
             if (!first) acting_osd_list << ",";
             acting_osd_list << op_v->acting[i];


### PR DESCRIPTION
acting[] was originally declared as acting[8] in commit a224791, with matching loop bounds of i < 8. Later, commit ada1407 reduced the array to acting[6] to make room for cls_ops[3], but forgot to update the loop bounds in radostrace.cc and radostrace.bpf.c, causing OOB access.