### PR TITLE
report hung radostrace ops on interrupt

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,16 @@ sudo ./radostrace -i 17.2.9-0ubuntu0.22.04.3_dwarf.json -p <qemu-pid>
 ### Sample Output:
 
 ```
-     pid  client     tid  pool  pg     acting       w/r    size  latency     object[ops][offset,length]
-   19015   34206  419357     2  1e     [1,11,121]     W        0     887     rbd_header.374de3730ad0[watch ]
-   19015   34206  419358     2  1e     [1,11,121]     W        0    8561     rbd_header.374de3730ad0[call ]
-   19015   34206  419359     2  39     [0,121,11]     R     4096    1240     rbd_data.374de3730ad0.0000000000000000[read ][0, 4096]
-   19015   34206  419360     2  39     [0,121,11]     R     4096    1705     rbd_data.374de3730ad0.0000000000000000[read ][4096, 4096]
-   19015   34206  419361     2  39     [0,121,11]     R     4096    1334     rbd_data.374de3730ad0.0000000000000000[read ][12288, 4096]
-   19015   34206  419362     2  2b     [77,11,1]      R     4096    2180     rbd_data.374de3730ad0.00000000000000ff[read ][4128768, 4096]
+     pid  client     tid  pool  pg     acting       w/r    size  latency   Complete     object[ops][offset,length]
+   19015   34206  419357     2  1e     [1,11,121]     W        0     887          1     rbd_header.374de3730ad0[watch ]
+   19015   34206  419358     2  1e     [1,11,121]     W        0    8561          1     rbd_header.374de3730ad0[call ]
+   19015   34206  419359     2  39     [0,121,11]     R     4096    1240          1     rbd_data.374de3730ad0.0000000000000000[read ][0, 4096]
+   19015   34206  419360     2  39     [0,121,11]     R     4096    1705          1     rbd_data.374de3730ad0.0000000000000000[read ][4096, 4096]
+   19015   34206  419361     2  39     [0,121,11]     R     4096    1334          1     rbd_data.374de3730ad0.0000000000000000[read ][12288, 4096]
+   19015   34206  419362     2  2b     [77,11,1]      R     4096    2180          1     rbd_data.374de3730ad0.00000000000000ff[read ][4128768, 4096]
 ```
+Ops still in flight when tracing stops (Ctrl-C or `-t`) are printed with
+`Complete` set to 0 and `latency` showing how long they have been outstanding.
 
 📖 **Detailed guide:** [Getting Started](doc/getting-started.md)
 

--- a/doc/radostrace.md
+++ b/doc/radostrace.md
@@ -129,6 +129,9 @@ sudo ./radostrace -t 60
 ```bash
 sudo ./radostrace -p 12345 -o events.csv
 ```
+The CSV has the same columns as the terminal output, with `object[ops]` split
+into `object`, `ops`, `offset` and `length`:
+`pid,client,tid,pool,pg,acting,WR,size,latency,Complete,object,ops,offset,length`.
 
 #### Use DWARF JSON file
 ```bash
@@ -160,13 +163,13 @@ sudo ./radostrace -p 12345 -i dwarf.json --skip-version-check
 ### Example Output
 
 ```
-     pid  client     tid  pool  pg     acting            w/r    size  latency     object[ops][offset,length]
-   19015   34206  419357     2  1e     [1,11,121,77,0]     W        0     887     rbd_header.374de3730ad0[watch ]
-   19015   34206  419358     2  1e     [1,11,121,77,0]     W        0    8561     rbd_header.374de3730ad0[call ]
-   19015   34206  419359     2  39     [0,121,11,77,1]     R     4096    1240     rbd_data.374de3730ad0.0000000000000000[read ][0, 4096]
-   19015   34206  419360     2  39     [0,121,11,77,1]     R     4096    1705     rbd_data.374de3730ad0.0000000000000000[read ][4096, 4096]
-   19015   34206  419361     2  39     [0,121,11,77,1]     R     4096    1334     rbd_data.374de3730ad0.0000000000000000[read ][12288, 4096]
-   19015   34206  419362     2  2b     [77,11,1,0,121]     R     4096    2180     rbd_data.374de3730ad0.00000000000000ff[read ][4128768, 4096]
+     pid  client     tid  pool  pg     acting            w/r    size  latency   Complete     object[ops][offset,length]
+   19015   34206  419357     2  1e     [1,11,121,77,0]     W        0     887          1     rbd_header.374de3730ad0[watch ]
+   19015   34206  419358     2  1e     [1,11,121,77,0]     W        0    8561          1     rbd_header.374de3730ad0[call ]
+   19015   34206  419359     2  39     [0,121,11,77,1]     R     4096    1240          1     rbd_data.374de3730ad0.0000000000000000[read ][0, 4096]
+   19015   34206  419360     2  39     [0,121,11,77,1]     R     4096    1705          1     rbd_data.374de3730ad0.0000000000000000[read ][4096, 4096]
+   19015   34206  419361     2  39     [0,121,11,77,1]     R     4096    1334          1     rbd_data.374de3730ad0.0000000000000000[read ][12288, 4096]
+   19015   34206  419362     2  2b     [77,11,1,0,121]     R     4096    2180          1     rbd_data.374de3730ad0.00000000000000ff[read ][4128768, 4096]
 ```
 
 ### Column Descriptions
@@ -183,7 +186,8 @@ Each row represents one I/O operation sent from the client to the Ceph cluster:
 | **acting** | OSD acting set | [1,11,121,77,0] | OSDs handling this PG (primary first) |
 | **w/r** | Operation type | R or W | Read (R) or Write (W) |
 | **size** | Operation size in bytes | 4096 | Data size being read/written (0 for metadata ops) |
-| **latency** | Operation latency | 1240 | End-to-end latency in microseconds (μs) |
+| **latency** | Operation latency | 1240 | End-to-end latency in microseconds (μs). For an incomplete op (Complete=0) this is how long the op had been outstanding when tracing stopped |
+| **Complete** | Reply seen | 1 or 0 | 1: the reply arrived while tracing. 0: the op was still in flight when radostrace stopped (Ctrl-C or `-t` timeout); see [Incomplete Operations](#incomplete-operations) |
 | **object** | Object name and operations | rbd_data....[read][0, 4096] | Object name, operation type, offset, length. Up to 3 ops are listed; a request carrying more ends with a truncation count, e.g. `[create setxattr setxattr ...+9]` |
 
 ### Understanding the Output
@@ -198,6 +202,27 @@ Operations with size 0 are typically metadata operations:
 - `call` - Class method calls (e.g., RBD header operations)
 - `stat` - Object stat operations
 - `create` - Object creation
+
+#### Incomplete Operations
+Every row printed while tracing runs has `Complete=1`: the row is emitted when
+the reply arrives. When radostrace stops, on Ctrl-C or when the `-t` timeout
+expires, it prints one more row for every op that was sent but has not been
+answered yet, with `Complete=0` and `latency` set to how long the op has been
+outstanding so far.
+
+On a healthy cluster these are just the client's queue depth worth of
+in-flight ops, with latencies similar to the completed rows. An op that has
+been outstanding for seconds is stuck somewhere; its `acting` set tells you
+which OSDs to look at:
+
+```
+     pid  client     tid  pool  pg     acting     w/r    size  latency   Complete     object[ops][offset,length]
+   19015   34206  421811     2  12     [0,1,2]      W     4096  3028342          0     rbd_data.374de3730ad0.0000000000000041[write ][0, 4096]
+   19015   34206  421813     2  1c     [0,1,2]      W     4096  3025218          0     rbd_data.374de3730ad0.0000000000000043[write ][0, 4096]
+```
+
+Nothing but rows is written to stdout, so `grep ' 0     '`-style filtering
+or the CSV `Complete` column can be used to pick these out.
 
 #### Acting Set
 The first OSD in the acting set is the **primary OSD**. The client sends all operations to the primary, which then coordinates with replicas.

--- a/src/radostrace.bpf.c
+++ b/src/radostrace.bpf.c
@@ -94,7 +94,6 @@ int uprobe_send_op(struct pt_regs *ctx) {
   if (val == NULL) {
     return 0;
   }
-  val->sent_stamp = bpf_ktime_get_boot_ns();
   val->tid = key.tid;
   val->cid = key.cid;
 
@@ -173,6 +172,8 @@ int uprobe_send_op(struct pt_regs *ctx) {
     }
   }
 
+  val->sent_stamp = bpf_ktime_get_boot_ns();
+  val->pid = get_pid();
   return 0;
 }
 
@@ -194,7 +195,6 @@ int uprobe_finish_op(struct pt_regs *ctx) {
     return 0;
   }
   opv->finish_stamp = bpf_ktime_get_boot_ns();
-  opv->pid = get_pid();
   // submit to ringbuf
   struct client_op_v *e = bpf_ringbuf_reserve(&rb, sizeof(struct client_op_v), 0);
   if (NULL == e) {

--- a/src/radostrace.cc
+++ b/src/radostrace.cc
@@ -307,7 +307,7 @@ static int print_event(const struct client_op_v *op_v, bool complete) {
         }
         // Print CSV Headers
         if (csv_fp && !csv_headers_printed) {
-          fprintf(csv_fp, "pid,client,tid,pool,pg,acting,WR,size,latency,Complete,object,ops,offset,length\n");
+            fprintf(csv_fp, "pid,client,tid,pool,pg,acting,WR,size,latency,Complete,object,ops,offset,length\n");
             csv_headers_printed = true;
         }
 
@@ -316,7 +316,7 @@ static int print_event(const struct client_op_v *op_v, bool complete) {
 
         if (csv_fp) {
             fprintf(csv_fp,
-             "%d,%lld,%lld,%lld,%s,%s,%s,%lld,%lld,%d,%s,%s,%s,%s\n",
+               "%d,%lld,%lld,%lld,%s,%s,%s,%lld,%lld,%d,%s,%s,%s,%s\n",
                 op_v->pid,
                 (long long)op_v->cid,
                 (long long)op_v->tid,
@@ -376,10 +376,10 @@ static int print_event(const struct client_op_v *op_v, bool complete) {
            widths.pg, pgid.c_str(),
            widths.acting, acting_str.c_str());
 
-        printf("%*s%*lld%*lld%11d",
+    printf("%*s%*lld%*lld%11d",
            widths.wr, wr_str.c_str(),
            widths.size, op_v->length,
-          widths.latency, latency_us, complete ? 1 : 0);
+           widths.latency, latency_us, complete ? 1 : 0);
 
     // Object name and operations (no fixed width needed)
     printf("     %s ", op_v->object_name);
@@ -394,17 +394,20 @@ static int print_event(const struct client_op_v *op_v, bool complete) {
     return 0;
 }
 
-  static int handle_event(void *ctx, void *data, size_t size) {
+static int handle_event(void *ctx, void *data, size_t size) {
     (void)ctx;
     (void)size;
     return print_event((const struct client_op_v *)data, true);
-  }
+}
 
-  static int report_hung_ops(struct radostrace_bpf *skel) {
+// Print every op still in the BPF ops map as an incomplete row (Complete=0),
+// with latency measured up to now.  Entries with sent_stamp == 0 are being
+// filled in by uprobe_send_op and are skipped.
+static int report_hung_ops(struct radostrace_bpf *skel) {
     struct timespec now;
     if (clock_gettime(CLOCK_BOOTTIME, &now) != 0) {
-      perror("clock_gettime(CLOCK_BOOTTIME)");
-      return -1;
+        perror("clock_gettime(CLOCK_BOOTTIME)");
+        return -1;
     }
 
     __u64 now_ns = (__u64)now.tv_sec * 1000000000ULL + now.tv_nsec;
@@ -414,21 +417,20 @@ static int print_event(const struct client_op_v *op_v, bool complete) {
     int found = 0;
 
     while (bpf_map__get_next_key(skel->maps.ops, key_ptr, &next_key,
-                   sizeof(next_key)) == 0) {
-      if (bpf_map__lookup_elem(skel->maps.ops, &next_key, sizeof(next_key),
-                   &op, sizeof(op), 0) == 0 && op.sent_stamp != 0) {
-        op.finish_stamp = now_ns;
-        print_event(&op, false);
-        found++;
-      }
-      current_key = next_key;
-      key_ptr = &current_key;
+                                 sizeof(next_key)) == 0) {
+        if (bpf_map__lookup_elem(skel->maps.ops, &next_key, sizeof(next_key),
+                                 &op, sizeof(op), 0) == 0 &&
+            op.sent_stamp != 0) {
+            op.finish_stamp = now_ns;
+            print_event(&op, false);
+            found++;
+        }
+        current_key = next_key;
+        key_ptr = &current_key;
     }
 
-    if (found > 0)
-      fprintf(stderr, "Total reported ops: %d\n", found);
     return found;
-  }
+}
 
 // One row of `--list` output: a client process that has libceph-common loaded.
 struct CephClientInfo {
@@ -986,6 +988,7 @@ int main(int argc, char **argv) {
   rb = ring_buffer__new(bpf_map__fd(skel->maps.rb), handle_event, NULL, NULL);
   if (!rb) {
     cerr << "failed to setup ring_buffer" << endl;
+    ret = -1;
     goto cleanup;
   }
 
@@ -1019,12 +1022,9 @@ int main(int argc, char **argv) {
     goto cleanup;
   }
 
-  if (timeout_occurred) {
-      cerr << "Timeout occurred. Reporting pending ops before exit." << endl;
-  } else if (got_sigint) {
-      cerr << "SIGINT received. Reporting pending ops before exit." << endl;
-  }
-
+  // On timeout or SIGINT the ops still in the map are printed as rows with
+  // Complete=0; nothing else is written to stdout so the event stream stays
+  // clean for consumers.
   if (timeout_occurred || got_sigint) {
     // Detach first so no new finish events race with the map walk, then
     // drain what the probes already submitted (consume, not poll: with
@@ -1039,6 +1039,7 @@ int main(int argc, char **argv) {
   }
 
 cleanup:
+  fflush(stdout);  // rows before the stderr log line when both are redirected
   clog << "Clean up the eBPF program" << endl;
   ring_buffer__free(rb);
   radostrace_bpf__destroy(skel);

--- a/src/radostrace.cc
+++ b/src/radostrace.cc
@@ -85,6 +85,7 @@ DwarfParser::probes_t rados_probes = {
 };
 
 volatile sig_atomic_t timeout_occurred = 0;
+volatile sig_atomic_t got_sigint = 0;
 
 // CSV Output
 bool export_csv = false;
@@ -100,11 +101,9 @@ const char * ceph_osd_op_str(int opc) {
 }
 
 void signal_handler(int signum){
-  clog << "Caught signal " << signum << endl;
   if (signum == SIGINT) {
-      clog << "process killed" << endl;
+      got_sigint = 1;
   }
-  exit(signum);
 }
 
 void timeout_handler(int signum) {
@@ -208,10 +207,7 @@ int digitnum(int x) {
   return cnt;
 }
 
-static int handle_event(void *ctx, void *data, size_t size) {
-    (void)ctx;
-    (void)size;
-    struct client_op_v * op_v = (struct client_op_v *)data;
+static int print_event(const struct client_op_v *op_v, bool complete) {
     std::stringstream ss;
     ss << std::hex << op_v->m_seed;
     std::string pgid(ss.str());
@@ -311,7 +307,7 @@ static int handle_event(void *ctx, void *data, size_t size) {
         }
         // Print CSV Headers
         if (csv_fp && !csv_headers_printed) {
-            fprintf(csv_fp, "pid,client,tid,pool,pg,acting,WR,size,latency,object,ops,offset,length\n");
+          fprintf(csv_fp, "pid,client,tid,pool,pg,acting,WR,size,latency,Complete,object,ops,offset,length\n");
             csv_headers_printed = true;
         }
 
@@ -320,7 +316,7 @@ static int handle_event(void *ctx, void *data, size_t size) {
 
         if (csv_fp) {
             fprintf(csv_fp,
-               "%d,%lld,%lld,%lld,%s,%s,%s,%lld,%lld,%s,%s,%s,%s\n",
+             "%d,%lld,%lld,%lld,%s,%s,%s,%lld,%lld,%d,%s,%s,%s,%s\n",
                 op_v->pid,
                 (long long)op_v->cid,
                 (long long)op_v->tid,
@@ -330,6 +326,7 @@ static int handle_event(void *ctx, void *data, size_t size) {
                 wr_str.c_str(),
                 (long long)op_v->length,
                 (long long)latency_us,
+                complete ? 1 : 0,
                 csv_escape(op_v->object_name).c_str(),
                 csv_escape(ops_str).c_str(),
                 csv_escape(offset_field).c_str(),
@@ -353,7 +350,7 @@ static int handle_event(void *ctx, void *data, size_t size) {
         widths.latency = MAX(9, (int)std::to_string(latency_us).length() + 1);
         
         // Print header using calculated widths
-        printf("%*s%*s%*s%*s%*s %*s%*s%*s%*s%s\n",
+        printf("%*s%*s%*s%*s%*s %*s%*s%*s%*s%11s%s\n",
                widths.pid, "pid",
                widths.client, "client",
                widths.tid, "tid",
@@ -362,7 +359,7 @@ static int handle_event(void *ctx, void *data, size_t size) {
                widths.acting, "acting",
                widths.wr, "WR",
                widths.size, "size",
-               widths.latency, "latency",
+               widths.latency, "latency", "Complete",
                "     object[ops]");
         
         firsttime = false;
@@ -379,10 +376,10 @@ static int handle_event(void *ctx, void *data, size_t size) {
            widths.pg, pgid.c_str(),
            widths.acting, acting_str.c_str());
 
-    printf("%*s%*lld%*lld",
+        printf("%*s%*lld%*lld%11d",
            widths.wr, wr_str.c_str(),
            widths.size, op_v->length,
-           widths.latency, latency_us);
+          widths.latency, latency_us, complete ? 1 : 0);
 
     // Object name and operations (no fixed width needed)
     printf("     %s ", op_v->object_name);
@@ -396,6 +393,42 @@ static int handle_event(void *ctx, void *data, size_t size) {
 
     return 0;
 }
+
+  static int handle_event(void *ctx, void *data, size_t size) {
+    (void)ctx;
+    (void)size;
+    return print_event((const struct client_op_v *)data, true);
+  }
+
+  static int report_hung_ops(struct radostrace_bpf *skel) {
+    struct timespec now;
+    if (clock_gettime(CLOCK_BOOTTIME, &now) != 0) {
+      perror("clock_gettime(CLOCK_BOOTTIME)");
+      return -1;
+    }
+
+    __u64 now_ns = (__u64)now.tv_sec * 1000000000ULL + now.tv_nsec;
+    struct client_op_k current_key, next_key;
+    struct client_op_k *key_ptr = NULL;
+    struct client_op_v op;
+    int found = 0;
+
+    while (bpf_map__get_next_key(skel->maps.ops, key_ptr, &next_key,
+                   sizeof(next_key)) == 0) {
+      if (bpf_map__lookup_elem(skel->maps.ops, &next_key, sizeof(next_key),
+                   &op, sizeof(op), 0) == 0 && op.sent_stamp != 0) {
+        op.finish_stamp = now_ns;
+        print_event(&op, false);
+        found++;
+      }
+      current_key = next_key;
+      key_ptr = &current_key;
+    }
+
+    if (found > 0)
+      fprintf(stderr, "Total reported ops: %d\n", found);
+    return found;
+  }
 
 // One row of `--list` output: a client process that has libceph-common loaded.
 struct CephClientInfo {
@@ -972,24 +1005,43 @@ int main(int argc, char **argv) {
   // the ring buffer ourselves, sleeping only when a drain found it empty so
   // that a burst larger than the ring can be consumed without dropping
   // events.  Output latency is bounded by RINGBUF_DRAIN_INTERVAL_MS.
-  while (!timeout_occurred || timeout == -1) {
+  ret = 0;
+  while (!got_sigint && (!timeout_occurred || timeout == -1)) {
     ret = ring_buffer__consume(rb);
     if (ret < 0)
       break;
     if (ret == 0)
       usleep(RINGBUF_DRAIN_INTERVAL_MS * 1000);
   }
-  if (ret >= 0)
-    ring_buffer__consume(rb); // final drain
+
+  if (ret < 0) {
+    cerr << "Error draining ring buffer: " << -ret << endl;
+    goto cleanup;
+  }
 
   if (timeout_occurred) {
-      cerr << "Timeout occurred. Exiting." << endl;
+      cerr << "Timeout occurred. Reporting pending ops before exit." << endl;
+  } else if (got_sigint) {
+      cerr << "SIGINT received. Reporting pending ops before exit." << endl;
+  }
+
+  if (timeout_occurred || got_sigint) {
+    // Detach first so no new finish events race with the map walk, then
+    // drain what the probes already submitted (consume, not poll: with
+    // BPF_RB_NO_WAKEUP the epoll fd never signals readiness).
+    radostrace_bpf::detach(skel);
+    ret = ring_buffer__consume(rb);
+    if (ret < 0) {
+      cerr << "Error draining ring buffer: " << -ret << endl;
+      goto cleanup;
+    }
+    report_hung_ops(skel);
   }
 
 cleanup:
   clog << "Clean up the eBPF program" << endl;
   ring_buffer__free(rb);
   radostrace_bpf__destroy(skel);
-  return timeout_occurred ? -1 : -errno;
+  return ret < 0 ? 1 : 0;
 }
 

--- a/tests/functional-test-microceph.sh
+++ b/tests/functional-test-microceph.sh
@@ -41,6 +41,10 @@ cleanup() {
     pkill -f radostrace || true
     pkill -f "rbd bench" || true
 
+    # The hung-op scenario freezes OSDs. Always restore them, including when a
+    # later assertion fails.
+    kill -CONT $(pgrep -f "ceph-osd") 2>/dev/null || true
+
     if [[ -e $OSDTRACE_LOG ]]; then
         info "OSD trace output:"
         cat $OSDTRACE_LOG
@@ -283,6 +287,55 @@ verify_osdtrace_targets_only "$OSDTRACE_ID_LOG" "$TARGET_OSD_ID"
 
 info "=== Step 12: Verify radostrace output ==="
 verify_radostrace_output "$RADOSTRACE_LOG" "$TEST_POOL_ID" "$MAX_OSD_ID" 50
+
+info "=== Step 13: Test hung op detection ==="
+HUNG_OP_LOG="/tmp/radostrace_hung.log"
+
+microceph.rados -p test_pool bench 120 write -O 4M --no-cleanup > /dev/null 2>&1 &
+BENCH_PID=$!
+sleep 1
+
+BENCH_RADOS_PID=""
+for i in $(seq 1 30); do
+    for pid in $(pgrep -f "rados" 2>/dev/null); do
+        if grep -q "librados" /proc/$pid/maps 2>/dev/null; then
+            BENCH_RADOS_PID=$pid
+            break 2
+        fi
+    done
+    sleep 0.5
+done
+
+if [[ -z $BENCH_RADOS_PID ]]; then
+    err "Could not find rados bench process with librados for hung op test"
+    kill $BENCH_PID 2>/dev/null || true
+    exit 1
+fi
+
+$PROJECT_ROOT/radostrace -p $BENCH_RADOS_PID -i $RADOS_DWARF --skip-version-check -t 12 \
+    >$HUNG_OP_LOG 2>&1 &
+RADOSTRACE_HUNG_PID=$!
+
+for i in $(seq 1 30); do
+    if grep -q "Started to poll" $HUNG_OP_LOG 2>/dev/null; then
+        break
+    fi
+    sleep 0.5
+done
+
+OSD_PIDS=$(pgrep -f "ceph-osd" | tr '\n' ' ')
+kill -STOP $OSD_PIDS 2>/dev/null || true
+wait $RADOSTRACE_HUNG_PID 2>/dev/null || true
+kill -CONT $OSD_PIDS 2>/dev/null || true
+kill $BENCH_PID 2>/dev/null || true
+wait $BENCH_PID 2>/dev/null || true
+
+if ! awk '$1 ~ /^[0-9]+$/ && NF >= 11 && $10 == "0" { found=1 } END { exit !found }' $HUNG_OP_LOG; then
+    err "Expected at least one incomplete op (Complete=0) not found in radostrace output"
+    exit 1
+fi
+
+rm -f $HUNG_OP_LOG
 
 info "=== Test Summary ==="
 info "✓ MicroCeph cluster deployed successfully"

--- a/tests/functional-test-microceph.sh
+++ b/tests/functional-test-microceph.sh
@@ -43,7 +43,7 @@ cleanup() {
 
     # The hung-op scenario freezes OSDs. Always restore them, including when a
     # later assertion fails.
-    kill -CONT $(pgrep -f "ceph-osd") 2>/dev/null || true
+    kill -CONT $(pgrep -x ceph-osd) 2>/dev/null || true
 
     if [[ -e $OSDTRACE_LOG ]]; then
         info "OSD trace output:"
@@ -297,7 +297,7 @@ sleep 1
 
 BENCH_RADOS_PID=""
 for i in $(seq 1 30); do
-    for pid in $(pgrep -f "rados" 2>/dev/null); do
+    for pid in $(pgrep -x rados 2>/dev/null); do
         if grep -q "librados" /proc/$pid/maps 2>/dev/null; then
             BENCH_RADOS_PID=$pid
             break 2
@@ -323,7 +323,9 @@ for i in $(seq 1 30); do
     sleep 0.5
 done
 
-OSD_PIDS=$(pgrep -f "ceph-osd" | tr '\n' ' ')
+# Match on the process name (-x), not the command line (-f): -f would also
+# freeze any shell or log tail whose arguments merely mention ceph-osd.
+OSD_PIDS=$(pgrep -x ceph-osd | tr '\n' ' ')
 kill -STOP $OSD_PIDS 2>/dev/null || true
 wait $RADOSTRACE_HUNG_PID 2>/dev/null || true
 kill -CONT $OSD_PIDS 2>/dev/null || true

--- a/tests/functional-test-microceph.sh
+++ b/tests/functional-test-microceph.sh
@@ -330,7 +330,11 @@ kill -CONT $OSD_PIDS 2>/dev/null || true
 kill $BENCH_PID 2>/dev/null || true
 wait $BENCH_PID 2>/dev/null || true
 
-if ! awk '$1 ~ /^[0-9]+$/ && NF >= 11 && $10 == "0" { found=1 } END { exit !found }' $HUNG_OP_LOG; then
+# Rows come from _radostrace_rows so the column layout lives in one place;
+# field 10 is the Complete flag.  verify_radostrace_output is not usable
+# here: it expects rbd_* object names and bounds latency, and these rows
+# are rados bench objects stuck for up to the 12 s trace window.
+if ! _radostrace_rows "$HUNG_OP_LOG" | awk -F'|' '$10 == 0 { found=1 } END { exit !found }'; then
     err "Expected at least one incomplete op (Complete=0) not found in radostrace output"
     exit 1
 fi
@@ -340,6 +344,7 @@ rm -f $HUNG_OP_LOG
 info "=== Test Summary ==="
 info "✓ MicroCeph cluster deployed successfully"
 info "✓ osdtrace (-p and --id) and radostrace output validated"
+info "✓ radostrace reports in-flight ops (Complete=0) on timeout"
 info "✓ All functional tests passed!"
 
 exit 0

--- a/tests/functional-test-qemu-rbd.sh
+++ b/tests/functional-test-qemu-rbd.sh
@@ -219,7 +219,7 @@ POOL_ID=$($CEPH_CMD osd pool ls detail | awk -v p="'$POOL'" '$1 == "pool" && $3 
 info "Pool $POOL has id ${POOL_ID:-unknown}"
 
 total=0; writes=0; reads=0; rbd_data_rows=0; bad_pool=0; malformed=0
-while IFS='|' read -r pid _client _tid pool _pg _acting wr _size _latency object; do
+while IFS='|' read -r pid _client _tid pool _pg _acting wr _size _latency _complete object; do
     [ -z "$pid" ] && continue
     # Reject fragments that slipped past the loose row filter (e.g. a row
     # split by an interleaved log line, or cut by an unclean kill): a real

--- a/tests/lib/verify-trace-output.sh
+++ b/tests/lib/verify-trace-output.sh
@@ -135,7 +135,7 @@ _osdtrace_rows() {
 # Stream pipe-separated radostrace data rows to stdout, one per line:
 #   pid|client|tid|pool|pg|acting|wr|size|latency|object
 # Data rows start with a numeric PID (the traced process's PID).  Predicate
-# `$1 ~ /^[0-9]+$/ && NF >= 10` rejects the header line ("pid client … "),
+# `$1 ~ /^[0-9]+$/ && NF >= 11` rejects the header line ("pid client … "),
 # status messages, tool log noise, and — importantly — any truncated tail
 # record left behind when SIGKILL hits radostrace mid-printf (after the
 # latency field but before object_name).  Numeric coercion on $8/$9
@@ -152,10 +152,10 @@ _radostrace_rows() {
     # safe.  Cost: one good row per trace among thousands.
     awk '
         function flush_pending() { if (prev != "") { print prev; prev = "" } }
-        $1 ~ /^[0-9]+$/ && NF >= 10 {
+        $1 ~ /^[0-9]+$/ && NF >= 11 {
             flush_pending()
             prev = $1 "|" $2 "|" $3 "|" $4 "|" $5 "|" $6 "|" $7 "|" \
-                   ($8 + 0) "|" ($9 + 0) "|" $10
+                   ($8 + 0) "|" ($9 + 0) "|" $11
         }
         # END deliberately omitted: prev holds the last data row; not
         # flushing it here drops it.

--- a/tests/lib/verify-trace-output.sh
+++ b/tests/lib/verify-trace-output.sh
@@ -133,18 +133,22 @@ _osdtrace_rows() {
 # _radostrace_rows <log>
 #
 # Stream pipe-separated radostrace data rows to stdout, one per line:
-#   pid|client|tid|pool|pg|acting|wr|size|latency|object
+#   pid|client|tid|pool|pg|acting|wr|size|latency|complete|object
 # Data rows start with a numeric PID (the traced process's PID).  Predicate
 # `$1 ~ /^[0-9]+$/ && NF >= 11` rejects the header line ("pid client … "),
 # status messages, tool log noise, and — importantly — any truncated tail
 # record left behind when SIGKILL hits radostrace mid-printf (after the
-# latency field but before object_name).  Numeric coercion on $8/$9
+# Complete field but before object_name).  Numeric coercion on $8/$9/$10
 # guards against the same kind of partial-write artifact appearing in
-# the size/latency fields.
+# the size/latency/complete fields.
+#
+# `complete` is 1 for an op whose reply was seen and 0 for an op still in
+# flight when radostrace stopped (SIGINT or -t timeout); for those rows
+# `latency` is the time the op had been outstanding at that moment.
 _radostrace_rows() {
     # Drop the last data row.  SIGKILL/SIGTERM of the writer can leave
     # the file's tail mid-printf (e.g. an `rbd_data.<hex>.<seq>` object
-    # name truncated to just `rbd`), and the NF >= 10 predicate is
+    # name truncated to just `rbd`), and the NF >= 11 predicate is
     # loose enough to admit those byte-truncated rows.  Buffering the
     # latest match in `prev` and not flushing it at END drops exactly
     # the one potentially-malformed row; previously-completed write()
@@ -155,7 +159,7 @@ _radostrace_rows() {
         $1 ~ /^[0-9]+$/ && NF >= 11 {
             flush_pending()
             prev = $1 "|" $2 "|" $3 "|" $4 "|" $5 "|" $6 "|" $7 "|" \
-                   ($8 + 0) "|" ($9 + 0) "|" $11
+                   ($8 + 0) "|" ($9 + 0) "|" ($10 + 0) "|" $11
         }
         # END deliberately omitted: prev holds the last data row; not
         # flushing it here drops it.
@@ -378,10 +382,10 @@ _verify_radostrace_output_impl() {
     local total=0
     local saw_w=0 saw_r=0 saw_bench_size=0
     local -A row
-    local pid client tid pool pg acting wr size latency object
+    local pid client tid pool pg acting wr size latency complete object
     local acting_inner osd_id_str osd_id
 
-    while IFS='|' read -r pid client tid pool pg acting wr size latency object; do
+    while IFS='|' read -r pid client tid pool pg acting wr size latency complete object; do
         [ -z "$pid" ] && continue
 
         # Per-row dict.  All subsequent checks read fields by name.
@@ -395,9 +399,18 @@ _verify_radostrace_output_impl() {
             [wr]="$wr"
             [size]="$size"
             [latency]="$latency"
+            [complete]="$complete"
             [object]="$object"
         )
         total=$((total + 1))
+
+        # Complete is 1 (reply seen) or 0 (still in flight when the trace
+        # stopped).  Anything else means the columns are misaligned.
+        case "${row[complete]}" in
+            0|1) ;;
+            *) err "Invalid Complete flag '${row[complete]}' in radostrace output (expected 0 or 1, tid=${row[tid]})"
+               return 1 ;;
+        esac
 
         # 1. Pool id matches test_pool.
         if [ "${row[pool]}" != "$test_pool_id" ]; then
@@ -447,7 +460,7 @@ _verify_radostrace_output_impl() {
         #    Catches garbled object-name extraction in the BPF helper.
         #    Truncated tail records (where radostrace was killed before
         #    printing the object name) are filtered upstream by the NF >=
-        #    10 predicate in _radostrace_rows.
+        #    11 predicate in _radostrace_rows.
         if [[ ! "${row[object]}" =~ ^rbd_ ]]; then
             err "Unexpected object name '${row[object]}' in radostrace output (expected rbd_*, tid=${row[tid]} wr=${row[wr]})"
             return 1
@@ -584,10 +597,10 @@ _verify_radostrace_rgw_output_impl() {
     local total=0
     local saw_w=0 saw_r=0
     local -A row
-    local pid client tid pool pg acting wr size latency object
+    local pid client tid pool pg acting wr size latency complete object
     local acting_inner osd_id_str osd_id
 
-    while IFS='|' read -r pid client tid pool pg acting wr size latency object; do
+    while IFS='|' read -r pid client tid pool pg acting wr size latency complete object; do
         [ -z "$pid" ] && continue
 
         row=(
@@ -600,9 +613,18 @@ _verify_radostrace_rgw_output_impl() {
             [wr]="$wr"
             [size]="$size"
             [latency]="$latency"
+            [complete]="$complete"
             [object]="$object"
         )
         total=$((total + 1))
+
+        # Complete is 1 (reply seen) or 0 (still in flight when the trace
+        # stopped).  Anything else means the columns are misaligned.
+        case "${row[complete]}" in
+            0|1) ;;
+            *) err "Invalid Complete flag '${row[complete]}' in radostrace output (expected 0 or 1, tid=${row[tid]})"
+               return 1 ;;
+        esac
 
         case "${row[wr]}" in
             W) saw_w=1 ;;


### PR DESCRIPTION
Handle SIGINT without exiting immediately so radostrace can dump operations still pending in the BPF ops map before cleanup.

- add SIGINT state tracking in radostrace
- iterate the ops BPF map and print unfinished operations
- include stuck duration, client, tid, target osd, object, and rw mode
- return cleanly after interrupt/timeout-triggered shutdown