### PR TITLE
Add --version option to osdtrace/radostrace/kfstrace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,20 @@
-VERSION := 1.4
+VERSION := 1.6
 DATE ?= $(shell date +%Y-%m-%d)
 SRC_TGT := release
+
+# Git metadata for the --version banner. These resolve to empty strings on
+# release-tarball builds (no .git/ present) which is exactly what
+# print_tool_version() uses to distinguish "release" from "development".
+GIT_DESCRIBE := $(shell git describe --tags --dirty --always 2>/dev/null)
+GIT_BRANCH   := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+# Defines applied only when compiling src/version_utils.cc — keeps every
+# other translation unit cache-friendly even when git state changes.
+VERSION_DEFINES := \
+    -DCEPHTRACE_VERSION='"$(VERSION)"' \
+    -DCEPHTRACE_BUILD_DATE='"$(DATE)"' \
+    -DCEPHTRACE_GIT_DESCRIBE='"$(GIT_DESCRIBE)"' \
+    -DCEPHTRACE_GIT_BRANCH='"$(GIT_BRANCH)"'
 # Populate Source Package Name
 ifeq ($(SRC_TGT),debian)
 	SRC_PKG := cephtrace_$(VERSION).orig.tar.gz
@@ -164,10 +178,16 @@ $(OUTPUT)/dwarf_parser.o: $(OSDTRACE_SRC)/dwarf_parser.cc $(OUTPUT)/osdtrace.ske
 	$(call msg,CXX,$@)
 	$(Q)$(CXX) $(CXXFLAGS) -c -o $@ $<
 
-# Special rule for version_utils.o since it doesn't need a skel.h
-$(OUTPUT)/version_utils.o: $(OSDTRACE_SRC)/version_utils.cc $(OSDTRACE_SRC)/*.h | $(OUTPUT) $(LIBBPF_OBJ)
+# Special rule for version_utils.o since it doesn't need a skel.h.
+# Depends on FORCE so the git describe / build-date macros are always
+# re-evaluated — otherwise an unchanged source file would keep stale
+# metadata in the binary across commits.
+.PHONY: FORCE
+FORCE:
+
+$(OUTPUT)/version_utils.o: $(OSDTRACE_SRC)/version_utils.cc $(OSDTRACE_SRC)/*.h FORCE | $(OUTPUT) $(LIBBPF_OBJ)
 	$(call msg,CXX,$@)
-	$(Q)$(CXX) $(CXXFLAGS) -c -o $@ $<
+	$(Q)$(CXX) $(CXXFLAGS) $(VERSION_DEFINES) -c -o $@ $<
 
 
 # Special rule for kfstrace.o since it doesn't need dwarf_parser
@@ -182,10 +202,11 @@ $(1): $(OUTPUT)/$(1).o $(COMMON_OBJS) $(OUTPUT)/$(1).skel.h $(LIBBPF_OBJ) | $(OU
 	$(Q)$$(CXX) $$(CXXFLAGS) -o $$@ $$< $$(COMMON_OBJS) $$(LIBS)
 endef
 
-# Special rule for kfstrace - doesn't need dwarf_parser
-kfstrace: $(OUTPUT)/kfstrace.o $(OUTPUT)/kfstrace.skel.h $(LIBBPF_OBJ) | $(OUTPUT)
+# Special rule for kfstrace - doesn't need dwarf_parser, but does pull in
+# version_utils for the shared --version banner.
+kfstrace: $(OUTPUT)/kfstrace.o $(OUTPUT)/version_utils.o $(OUTPUT)/kfstrace.skel.h $(LIBBPF_OBJ) | $(OUTPUT)
 	$(call msg,LINK,$@)
-	$(Q)$(CXX) $(CXXFLAGS) -o $(DESTDIR)$@ $< $(LIBBPF_OBJ) -lelf -lz -ldl
+	$(Q)$(CXX) $(CXXFLAGS) -o $(DESTDIR)$@ $< $(OUTPUT)/version_utils.o $(LIBBPF_OBJ) -lelf -lz -ldl
 
 # Apply build rule to other programs (osdtrace and radostrace)
 $(foreach prog,$(filter-out kfstrace,$(PROG_OBJS)),$(eval $(call build_rule,$(prog))))

--- a/src/kfstrace.cc
+++ b/src/kfstrace.cc
@@ -23,6 +23,7 @@
 
 #include "kfstrace.skel.h"
 #include "bpf_ceph_types.h"
+#include "version_utils.h"
 
 #define CEPH_PG_MAX_SIZE 8
 #define CEPH_OID_INLINE_LEN 24
@@ -293,6 +294,7 @@ static void print_usage(const char *prog)
     printf("Usage: %s [OPTIONS]\n", prog);
     printf("\nOPTIONS:\n");
     printf("  -h, --help                   Show this help message\n");
+    printf("  -V, --version                Print version information and exit\n");
     printf("  -t, --timeout <s>            Set execution timeout (default: no timeout)\n");
     printf("  -m, --mode <mode>            Tracing mode: osd, mds, or all (default: mds)\n");
     printf("  -l, --latency <microseconds> Set operation latency threshold to capture (default: 0)\n");
@@ -323,6 +325,7 @@ int main(int argc, char **argv)
 
     static const struct option long_options[] = {
         {"help", no_argument, NULL, 'h'},
+        {"version", no_argument, NULL, 'V'},
         {"timeout", required_argument, NULL, 't'},
         {"mode", required_argument, NULL, 'm'},
         {"latency", required_argument, NULL, 'l'},
@@ -331,10 +334,13 @@ int main(int argc, char **argv)
 
     // Parse command line arguments
     int opt;
-    while ((opt = getopt_long(argc, argv, "ht:m:l:", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "hVt:m:l:", long_options, NULL)) != -1) {
         switch (opt) {
         case 'h':
             print_usage(argv[0]);
+            return 0;
+        case 'V':
+            print_tool_version("kfstrace");
             return 0;
         case 't':
             timeout_seconds = atoi(optarg);

--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -1031,7 +1031,10 @@ int parse_args(int argc, char **argv) {
   };
 
   int option_index = 0;
-  char opt;
+  // getopt_long() returns int and uses -1 to signal end-of-options; storing
+  // it in a plain char is unsafe on platforms where char is unsigned by
+  // default (the `!= -1` test can then loop forever).  Match kfstrace.
+  int opt;
   while ((opt = getopt_long(argc, argv, ":d:m:t:o:xbj:i:l:p:V", long_options, &option_index)) != -1) {
     switch (opt) {
       case 0:

--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -1026,12 +1026,13 @@ std::set<int> process_ids;  // Support multiple PIDs (set ensures deduplication)
 int parse_args(int argc, char **argv) {
   static struct option long_options[] = {
     {"skip-version-check", no_argument, 0, 0},
+    {"version", no_argument, 0, 'V'},
     {0, 0, 0, 0}
   };
 
   int option_index = 0;
   char opt;
-  while ((opt = getopt_long(argc, argv, ":d:m:t:o:xbj:i:l:p:", long_options, &option_index)) != -1) {
+  while ((opt = getopt_long(argc, argv, ":d:m:t:o:xbj:i:l:p:V", long_options, &option_index)) != -1) {
     switch (opt) {
       case 0:
         // Handle long options
@@ -1039,6 +1040,9 @@ int parse_args(int argc, char **argv) {
           skip_version_check = true;
         }
         break;
+      case 'V':
+        print_tool_version("osdtrace");
+        exit(0);
       case 'd':
         period = optarg[0] - '0';
         break;
@@ -1111,6 +1115,7 @@ int parse_args(int argc, char **argv) {
         std::cout << "  -t <seconds>              Set execution timeout in seconds\n";
         std::cout << "  -p <pid1,pid2,...>        Probe using Process IDs (comma-separated, mandatory for tracing containerized processes)\n";
         std::cout << "  --skip-version-check      Skip version check when importing DWARF JSON (currently needed for containers)\n";
+        std::cout << "  -V, --version             Print version information and exit\n";
         std::cout << "  -h                        Show this help message\n";
         std::cout << "----------------------------------------------------------------------------------------------------------------------------------------\n";
         std::cout << "                                                SUPPORTED PROBE MODE DETAILS\n";

--- a/src/radostrace.cc
+++ b/src/radostrace.cc
@@ -472,6 +472,9 @@ int main(int argc, char **argv) {
           }
       } else if (arg == "--skip-version-check") {
           skip_version_check = true;
+      } else if (arg == "-V" || arg == "--version") {
+          print_tool_version("radostrace");
+          return 0;
       } else if (arg == "-h" || arg == "--help") {
           std::cout << "Usage: " << argv[0] << " [-t <timeout seconds>] [-j [filename]] [-i <filename>] [-o [filename]] [-p <pid>] [--skip-version-check]\n";
           std::cout << "  -t, --timeout <seconds>    Set execution timeout in seconds\n";
@@ -480,6 +483,7 @@ int main(int argc, char **argv) {
           std::cout << "  -o, --output <file>        Export events data info to CSV (default: radostrace_events.csv)\n";
           std::cout << "  -p, --pid <pid>            Attach uprobes only to the specified process ID (Mandatory for container based process tracing)\n";
           std::cout << "  --skip-version-check       Skip version check when importing DWARF JSON (currently needed for containers)\n";
+          std::cout << "  -V, --version              Print version information and exit\n";
           std::cout << "  -h, --help                 Show this help message\n";
           return 0;
       }

--- a/src/version_utils.cc
+++ b/src/version_utils.cc
@@ -16,6 +16,23 @@
 
 using json = nlohmann::json;
 
+// Build-time metadata. The Makefile injects these via -D flags when
+// compiling this translation unit. The fallbacks here let the file still
+// compile if it is built outside the project Makefile (e.g. for IDE
+// indexing), in which case the --version output simply reports "unknown".
+#ifndef CEPHTRACE_VERSION
+#define CEPHTRACE_VERSION "unknown"
+#endif
+#ifndef CEPHTRACE_BUILD_DATE
+#define CEPHTRACE_BUILD_DATE "unknown"
+#endif
+#ifndef CEPHTRACE_GIT_DESCRIBE
+#define CEPHTRACE_GIT_DESCRIBE ""
+#endif
+#ifndef CEPHTRACE_GIT_BRANCH
+#define CEPHTRACE_GIT_BRANCH ""
+#endif
+
 std::string get_package_version(const std::string& library_path) {
     // Extract the library name from the path
     std::string lib_name;
@@ -495,6 +512,35 @@ bool check_executable_deleted(int process_id, const std::string& exe_name) {
     }
 
     return false;
+}
+
+void print_tool_version(const char* tool_name) {
+    const std::string version = CEPHTRACE_VERSION;
+    const std::string git_describe = CEPHTRACE_GIT_DESCRIBE;
+    const std::string git_branch = CEPHTRACE_GIT_BRANCH;
+    const std::string build_date = CEPHTRACE_BUILD_DATE;
+
+    // A development build is anything built from a git checkout — the
+    // Makefile only populates GIT_DESCRIBE when `git` succeeds. Release
+    // tarballs / .deb builds ship without .git and so produce an empty
+    // string, which we treat as the release-build path.
+    const bool is_dev_build = !git_describe.empty();
+
+    std::cout << tool_name << " " << version;
+    if (is_dev_build) {
+        std::cout << " (development build)";
+    }
+    std::cout << "\n";
+
+    if (is_dev_build) {
+        std::cout << "Based on:  cephtrace " << version << "\n";
+        std::cout << "Git:       " << git_describe;
+        if (!git_branch.empty() && git_branch != "HEAD") {
+            std::cout << " (branch " << git_branch << ")";
+        }
+        std::cout << "\n";
+    }
+    std::cout << "Built:     " << build_date << std::endl;
 }
 
 std::string get_version_from_json(const std::string& json_file) {

--- a/src/version_utils.h
+++ b/src/version_utils.h
@@ -97,4 +97,26 @@ bool is_ceph_version_squid_or_above(const std::string& version);
  */
 std::string get_version_from_json(const std::string& json_file);
 
+/**
+ * Print the version banner for a cephtrace tool to stdout.
+ *
+ * For a tagged release tarball (no embedded git metadata) prints just the
+ * point release, e.g.
+ *
+ *     osdtrace 1.4
+ *     Built: 2026-05-13
+ *
+ * For a development build (compiled from a git checkout) it additionally
+ * shows which point release the build is derived from plus the git locator,
+ * e.g.
+ *
+ *     osdtrace 1.4 (development build)
+ *     Based on:  cephtrace 1.4
+ *     Git:       v1.4-3-gabc1234-dirty (branch main)
+ *     Built:     2026-05-13
+ *
+ * @param tool_name The name to display (e.g. "osdtrace", "radostrace").
+ */
+void print_tool_version(const char* tool_name);
+
 #endif // VERSION_UTILS_H


### PR DESCRIPTION
## Summary

- Adds a shared `print_tool_version()` helper in `src/version_utils.{h,cc}` so all three tools (`osdtrace`, `radostrace`, `kfstrace`) print a consistent `--version` / `-V` banner.
- For binaries built from a git checkout, the banner additionally shows the git locator (`git describe --tags --dirty --always`), branch name, and build date — so a development binary always reflects which point release it is based on.
- Bumps `VERSION` from 1.4 to 1.6 in preparation for the next release.

## Design

| Macro | Source |
|---|---|
| `CEPHTRACE_VERSION` | `VERSION` in Makefile |
| `CEPHTRACE_BUILD_DATE` | `DATE` in Makefile (`date +%Y-%m-%d` by default) |
| `CEPHTRACE_GIT_DESCRIBE` | `git describe --tags --dirty --always` |
| `CEPHTRACE_GIT_BRANCH` | `git rev-parse --abbrev-ref HEAD` |

All four are injected via `-D` flags only when compiling `version_utils.o`. The Makefile gains a `FORCE` dependency on that object so git/build-date macros stay fresh across commits without triggering unrelated rebuilds. `kfstrace`, which previously did not depend on `version_utils.o`, now links against it.

Heuristic: empty `CEPHTRACE_GIT_DESCRIBE` (no `.git/` in tree → tarball / `.deb` build) means release, anything else means development. This mirrors how Ceph distinguishes tarball builds from checkout builds via the `.git_version` file written by `make-dist`.

## Sample output

Development build (this branch):
```
osdtrace 1.6 (development build)
Based on:  cephtrace 1.6
Git:       v1.4-59-gf368597-dirty (branch main)
Built:     2026-05-13
```

Release-tarball build (no `.git/` in tree):
```
osdtrace 1.6
Built:     2026-05-13
```

The exact same banner is emitted by `radostrace --version` and `kfstrace --version`; only the tool name differs.

## Test plan

- [x] `make osdtrace radostrace kfstrace` succeeds on a fresh local checkout
- [x] `./osdtrace --version`, `./osdtrace -V`, equivalents for `radostrace`/`kfstrace` — all three show the development-build banner with matching git locator
- [x] `-h` / `--help` lists the new `-V, --version` option for all three tools
- [x] Simulated release build (tree copied to `/tmp` with `.git/` removed) prints the release banner with no `(development build)` suffix and no git locator

🤖 Generated with [Claude Code](https://claude.com/claude-code)