### PR TITLE
Add cephadm + radosgw E2E coverage for quincy → tentacle

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -42,6 +42,36 @@ jobs:
       - name: Embedded DWARF data test - verify integrity and E2E
         run: sudo ./tests/functional-test-embedded-dwarf.sh
 
+  build-ubuntu-cephadm:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+        release: [quincy, reef, squid, tentacle]
+    steps:
+      - name: Checkout code and submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install build dependencies
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y g++ clang libelf-dev libc6-dev-i386 libdw-dev python3
+
+      - name: Run Makefile build
+        run: make -j all
+
+      - name: Functional test - cephadm + radosgw (${{ matrix.release }})
+        # The script provisions a single-host cephadm cluster (1 MON+MGR,
+        # 3 LVM-wrapped loopback OSDs, 1 radosgw), drives S3 traffic, then
+        # traces both the radosgw and one OSD with the matching embedded
+        # DWARF data.  Self-contained: installs podman/s3cmd/lvm2 itself.
+        run: sudo ./tests/functional-test-cephadm-rgw.sh ${{ matrix.release }}
+
   build-ubuntu-arm64:
     runs-on: ubuntu-24.04-arm
     steps:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -72,6 +72,32 @@ jobs:
         # DWARF data.  Self-contained: installs podman/s3cmd/lvm2 itself.
         run: sudo ./tests/functional-test-cephadm-rgw.sh ${{ matrix.release }}
 
+      # The functional test's cleanup() trap only dumps the last 50 lines of
+      # each trace log into the runner's stdout, then unlinks the files.  On
+      # failure we want the *full* logs to diagnose the offending event (e.g.
+      # an underflowed op_lat value pinpointed by the verifier).  Stage them
+      # into the workspace under a release-tagged dir, then upload as a
+      # per-cell artifact retained for two weeks.
+      - name: Stage trace logs for failure artifact
+        if: failure()
+        run: |
+            mkdir -p trace-logs
+            for f in /tmp/osdtrace-cephadm-${{ matrix.release }}.log \
+                     /tmp/radostrace-cephadm-${{ matrix.release }}.log \
+                     /tmp/s3-workload-${{ matrix.release }}.log; do
+                [ -e "$f" ] && sudo cp "$f" trace-logs/ || true
+            done
+            sudo chown -R "$USER" trace-logs
+
+      - name: Upload trace logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trace-logs-${{ matrix.os }}-${{ matrix.release }}
+          path: trace-logs/
+          retention-days: 14
+          if-no-files-found: ignore
+
   build-ubuntu-arm64:
     runs-on: ubuntu-24.04-arm
     steps:

--- a/files/centos-stream/osdtrace/osd-2:17.2.8-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:17.2.8-0.el9_dwarf.json
@@ -1,0 +1,1338 @@
+{
+  "version": "2:17.2.8-0.el9",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "35125af39c8129e981e32543745079b7d0a72f94",
+    "func2pc": {
+      "BlueStore::_do_write": 9692416,
+      "BlueStore::_txc_apply_kv": 9569296,
+      "BlueStore::_txc_calc_cost": 9552400,
+      "BlueStore::_txc_state_proc": 9570608,
+      "BlueStore::_wctx_finish": 9687504,
+      "BlueStore::log_latency": 16980000,
+      "BlueStore::log_latency_fn": 9769888,
+      "BlueStore::queue_transactions": 9717888,
+      "ECBackend::submit_transaction": 8432976,
+      "OSD::dequeue_op": 5143504,
+      "OSD::enqueue_op": 5142288,
+      "OpRequest::mark_flag_point": 13069328,
+      "OpRequest::mark_flag_point_string": 13069792,
+      "PrimaryLogPG::execute_ctx": 5873040,
+      "PrimaryLogPG::log_op_stats": 5906752,
+      "ReplicatedBackend::do_repop_reply": 8177152,
+      "ReplicatedBackend::generate_subop": 8197392,
+      "ReplicatedBackend::repop_commit": 8239888,
+      "ReplicatedBackend::submit_transaction": 8203888
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 732,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 732,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 160,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/files/centos-stream/osdtrace/osd-2:17.2.9-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:17.2.9-0.el9_dwarf.json
@@ -1,0 +1,1338 @@
+{
+  "version": "2:17.2.9-0.el9",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "316ac6a34b0493ba15893b9e09acc1981fc4c318",
+    "func2pc": {
+      "BlueStore::_do_write": 9692304,
+      "BlueStore::_txc_apply_kv": 9569184,
+      "BlueStore::_txc_calc_cost": 9552288,
+      "BlueStore::_txc_state_proc": 9570496,
+      "BlueStore::_wctx_finish": 9687392,
+      "BlueStore::log_latency": 16979952,
+      "BlueStore::log_latency_fn": 9769776,
+      "BlueStore::queue_transactions": 9717776,
+      "ECBackend::submit_transaction": 8432992,
+      "OSD::dequeue_op": 5143504,
+      "OSD::enqueue_op": 5142288,
+      "OpRequest::mark_flag_point": 13069232,
+      "OpRequest::mark_flag_point_string": 13069696,
+      "PrimaryLogPG::execute_ctx": 5873040,
+      "PrimaryLogPG::log_op_stats": 5906752,
+      "ReplicatedBackend::do_repop_reply": 8177168,
+      "ReplicatedBackend::generate_subop": 8197408,
+      "ReplicatedBackend::repop_commit": 8239904,
+      "ReplicatedBackend::submit_transaction": 8203904
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 732,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 732,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 160,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/files/centos-stream/radostrace/rados-2:17.2.8-0.el9_dwarf.json
+++ b/files/centos-stream/radostrace/rados-2:17.2.8-0.el9_dwarf.json
@@ -1,0 +1,843 @@
+{
+  "version": "2:17.2.8-0.el9",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "3417a3e8c2c6002da3f4516649bbd98ad641d973",
+    "func2pc": {
+      "Objecter::_finish_op": 5559408,
+      "Objecter::_send_op": 5577568
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librados.so.2": {
+    "build_id": "21fa65fbb3c53fde371a55e325c31c875d5d52e2",
+    "func2pc": {
+      "Objecter::_finish_op": 926192,
+      "Objecter::_send_op": 929584
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "da888b6a34bdac9c35bb5c364cef562057f0a5fe",
+    "func2pc": {
+      "Objecter::_finish_op": 4842800
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/files/centos-stream/radostrace/rados-2:17.2.9-0.el9_dwarf.json
+++ b/files/centos-stream/radostrace/rados-2:17.2.9-0.el9_dwarf.json
@@ -1,0 +1,843 @@
+{
+  "version": "2:17.2.9-0.el9",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "400ae150831798b1422698c2446330e0af2e2d08",
+    "func2pc": {
+      "Objecter::_finish_op": 5559408,
+      "Objecter::_send_op": 5577568
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librados.so.2": {
+    "build_id": "c8c7823be79de07ebf0ad62fae0f6f574ba2859e",
+    "func2pc": {
+      "Objecter::_finish_op": 926192,
+      "Objecter::_send_op": 929584
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "22529f57713113c085bb561ae7106ea9bf5aa26f",
+    "func2pc": {
+      "Objecter::_finish_op": 4842800
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/osdtrace.bpf.c
+++ b/src/osdtrace.bpf.c
@@ -97,6 +97,44 @@ int uprobe_enqueue_op(struct pt_regs *ctx) {
   }
 
   key.pid = get_pid();
+
+  /* Retry detection.
+   *
+   * If an entry for (pid, owner, tid) is already in the map, an earlier
+   * op with the same key is still in flight (its completion uprobe has
+   * not fired yet) -- this is a client-side retry of an op the OSD is
+   * still processing.  Without this guard, the bpf_map_update_elem call
+   * below would overwrite the original's tracking with a freshly-memset
+   * record; when the original later completes, log_op_stats picks up
+   * the retry's record (deq == 0, every per-stage latency == 0, peer
+   * slots reset to -1) and emits nonsense -- queue_lat in particular
+   * underflows to ~UINT64_MAX because deq is zero while enq is the
+   * retry's bpf_ktime_get_boot_ns().
+   *
+   * Ceph handles retries via PrimaryLogPG::already_complete() inside
+   * do_op, so skipping the BPF update has no effect on what Ceph
+   * reports to the client -- it only preserves our tracking of the
+   * original op so its log_op_stats emission is well-formed.
+   *
+   * An age threshold separates a true retry (in-flight original) from
+   * an orphan (entry left behind because some completion uprobe was
+   * missed for an earlier op).  5 s is much longer than any healthy op
+   * takes but well below the time it would take a tid to be legitimately
+   * reused via a client session reset.  Orphans older than that are
+   * cleaned up by falling through to the overwrite.
+   */
+  struct op_v *existing = bpf_map_lookup_elem(&ops, &key);
+  if (existing != NULL) {
+    __u64 age_ns = bpf_ktime_get_boot_ns() - existing->enqueue_stamp;
+    if (age_ns < 5000000000ULL) {
+      bpf_printk("uprobe_enqueue_op: retry detected, preserving original tracking (client=%lld tid=%lld age_ns=%llu)\n",
+                 key.owner, key.tid, age_ns);
+      return 0;
+    }
+    bpf_printk("uprobe_enqueue_op: orphan cleanup, overwriting stale entry (client=%lld tid=%lld age_ns=%llu)\n",
+               key.owner, key.tid, age_ns);
+  }
+
   struct op_v value;
   memset(&value, 0, sizeof(value));
   // ktime_get_real_ts64 can't be called

--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -1334,8 +1334,12 @@ int main(int argc, char **argv) {
 
   std::cout << "Tracing ceph-osd at: " << osd_path << std::endl;
 
-  // Check if any ceph-osd processes are running with old/deleted executables
-  if (check_executable_deleted(-1, "ceph-osd")) {
+  // Check if any ceph-osd processes are running with old/deleted executables.
+  // Only enforced for live tracing; for JSON export we deliberately want to
+  // read the *on-disk* (possibly newly-upgraded) binary so the exported
+  // DWARF metadata matches the binary version recorded in the JSON, not
+  // whatever stale image happens to still be mapped in the process.
+  if (!export_json && check_executable_deleted(-1, "ceph-osd")) {
     std::cerr << "Warning: Found ceph-osd processes running with deleted/old executables." << std::endl;
     std::cerr << "This may indicate that ceph-osd was updated but processes haven't been restarted." << std::endl;
     std::cerr << "Consider restarting ceph-osd services for accurate tracing." << std::endl;

--- a/src/radostrace.cc
+++ b/src/radostrace.cc
@@ -520,7 +520,10 @@ int main(int argc, char **argv) {
     clog << "Libraries to be traced: " << librbd_path << ", " << librados_path << ", " << libceph_common_path << endl;
   }
 
-  if (check_library_deleted(process_id, "librados")) {
+  // Same rationale as osdtrace: skip the deleted-library check when we are
+  // exporting JSON, since the export path intentionally wants to parse the
+  // newly-upgraded on-disk binaries.
+  if (!export_json && check_library_deleted(process_id, "librados")) {
      cerr << "Error: librados library mismatch detected!" << endl;
      cerr << "The ceph package has been upgraded on disk, but one or more processes are still using the old version in memory." << endl;
      cerr << "Please restart the affected processes to pick up the new version." << endl;

--- a/tests/functional-test-cephadm-rgw.sh
+++ b/tests/functional-test-cephadm-rgw.sh
@@ -45,6 +45,7 @@ MIN_RGW_ROWS=50
 FSID=""
 
 cleanup() {
+    local rc=$?
     info "=== Cleanup ==="
     pkill -f "$PROJECT_ROOT/osdtrace" 2>/dev/null || true
     pkill -f "$PROJECT_ROOT/radostrace" 2>/dev/null || true
@@ -66,8 +67,15 @@ cleanup() {
             cleanup_cephadm_cluster "$FSID" || true
         fi
     fi
-    if [[ "${KEEP_CLUSTER:-0}" -ne 1 ]]; then
+    # Preserve trace logs on failure (rc != 0) so the GHA artifact-upload
+    # step in .github/workflows/pr-build.yaml has the full file to attach;
+    # cleanup_cephadm_cluster already wiped the runtime state, so the only
+    # remaining cost is a few MB of log on the runner's tmpfs.  Also keep
+    # them when KEEP_CLUSTER=1 (developer is iterating locally).
+    if [[ $rc -eq 0 && "${KEEP_CLUSTER:-0}" -ne 1 ]]; then
         rm -f "$S3CFG" "$OSDTRACE_LOG" "$RADOSTRACE_LOG" "$WORKLOAD_LOG" 2>/dev/null || true
+    else
+        info "Preserving trace logs at $OSDTRACE_LOG / $RADOSTRACE_LOG (exit=$rc)"
     fi
     info "cleanup done"
 }

--- a/tests/functional-test-cephadm-rgw.sh
+++ b/tests/functional-test-cephadm-rgw.sh
@@ -1,0 +1,326 @@
+#!/bin/bash
+#
+# End-to-end test: deploy a single-host cephadm cluster (1 MON+MGR, 3 OSDs,
+# 1 radosgw) for a target Ceph major release, drive S3 traffic through the
+# RGW, and trace BOTH:
+#   - the radosgw daemon with radostrace      (librados client path)
+#   - one ceph-osd daemon with osdtrace       (server-side OSD path)
+# simultaneously, then validate that both produce expected trace output.
+#
+# Usage:
+#   sudo ./tests/functional-test-cephadm-rgw.sh <release>
+#       release ∈ { quincy | reef | squid | tentacle }
+#
+# Expects $PROJECT_ROOT/osdtrace and $PROJECT_ROOT/radostrace to be built.
+
+set -e
+set -x
+
+CEPH_RELEASE="${1:?usage: $0 <quincy|reef|squid|tentacle>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/log.sh
+source "$SCRIPT_DIR/lib/log.sh"
+# shellcheck source=lib/cephadm-setup.sh
+source "$SCRIPT_DIR/lib/cephadm-setup.sh"
+# shellcheck source=lib/verify-trace-output.sh
+source "$SCRIPT_DIR/lib/verify-trace-output.sh"
+
+OSDTRACE_LOG="/tmp/osdtrace-cephadm-${CEPH_RELEASE}.log"
+RADOSTRACE_LOG="/tmp/radostrace-cephadm-${CEPH_RELEASE}.log"
+WORKLOAD_LOG="/tmp/s3-workload-${CEPH_RELEASE}.log"
+S3CFG="/root/.s3cfg-cephadm-test"
+
+# Trace sustained read+write window.  Long enough to overlap radostrace's
+# uprobe attach + the workload's steady-state phase.
+TRACE_SECONDS=45
+# osdtrace counts only rows targeting the chosen RGW data pool; that pool
+# carries the S3 object payloads, so it dominates traffic but is a strict
+# subset of the total trace volume.
+MIN_OSD_ROWS=20
+MIN_RGW_ROWS=50
+
+FSID=""
+
+cleanup() {
+    info "=== Cleanup ==="
+    pkill -f "$PROJECT_ROOT/osdtrace" 2>/dev/null || true
+    pkill -f "$PROJECT_ROOT/radostrace" 2>/dev/null || true
+    pkill -f "s3cmd" 2>/dev/null || true
+    if [[ -e "$OSDTRACE_LOG" ]]; then
+        info "--- osdtrace tail (last 50 lines) ---"
+        tail -50 "$OSDTRACE_LOG" || true
+    fi
+    if [[ -e "$RADOSTRACE_LOG" ]]; then
+        info "--- radostrace tail (last 50 lines) ---"
+        tail -50 "$RADOSTRACE_LOG" || true
+    fi
+    if [[ -n "$FSID" ]]; then
+        info "--- final ceph -s ---"
+        cephadm shell --fsid "$FSID" -- ceph -s 2>/dev/null || true
+        if [[ "${KEEP_CLUSTER:-0}" -eq 1 ]]; then
+            info "KEEP_CLUSTER=1 — leaving cluster $FSID intact for inspection"
+        else
+            cleanup_cephadm_cluster "$FSID" || true
+        fi
+    fi
+    if [[ "${KEEP_CLUSTER:-0}" -ne 1 ]]; then
+        rm -f "$S3CFG" "$OSDTRACE_LOG" "$RADOSTRACE_LOG" "$WORKLOAD_LOG" 2>/dev/null || true
+    fi
+    info "cleanup done"
+}
+trap cleanup EXIT
+
+[ "$EUID" -eq 0 ] || { err "must run as root"; exit 1; }
+[ -x "$PROJECT_ROOT/osdtrace" ]   || { err "osdtrace not built (run 'make all' first)"; exit 1; }
+[ -x "$PROJECT_ROOT/radostrace" ] || { err "radostrace not built (run 'make all' first)"; exit 1; }
+
+
+############################################################################
+info "=== Step 1: install host deps (podman, s3cmd, lvm2) ==="
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -q
+apt-get install -y -q podman s3cmd python3 curl lvm2 gdisk parted
+
+# Quincy's bundled cephadm (v17.2.x) has a buggy `_fetch_apparmor` that
+# splits each /sys/kernel/security/apparmor/profiles line by a single
+# space (`item, mode = line.split(' ')`).  Ubuntu 24.04 ships an apparmor
+# profile declared as `profile "MongoDB Compass" ...` -- the profile
+# *name* contains a literal space, so the kernel exposes it in
+# /sys/kernel/security/apparmor/profiles as `MongoDB Compass (unconfined)`
+# (3 space-separated tokens), which triggers
+# ValueError("too many values to unpack") inside the mgr's orchestrator
+# and silently fails the OSD apply.
+#
+# None of the apparmor profiles in /etc/apparmor.d/ are relevant to this
+# headless test VM (they cover desktop apps like 1password, Discord, the
+# offending MongoDB Compass, etc).  Unload all of them so the
+# /sys/kernel/security/apparmor/profiles file the quincy cephadm parser
+# reads no longer contains any space-named profile.  No-op for the
+# already-loaded profiles cephadm/podman uses (containers-default-* and
+# docker-default); those have no spaces in their names and we leave them
+# alone implicitly because we only target /etc/apparmor.d/* files.
+if command -v apparmor_parser >/dev/null; then
+    while IFS= read -r profile_file; do
+        apparmor_parser -R "$profile_file" 2>/dev/null || true
+    done < <(find /etc/apparmor.d -maxdepth 1 -type f 2>/dev/null)
+fi
+
+
+############################################################################
+info "=== Step 2: install cephadm + resolve image for $CEPH_RELEASE ==="
+CEPH_IMG=$(cephadm_image_for_release "$CEPH_RELEASE")
+info "image: $CEPH_IMG"
+install_cephadm "$CEPH_RELEASE" /tmp/cephadm "$CEPH_IMG"
+
+
+############################################################################
+info "=== Step 3: provision 3 loopback OSD devices (3 GiB each) ==="
+mapfile -t OSD_DEVS < <(provision_loopback_osds 3 3)
+losetup -l
+info "OSD devices: ${OSD_DEVS[*]}"
+
+
+############################################################################
+info "=== Step 4: bootstrap single-host cephadm cluster ==="
+MON_IP=$(hostname -I | awk '{print $1}')
+info "MON_IP=$MON_IP"
+FSID=$(cephadm_bootstrap_single_host "$CEPH_IMG" "$MON_IP" /tmp/cephadm)
+[ -n "$FSID" ] || { err "bootstrap failed to produce FSID"; exit 1; }
+info "FSID=$FSID"
+
+
+############################################################################
+info "=== Step 5: apply OSD spec with explicit device paths ==="
+# Why not `ceph orch apply osd --all-available-devices`?
+#   - `ceph orch device ls` only enumerates devices that ceph-volume's
+#     inventory considers candidates, and inventory filters out
+#     /dev/loopX entirely (loops aren't rotational disks); even after
+#     wrapping each loop in LVM the LV nodes (/dev/mapper/*) are not
+#     bind-mounted into the cephadm shell container, so inventory still
+#     can't see them and returns empty.
+#
+# Why a single `orch apply osd <spec>` and not three `daemon add osd` calls?
+#   - daemon-add is async-queued by the orchestrator.  Firing three calls
+#     in rapid succession races the orchestrator's state machine: the
+#     second/third often return "Created no osd(s); already created?" and
+#     only 1-2 OSDs actually come up.  A single apply with all paths is
+#     processed atomically by the orchestrator's OSD planner.
+HOSTNAME_SHORT=$(hostname -s)
+OSD_SPEC=/tmp/osd-spec.yaml
+{
+    echo "service_type: osd"
+    echo "service_id: test-osds"
+    echo "placement:"
+    echo "  hosts: ['${HOSTNAME_SHORT}']"
+    echo "data_devices:"
+    echo "  paths:"
+    for dev in "${OSD_DEVS[@]}"; do
+        echo "  - ${dev}"
+    done
+} > "$OSD_SPEC"
+cat "$OSD_SPEC"
+# `cephadm shell` mounts /root from the host, so we can reference the
+# spec file from inside the container via its /root path.
+cephadm shell --fsid "$FSID" --mount "$OSD_SPEC:/tmp/osd-spec.yaml" -- \
+    ceph orch apply -i /tmp/osd-spec.yaml
+
+info "=== Step 6: wait for cluster healthy (1 MON + 1 MGR + 3 OSDs up) ==="
+if ! wait_cephadm_healthy "$FSID" 3 900; then
+    err "cluster did not become ready"
+    exit 1
+fi
+
+
+############################################################################
+info "=== Step 7: deploy RGW (1 instance, port 8080) ==="
+if ! apply_rgw_service "$FSID" test 8080; then
+    err "RGW deployment failed"
+    exit 1
+fi
+
+
+############################################################################
+info "=== Step 8: create RGW user + write S3 config ==="
+ACCESS_KEY="rgwtestaccesskey"
+SECRET_KEY="rgwtestsecretkeyrgwtestsecretkey"
+create_rgw_user "$FSID" testuser "$ACCESS_KEY" "$SECRET_KEY"
+cat > "$S3CFG" <<EOF
+[default]
+access_key = $ACCESS_KEY
+secret_key = $SECRET_KEY
+host_base  = ${MON_IP}:8080
+host_bucket = ${MON_IP}:8080/%(bucket)
+use_https = False
+signature_v2 = False
+check_ssl_certificate = False
+EOF
+S3="s3cmd --config=$S3CFG"
+
+
+############################################################################
+info "=== Step 9: create bucket + warm-up so RGW pools auto-create ==="
+$S3 mb s3://testbucket >>"$WORKLOAD_LOG" 2>&1
+for i in 1 2 3 4 5; do
+    echo "warmup-$i" | $S3 put - "s3://testbucket/warmup-$i" >>"$WORKLOAD_LOG" 2>&1 || true
+done
+sleep 3   # let any default.rgw.* pools settle
+
+
+############################################################################
+info "=== Step 10: identify PIDs to trace ==="
+# `radosgw -n client.rgw.test.<host>.<random>` runs on this host as a podman
+# container's main process; pgrep finds the HOST-side PID (via shared PID
+# namespace), which is what uprobe needs.  cephadm uses `-n <name>`, NOT
+# `--id <name>`.
+#
+# Anchoring with `^[^ ]*<binary>` is critical: cephadm starts each daemon
+# under `/run/podman-init -- /usr/bin/<binary> -n ...`.  Without the anchor,
+# pgrep returns the podman-init PID (whose cmdline contains "ceph-osd" as
+# a later argv), and osdtrace/radostrace then fail with "Process is
+# running: /run/podman-init".
+RGW_PID=$(pgrep -f "^[^ ]*radosgw .*-n[[:space:]]+client\.rgw\.test\." | head -1)
+[ -n "$RGW_PID" ] || { err "could not find radosgw PID"; pgrep -af radosgw; exit 1; }
+
+# Trace osd.1 specifically — picking a non-zero id makes the test resilient
+# to the orchestrator renumbering OSDs across re-runs.  cephadm runs OSDs
+# as `ceph-osd -n osd.<id>` (not `--id <id>`).
+OSD_PID=$(pgrep -f "^[^ ]*ceph-osd .*-n[[:space:]]+osd\.1\b" | head -1)
+[ -n "$OSD_PID" ] || OSD_PID=$(pgrep -f "^[^ ]*ceph-osd .*-n[[:space:]]+osd\.[0-9]" | head -1)
+[ -n "$OSD_PID" ] || { err "could not find ceph-osd PID"; pgrep -af ceph-osd; exit 1; }
+
+info "RGW PID=$RGW_PID, OSD PID=$OSD_PID"
+
+
+############################################################################
+info "=== Step 11: start traces (osdtrace + radostrace in parallel) ==="
+# -x: per-event row format (one line per OSD op).  Without it osdtrace
+# emits aggregated stats which the verifier wouldn't recognise.
+timeout "$TRACE_SECONDS" "$PROJECT_ROOT/osdtrace"   -p "$OSD_PID" -x >"$OSDTRACE_LOG"   2>&1 &
+timeout "$TRACE_SECONDS" "$PROJECT_ROOT/radostrace" -p "$RGW_PID"    >"$RADOSTRACE_LOG" 2>&1 &
+
+# Give each tool a few seconds to parse DWARF and attach uprobes before
+# we start hammering the cluster — otherwise the first ~3 s of workload
+# fire before the probes are live and we under-count.
+sleep 6
+
+
+############################################################################
+info "=== Step 12: drive S3 workload (mixed PUT + GET) ==="
+# Two parallel loops keep the OSD and the RGW busy through the entire
+# trace window.  Object size varies between 8 KB and 256 KB so we get a
+# meaningful spread of librados ops (data write + index update + log).
+(
+    set +e
+    for i in $(seq 1 800); do
+        # mix object sizes for op-pattern diversity
+        head -c $((RANDOM % 262144 + 8192)) /dev/urandom \
+          | $S3 put - "s3://testbucket/obj-$i" >>"$WORKLOAD_LOG" 2>&1
+    done
+) &
+WL_PUT=$!
+
+(
+    set +e
+    sleep 3
+    for i in $(seq 1 800); do
+        $S3 get "s3://testbucket/obj-$i" "/tmp/get-$i" >>"$WORKLOAD_LOG" 2>&1
+        rm -f "/tmp/get-$i"
+    done
+) &
+WL_GET=$!
+
+
+############################################################################
+info "=== Step 13: wait for traces to finish (TRACE_SECONDS=${TRACE_SECONDS}) ==="
+wait
+
+# Kill any still-running workload loops (they will have produced their
+# share by now, but a slow s3cmd on a constrained runner can outlast the
+# trace window).
+kill "$WL_PUT" "$WL_GET" 2>/dev/null || true
+sleep 2
+
+
+############################################################################
+info "=== Step 14: gather cluster facts for verifiers ==="
+# osdtrace counts data rows targeting a single pool; pick the RGW data
+# pool (.rgw.buckets.data) because it carries the S3 object payloads
+# and therefore dominates osd traffic during the workload.  The other
+# RGW pools (.rgw.meta, .rgw.buckets.index, .rgw.log, ...) are still
+# checked by the per-row OSD-id/latency invariants, just not by the
+# per-pool PG / row-count thresholds.
+MAX_OSD_ID=$(cephadm shell --fsid "$FSID" -- ceph osd ls 2>/dev/null | sort -n | tail -1)
+DATA_POOL_NAME=$(cephadm shell --fsid "$FSID" -- ceph osd pool ls 2>/dev/null \
+    | grep -E '\.rgw\.buckets\.data$' | head -1)
+DATA_POOL_ID=$(cephadm shell --fsid "$FSID" -- ceph osd pool ls detail 2>/dev/null \
+    | grep "^pool.*'${DATA_POOL_NAME}'" | grep -oP "pool \K\d+")
+DATA_POOL_PG_NUM=$(cephadm shell --fsid "$FSID" -- \
+    ceph osd pool get "$DATA_POOL_NAME" pg_num 2>/dev/null | awk '{print $2}')
+info "max OSD id: $MAX_OSD_ID, RGW data pool: $DATA_POOL_NAME (id=$DATA_POOL_ID, pg_num=$DATA_POOL_PG_NUM)"
+[ -n "$DATA_POOL_ID" ] && [ -n "$DATA_POOL_PG_NUM" ] \
+    || { err "failed to resolve RGW data pool id/pg_num"; exit 1; }
+
+
+############################################################################
+info "=== Step 15: verify osdtrace output ==="
+verify_osdtrace_rgw_output \
+    "$OSDTRACE_LOG" "$DATA_POOL_ID" "$MAX_OSD_ID" "$DATA_POOL_PG_NUM" "$MIN_OSD_ROWS"
+
+
+############################################################################
+info "=== Step 16: verify radostrace output ==="
+verify_radostrace_rgw_output \
+    "$RADOSTRACE_LOG" "$MAX_OSD_ID" "$MIN_RGW_ROWS"
+
+
+############################################################################
+info "=== Test Summary (cephadm + $CEPH_RELEASE) ==="
+info "✓ cluster bootstrapped via cephadm using $CEPH_IMG"
+info "✓ 3 OSDs deployed, 1 RGW serving on port 8080"
+info "✓ S3 workload (PUT + GET on testbucket) drove the cluster for ~${TRACE_SECONDS}s"
+info "✓ osdtrace traced OSD PID $OSD_PID; row-count + per-pool checks passed"
+info "✓ radostrace traced radosgw PID $RGW_PID; row-count + W/R diversity checks passed"
+exit 0

--- a/tests/lib/cephadm-setup.sh
+++ b/tests/lib/cephadm-setup.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+#
+# Helpers for bootstrapping a single-host cephadm cluster with:
+#   1 MON + 1 MGR (from --single-host-defaults)
+#   3 OSDs       (loopback-backed devices, --all-available-devices)
+#   1 radosgw    (cephadm orch service)
+#
+# Used by tests/functional-test-cephadm-rgw.sh as a matrix across the
+# Quincy → Tentacle line.  All cephadm operations target the cephadm
+# binary downloaded from the matching release branch; the cluster runs
+# against the matching quay.io/ceph/ceph:vX.Y.Z image.
+
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=log.sh
+source "$_LIB_DIR/log.sh"
+
+
+# cephadm_image_for_release <release>
+#
+# Echo the latest tracked stable point-release image tag for a major Ceph
+# release.  Bump these as upstream cuts new tags — the goal is "latest
+# point release of the named major series" per the test matrix.
+cephadm_image_for_release() {
+    case "$1" in
+        quincy)   echo "quay.io/ceph/ceph:v17.2.8"  ;;
+        reef)     echo "quay.io/ceph/ceph:v18.2.7"  ;;
+        squid)    echo "quay.io/ceph/ceph:v19.2.3"  ;;
+        tentacle) echo "quay.io/ceph/ceph:v20.2.1"  ;;
+        *) err "unknown release: $1"; return 1 ;;
+    esac
+}
+
+
+# install_cephadm <release> <dest_path>
+#
+# Make a working `cephadm` available at $dest.  Strategy:
+#   1. Try the distro-packaged cephadm (apt install on Ubuntu).  Ubuntu 24.04
+#      ships squid-era cephadm, which can bootstrap any v17–v20 image via
+#      `--image`.  This is the simplest and most reliable path.
+#   2. Fall back to extracting cephadm from the matching quay.io image.
+#      That guarantees the cephadm version matches the cluster image, which
+#      matters for older releases (quincy, reef) where flag names differ.
+#
+# Why not "curl the script from github.com/ceph/ceph/<branch>"?
+#   - Squid (and later) repackaged cephadm as a multi-file Python package
+#     that imports `cephadmlib.*`; pulling just `src/cephadm/cephadm` from
+#     GitHub fails at first import with ModuleNotFoundError.
+#   - Quincy/Reef shipped a self-contained single-file script, so the
+#     github-URL path worked, but the asymmetry is a footgun — drop it.
+install_cephadm() {
+    local release="$1"; local dest="${2:-/tmp/cephadm}"; local image="$3"
+
+    # Path 1: distro package.
+    if command -v cephadm >/dev/null; then
+        cp "$(command -v cephadm)" "$dest"
+        chmod +x "$dest"
+        info "using distro cephadm: $(cephadm --version 2>&1 | head -1 | tr -d '\n')"
+        return 0
+    fi
+    if apt-get install -y -q cephadm >/dev/null 2>&1; then
+        cp "$(command -v cephadm)" "$dest"
+        chmod +x "$dest"
+        info "installed cephadm via apt: $(cephadm --version 2>&1 | head -1 | tr -d '\n')"
+        return 0
+    fi
+
+    # Path 2: extract from the matching container image.  Every quay.io/ceph
+    # image bundles /usr/sbin/cephadm; pulling that out yields a cephadm
+    # whose bootstrap flag-set matches the image version exactly.
+    [ -n "$image" ] || { err "no fallback image supplied to install_cephadm"; return 1; }
+    info "extracting cephadm from $image (cold start ~1 min for image pull)"
+    podman pull "$image" >/dev/null
+    local cid; cid=$(podman create --rm "$image" /bin/true)
+    podman cp "${cid}:/usr/sbin/cephadm" "$dest"
+    podman rm -f "$cid" >/dev/null 2>&1 || true
+    chmod +x "$dest"
+    info "extracted cephadm from $image"
+    return 0
+}
+
+# Backwards-compatible alias for tests still calling the old name.
+download_cephadm() { install_cephadm "$@"; }
+
+
+# provision_loopback_osds <count> <size_gib>
+#
+# Create N sparse files of size $size_gib GB under /var/lib/ceph-test-osds,
+# attach each as /dev/loopXX, wrap each in its own LVM volume group, and
+# emit one LV path per line.
+#
+# Why LVM wrap?  cephadm's `ceph orch device ls` filters out raw /dev/loopX
+# from its inventory — `--all-available-devices` then sees nothing and no
+# OSDs get created.  Wrapping in LVM presents each loop as a real block
+# device path that cephadm's ceph-volume accepts.  One VG per loop keeps
+# the layout symmetric (one OSD per VG) and lets us add `lvm zap` cleanup
+# later if needed.
+provision_loopback_osds() {
+    local count="$1"; local size_gib="$2"
+    mkdir -p /var/lib/ceph-test-osds
+    local i lvs=()
+    for ((i=0; i<count; i++)); do
+        local img="/var/lib/ceph-test-osds/osd${i}.img"
+        truncate -s "${size_gib}G" "$img"
+        local dev
+        dev=$(losetup --find --show --partscan "$img")
+        wipefs -a "$dev" >/dev/null 2>&1 || true
+        sgdisk --zap-all "$dev" >/dev/null 2>&1 || true
+        local vg="ceph-test-vg${i}"
+        pvcreate -ff -y "$dev" >&2
+        vgcreate "$vg" "$dev" >&2
+        lvcreate -y -l 100%FREE -n "osd-data" "$vg" >&2
+        lvs+=("/dev/${vg}/osd-data")
+    done
+    printf '%s\n' "${lvs[@]}"
+}
+
+
+# cephadm_bootstrap_single_host <image> <mon_ip> [cephadm_bin]
+#
+# Bootstrap the cluster and echo the new FSID.  --single-host-defaults
+# relaxes the no-single-host warnings; --skip-mon-network avoids requiring
+# a real network range; --allow-overwrite lets the test be idempotent
+# across retries on the same runner.
+cephadm_bootstrap_single_host() {
+    local image="$1"; local mon_ip="$2"; local cephadm_bin="${3:-/tmp/cephadm}"
+    # --cluster-network is intentionally omitted: it requires a *network*
+    # address (e.g. 10.0.0.0/24), not a host address, and the rejection
+    # message is unhelpful ("has host bits set").  For a single-host cluster
+    # the cluster network defaults to the mon network anyway, which is what
+    # we want.
+    # --allow-mismatched-release is required when the host's cephadm is
+    # from a different Ceph release than the target image (e.g. Ubuntu
+    # 24.04 ships squid-era cephadm, but we may want to bootstrap a reef
+    # or quincy cluster).  cephadm refuses to proceed otherwise.
+    "$cephadm_bin" --image "$image" bootstrap \
+        --mon-ip "$mon_ip" \
+        --skip-mon-network \
+        --skip-firewalld \
+        --skip-dashboard \
+        --single-host-defaults \
+        --allow-overwrite \
+        --allow-mismatched-release \
+        --no-cleanup-on-failure \
+        >&2
+    ls /var/lib/ceph/ 2>/dev/null | grep -E '^[0-9a-f]{8}-[0-9a-f-]+$' | head -1
+}
+
+
+# _ceph <fsid> <args...>
+#
+# Convenience wrapper to run a ceph CLI command inside the bootstrap
+# container.  Each invocation spawns a fresh podman container, so use it
+# for short queries — for long-running shells, use `cephadm shell --fsid X`
+# directly.
+_ceph() {
+    local fsid="$1"; shift
+    cephadm shell --fsid "$fsid" -- "$@"
+}
+
+
+# wait_cephadm_healthy <fsid> <timeout_seconds>
+#
+# Poll `ceph -s` until at least 1 MON in quorum, an active MGR, and
+# `num_up_osds >= want_osds`.  We don't require HEALTH_OK because a fresh
+# single-host cluster legitimately reports HEALTH_WARN about pool size
+# defaults, mon insecure_global_id_reclaim, etc.
+wait_cephadm_healthy() {
+    local fsid="$1"; local want_osds="${2:-1}"; local timeout="${3:-600}"
+    local deadline=$(( $(date +%s) + timeout ))
+    while [[ $(date +%s) -lt $deadline ]]; do
+        local s
+        s=$(_ceph "$fsid" ceph -s --format=json 2>/dev/null) || true
+        if [[ -n "$s" ]] && python3 -c "
+import json, sys
+try:
+    d = json.loads('''$s''')
+except Exception:
+    sys.exit(2)
+mon  = len(d.get('quorum_names', []))
+# active_name is set only when the mgr CLI exposes per-name fields (older
+# releases); squid+ just exposes available in the top-level mgrmap.
+# Accept either signal as mgr-ready.  NOTE: this whole python block is
+# embedded inside a bash double-quoted string, so do not use double
+# quotes anywhere here -- they terminate the outer string and split the
+# script into separate args, silently truncating the check.
+mgrmap = d.get('mgrmap', {})
+mgr  = mgrmap.get('active_name') or mgrmap.get('available')
+ups  = d.get('osdmap', {}).get('num_up_osds', 0)
+sys.exit(0 if mon >= 1 and mgr and ups >= int('$want_osds') else 1)
+"; then
+            info "cluster ready: ${want_osds}+ OSDs up"
+            return 0
+        fi
+        sleep 5
+    done
+    err "cluster did not become ready within ${timeout}s"
+    _ceph "$fsid" ceph -s 2>&1 | tail -20 || true
+    return 1
+}
+
+
+# apply_rgw_service <fsid> <service_id> <port>
+#
+# Schedule a single radosgw daemon via cephadm orch.  Wait for the
+# `radosgw --id rgw.<service_id>...` process to start on this host AND
+# for the listening port to accept TCP, since orch reports "running" as
+# soon as the container starts — before the radosgw socket is ready.
+apply_rgw_service() {
+    local fsid="$1"; local svc_id="${2:-test}"; local port="${3:-8080}"
+    _ceph "$fsid" ceph orch apply rgw "$svc_id" \
+        --placement="count:1" --port="$port" >&2
+    local i
+    # cephadm names the daemon 'rgw.<svc_id>.<host>.<random>' and runs it
+    # via `-n client.rgw.<svc_id>.<host>.<random>` (NOT --id).  Match the
+    # 'client.rgw.<svc_id>.' prefix so we catch the per-host suffix that
+    # cephadm appends.
+    for i in $(seq 1 90); do
+        if pgrep -f "radosgw.*-n[[:space:]]+client\.rgw\.${svc_id}\." >/dev/null \
+           && curl -fs --max-time 3 "http://localhost:${port}/" >/dev/null 2>&1; then
+            info "radosgw ready on port $port"
+            return 0
+        fi
+        sleep 5
+    done
+    err "radosgw did not come up within 450s"
+    _ceph "$fsid" ceph orch ps 2>&1 | tail -10 || true
+    return 1
+}
+
+
+# create_rgw_user <fsid> <uid> <access_key> <secret_key>
+#
+# Create an RGW user with deterministic keys (so the test doesn't need to
+# parse the JSON response). Returns 0 on success.
+create_rgw_user() {
+    local fsid="$1"; local uid="$2"; local access="$3"; local secret="$4"
+    _ceph "$fsid" radosgw-admin user create \
+        --uid="$uid" --display-name="$uid" \
+        --access-key="$access" --secret-key="$secret" \
+        --format=json >/dev/null
+}
+
+
+# cleanup_cephadm_cluster <fsid>
+#
+# Tear down the cluster, detach loop devices, and remove backing files.
+# Used by tests' EXIT trap.  Tolerant of partial-init state.
+cleanup_cephadm_cluster() {
+    local fsid="$1"
+    [[ -n "$fsid" ]] && cephadm rm-cluster --fsid "$fsid" --force --zap-osds 2>/dev/null || true
+    # Tear down the LVM stack we built in provision_loopback_osds before
+    # detaching the loops — otherwise vgremove later complains about missing
+    # PVs, and stale /dev/ceph-test-vgN entries clutter subsequent runs.
+    local vg
+    for vg in $(vgs --noheadings -o vg_name 2>/dev/null | awk '/^ *ceph-test-vg/{print $1}'); do
+        vgremove -ff -y "$vg" >/dev/null 2>&1 || true
+    done
+    losetup -D 2>/dev/null || true
+    rm -rf /var/lib/ceph-test-osds 2>/dev/null || true
+}

--- a/tests/lib/cephadm-setup.sh
+++ b/tests/lib/cephadm-setup.sh
@@ -132,6 +132,10 @@ cephadm_bootstrap_single_host() {
     # from a different Ceph release than the target image (e.g. Ubuntu
     # 24.04 ships squid-era cephadm, but we may want to bootstrap a reef
     # or quincy cluster).  cephadm refuses to proceed otherwise.
+    # --no-cleanup-on-failure would let us inspect a partial bootstrap, but
+    # it was added later in the quincy line and the apt-installed cephadm
+    # on Ubuntu 22.04 rejects it.  CI doesn't need the inspection anyway —
+    # the default (auto-cleanup on failed bootstrap) is what we want there.
     "$cephadm_bin" --image "$image" bootstrap \
         --mon-ip "$mon_ip" \
         --skip-mon-network \
@@ -140,7 +144,6 @@ cephadm_bootstrap_single_host() {
         --single-host-defaults \
         --allow-overwrite \
         --allow-mismatched-release \
-        --no-cleanup-on-failure \
         >&2
     ls /var/lib/ceph/ 2>/dev/null | grep -E '^[0-9a-f]{8}-[0-9a-f-]+$' | head -1
 }

--- a/tests/lib/microceph-setup.sh
+++ b/tests/lib/microceph-setup.sh
@@ -46,17 +46,46 @@ microceph_setup_single_node() {
         info "Already have $current_osds OSDs (target $osd_count)"
     fi
 
-    info "Waiting for cluster to be healthy (timeout ${health_timeout}s)..."
+    # Wait until the cluster is genuinely ready to accept traffic.  A fresh
+    # bootstrap reports HEALTH_WARN immediately (because of TOO_FEW_OSDS,
+    # mon_warn_on_insecure_global_id_reclaim, etc.), so grepping for
+    # HEALTH_(OK|WARN) alone returns "ready" with 0 OSDs up -- and the test
+    # then attaches osdtrace to a ceph-osd PID that exits seconds later when
+    # the cluster's first pool-create races a still-booting OSD.
+    #
+    # Require: at least one mon in quorum, the requested number of OSDs
+    # both up AND in, and the overall health string OK or WARN.
+    info "Waiting for $osd_count OSDs up+in and mon quorum (timeout ${health_timeout}s)..."
     local elapsed=0
     while [ "$elapsed" -lt "$health_timeout" ]; do
-        if microceph.ceph status 2>/dev/null | grep -q "HEALTH_OK\|HEALTH_WARN"; then
-            info "Cluster is ready (${elapsed}s)"
+        local status_json
+        status_json=$(microceph.ceph status --format=json 2>/dev/null) || true
+        if [ -n "$status_json" ] && python3 -c "
+import json, sys
+try:
+    d = json.loads('''$status_json''')
+except Exception:
+    sys.exit(2)
+health = d.get('health', {}).get('status', '')
+quorum = len(d.get('quorum_names', []))
+osdmap = d.get('osdmap', {})
+ups = osdmap.get('num_up_osds', 0)
+ins = osdmap.get('num_in_osds', 0)
+need = int('$osd_count')
+sys.exit(0 if (health in ('HEALTH_OK', 'HEALTH_WARN')
+               and quorum >= 1
+               and ups >= need
+               and ins >= need)
+         else 1)
+"; then
+            info "Cluster ready: ${osd_count} OSDs up+in (${elapsed}s)"
             return 0
         fi
         sleep 5
         elapsed=$((elapsed + 5))
     done
-    err "Cluster did not become healthy within ${health_timeout}s"
+    err "Cluster did not become ready (${osd_count} OSDs up+in) within ${health_timeout}s"
+    microceph.ceph status 2>&1 | tail -20 || true
     return 1
 }
 

--- a/tests/lib/verify-trace-output.sh
+++ b/tests/lib/verify-trace-output.sh
@@ -65,42 +65,58 @@ TRACE_EXPECTED_IO_SIZE=2097152
 # Same logic drops rows with the `[delayed%d ... ]` continuation tokens
 # appended (their NF is inflated past the expected count).
 _osdtrace_rows() {
+    # The "prev" buffer + END (no flush of prev) makes the LAST data row
+    # the parser would otherwise emit get dropped.  Defense-in-depth on
+    # top of the NF/landmark check: if SIGKILL hits osdtrace mid-printf
+    # at a buffer-flush boundary (libc splitting a large stdio flush
+    # across multiple write() syscalls), the byte-truncation can land
+    # somewhere the strict NF/landmark check still happens to accept.
+    # Skipping the last emit closes that corner.  Cost: one good row per
+    # trace, against thousands captured.
     awk '
         function num(s,   _t) { _t = s; gsub(/[^0-9-]/, "", _t); return _t + 0 }
+        function flush_pending() { if (prev != "") { print prev; prev = "" } }
 
         $1 == "osd" && $3 == "pg" && \
         $2 ~ /^-?[0-9]+$/ && \
         $4 ~ /^[0-9]+\.[0-9a-fA-F]+$/ {
             split($4, pg, ".")
             op = $5
+            candidate = ""
             if (op == "op_r" && NF == 25 && \
                 $6 == "size" && $24 == "op_lat") {
-                printf "op_r|%d|%s|%s|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d\n", \
+                candidate = sprintf("op_r|%d|%s|%s|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d", \
                     $2, pg[1], pg[2], \
                     $7, $9, $11, \
                     $13, $15, $17, $19, $21, \
-                    $23, $25
+                    $23, $25)
             } else if (op == "subop_w" && NF == 35 && \
                        $22 == "bluestore_lat" && $24 == "(prepare" && \
                        $34 == "subop_lat") {
-                printf "subop_w|%d|%s|%s|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d\n", \
+                candidate = sprintf("subop_w|%d|%s|%s|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d", \
                     $2, pg[1], pg[2], \
                     $7, $9, $11, \
                     $13, $15, $17, $19, $21, \
-                    $23, $25, $27, $31, num($33), $35
+                    $23, $25, $27, $31, num($33), $35)
             } else if (op == "op_w" && NF == 40 && \
                        $22 == "peers" && $27 == "bluestore_lat" && \
                        $29 == "(prepare" && $39 == "op_lat") {
-                printf "op_w|%d|%s|%s|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d\n", \
+                candidate = sprintf("op_w|%d|%s|%s|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d", \
                     $2, pg[1], pg[2], \
                     $7, $9, $11, \
                     $13, $15, $17, $19, $21, \
                     num($23), num($24), num($25), num($26), \
-                    $28, $30, $32, $36, num($38), $40
+                    $28, $30, $32, $36, num($38), $40)
             }
             # else: row was truncated, has [delayed...] suffix, or printed
             #       an op type we do not parse.  Dropped silently.
+            if (candidate != "") {
+                flush_pending()
+                prev = candidate
+            }
         }
+        # END deliberately omitted: prev holds the last data row the
+        # parser would have emitted; not flushing it here drops it.
     ' "$1"
 }
 
@@ -117,11 +133,23 @@ _osdtrace_rows() {
 # guards against the same kind of partial-write artifact appearing in
 # the size/latency fields.
 _radostrace_rows() {
+    # Drop the last data row.  SIGKILL/SIGTERM of the writer can leave
+    # the file's tail mid-printf (e.g. an `rbd_data.<hex>.<seq>` object
+    # name truncated to just `rbd`), and the NF >= 10 predicate is
+    # loose enough to admit those byte-truncated rows.  Buffering the
+    # latest match in `prev` and not flushing it at END drops exactly
+    # the one potentially-malformed row; previously-completed write()
+    # syscalls already landed atomically, so every earlier match is
+    # safe.  Cost: one good row per trace among thousands.
     awk '
+        function flush_pending() { if (prev != "") { print prev; prev = "" } }
         $1 ~ /^[0-9]+$/ && NF >= 10 {
-            print $1 "|" $2 "|" $3 "|" $4 "|" $5 "|" $6 "|" $7 "|" \
-                  ($8 + 0) "|" ($9 + 0) "|" $10
+            flush_pending()
+            prev = $1 "|" $2 "|" $3 "|" $4 "|" $5 "|" $6 "|" $7 "|" \
+                   ($8 + 0) "|" ($9 + 0) "|" $10
         }
+        # END deliberately omitted: prev holds the last data row; not
+        # flushing it here drops it.
     ' "$1"
 }
 

--- a/tests/lib/verify-trace-output.sh
+++ b/tests/lib/verify-trace-output.sh
@@ -34,22 +34,72 @@ TRACE_EXPECTED_IO_SIZE=2097152
 
 # _osdtrace_rows <log>
 #
-# Stream pipe-separated osdtrace data rows to stdout, one per line:
-#   osd_id|pool|pg_hex|op|latency
-# Filters out the header/status/truncated lines and the `[delayed…]`
-# continuation lines.  Latency is forced numeric via `$NF + 0` so a
-# truncated mid-print row (whose last field becomes a non-numeric fragment
-# like "s" from a half-emitted "seq_wait") doesn't poison the downstream
-# bash arithmetic comparison.
+# Stream typed, pipe-separated osdtrace data rows to stdout.  The first
+# field is the op-type discriminator (op_r / subop_w / op_w); the
+# remaining fields are the op-type's full schema, in printf order.
+#
+# Schemas (mirror the three print_op_* functions in src/osdtrace.cc):
+#
+#   op_r    | osd | pool | pg | size | client | tid
+#           | throttle_lat | recv_lat | dispatch_lat | queue_lat | osd_lat
+#           | bluestore_lat | op_lat
+#
+#   subop_w | osd | pool | pg | size | client | tid
+#           | throttle_lat | recv_lat | dispatch_lat | queue_lat | osd_lat
+#           | bluestore_lat | prepare_lat | aio_wait_lat | seq_wait_lat
+#           | kv_commit_lat | subop_lat
+#
+#   op_w    | osd | pool | pg | size | client | tid
+#           | throttle_lat | recv_lat | dispatch_lat | queue_lat | osd_lat
+#           | peer0_id | peer0_lat | peer1_id | peer1_lat
+#           | bluestore_lat | prepare_lat | aio_wait_lat | seq_wait_lat
+#           | kv_commit_lat | op_lat
+#
+# Rejection of malformed/truncated rows is critical: a SIGKILL hitting
+# osdtrace mid-printf can leave a row whose tail is the underflowed
+# peer-latency token (`(-1, 18446743169577026)]`), and a naive `$NF + 0`
+# verifier mistakes that for the total op_lat.  This parser instead
+# matches each op type by exact NF AND by literal field-name landmarks
+# (e.g. `$24 == "op_lat"` for op_r, `$22 == "peers"` + `$39 == "op_lat"`
+# for op_w).  Truncated rows fail at least one landmark and are dropped.
+# Same logic drops rows with the `[delayed%d ... ]` continuation tokens
+# appended (their NF is inflated past the expected count).
 _osdtrace_rows() {
     awk '
+        function num(s,   _t) { _t = s; gsub(/[^0-9-]/, "", _t); return _t + 0 }
+
         $1 == "osd" && $3 == "pg" && \
         $2 ~ /^-?[0-9]+$/ && \
         $4 ~ /^[0-9]+\.[0-9a-fA-F]+$/ {
             split($4, pg, ".")
-            # $5 is the op type: op_r / op_w / subop_w.  Useful context for
-            # error messages even though no check currently keys off it.
-            print $2 "|" pg[1] "|" pg[2] "|" $5 "|" ($NF + 0)
+            op = $5
+            if (op == "op_r" && NF == 25 && \
+                $6 == "size" && $24 == "op_lat") {
+                printf "op_r|%d|%s|%s|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d\n", \
+                    $2, pg[1], pg[2], \
+                    $7, $9, $11, \
+                    $13, $15, $17, $19, $21, \
+                    $23, $25
+            } else if (op == "subop_w" && NF == 35 && \
+                       $22 == "bluestore_lat" && $24 == "(prepare" && \
+                       $34 == "subop_lat") {
+                printf "subop_w|%d|%s|%s|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d\n", \
+                    $2, pg[1], pg[2], \
+                    $7, $9, $11, \
+                    $13, $15, $17, $19, $21, \
+                    $23, $25, $27, $31, num($33), $35
+            } else if (op == "op_w" && NF == 40 && \
+                       $22 == "peers" && $27 == "bluestore_lat" && \
+                       $29 == "(prepare" && $39 == "op_lat") {
+                printf "op_w|%d|%s|%s|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d\n", \
+                    $2, pg[1], pg[2], \
+                    $7, $9, $11, \
+                    $13, $15, $17, $19, $21, \
+                    num($23), num($24), num($25), num($26), \
+                    $28, $30, $32, $36, num($38), $40
+            }
+            # else: row was truncated, has [delayed...] suffix, or printed
+            #       an op type we do not parse.  Dropped silently.
         }
     ' "$1"
 }
@@ -94,6 +144,55 @@ verify_osdtrace_output() {
     return $rc
 }
 
+# Per-row invariants shared across all three op types:
+#   - osd_id within [0, max_osd_id]
+#   - total op_lat (or subop_lat) within TRACE_MAX_LATENCY_US
+# Helpers read $row (associative array) and $max_osd_id from the caller's
+# scope; bash dynamic-scoped locals make that work.
+_osdtrace_check_common() {
+    if (( row[osd_id] < 0 || row[osd_id] > max_osd_id )); then
+        err "Found OSD id ${row[osd_id]} outside [0, $max_osd_id] (op=${row[op]} pool=${row[pool]} tid=${row[tid]})"
+        return 1
+    fi
+    if (( row[op_lat] > TRACE_MAX_LATENCY_US )); then
+        err "Found op_lat ${row[op_lat]} µs > $TRACE_MAX_LATENCY_US µs in osdtrace output (op=${row[op]} osd=${row[osd_id]} pool=${row[pool]} tid=${row[tid]})"
+        return 1
+    fi
+}
+
+# Strict invariant: every named sub-latency field must be <= total op_lat.
+# A sub-latency exceeding the total signals an unsigned-underflow in the
+# BPF timestamp subtraction (end < start), which has been seen on rare
+# events; without this check the underflowed value just looks like a
+# huge µs number and quietly poisons downstream analysis.
+_osdtrace_check_sublatencies() {
+    local field
+    for field in "$@"; do
+        if (( row[$field] > row[op_lat] )); then
+            err "Sub-latency ${field}=${row[$field]} µs > op_lat=${row[op_lat]} µs (op=${row[op]} osd=${row[osd_id]} pool=${row[pool]} tid=${row[tid]})"
+            return 1
+        fi
+    done
+}
+
+# Optional per-peer check for op_w only.  Peer slot is -1 when the pool's
+# replication factor leaves that slot unused; the corresponding peer_lat
+# is uninitialised garbage and must be skipped.
+_osdtrace_check_peer() {
+    local id_field=$1 lat_field=$2
+    if (( row[$id_field] == -1 )); then
+        return 0
+    fi
+    if (( row[$id_field] < 0 || row[$id_field] > max_osd_id )); then
+        err "Peer OSD id ${row[$id_field]} outside [0, $max_osd_id] (op_w osd=${row[osd_id]} pool=${row[pool]} tid=${row[tid]})"
+        return 1
+    fi
+    if (( row[$lat_field] > row[op_lat] )); then
+        err "Peer latency ${lat_field}=${row[$lat_field]} µs > op_lat=${row[op_lat]} µs (op_w osd=${row[osd_id]} peer=${row[$id_field]} tid=${row[tid]})"
+        return 1
+    fi
+}
+
 _verify_osdtrace_output_impl() {
     local log=$1
     local test_pool_id=$2
@@ -102,56 +201,89 @@ _verify_osdtrace_output_impl() {
     local min_rows=$5
 
     local pool_rows=0
+    local op_r_total=0 subop_w_total=0 op_w_total=0
+    local op_r_pool=0  subop_w_pool=0  op_w_pool=0
     local -A row
-    local osd_id pool pg_hex op latency
+    local line op_type _
     local pg_dec
 
-    while IFS='|' read -r osd_id pool pg_hex op latency; do
-        [ -z "$osd_id" ] && continue
+    # Per-op-type field lists, used to populate $row from the parser
+    # output and to enumerate sub-latency fields for the strict bound.
+    local -a OP_R_SUBLATS=(throttle_lat recv_lat dispatch_lat queue_lat osd_lat bluestore_lat)
+    local -a SUBOP_W_SUBLATS=(throttle_lat recv_lat dispatch_lat queue_lat osd_lat bluestore_lat prepare_lat aio_wait_lat seq_wait_lat kv_commit_lat)
+    local -a OP_W_SUBLATS=(throttle_lat recv_lat dispatch_lat queue_lat osd_lat bluestore_lat prepare_lat aio_wait_lat seq_wait_lat kv_commit_lat)
 
-        # Per-row dict.  All subsequent checks read fields by name.
-        row=(
-            [osd_id]="$osd_id"
-            [pool]="$pool"
-            [pg]="$pg_hex"
-            [op]="$op"
-            [latency]="$latency"
-        )
+    while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        op_type=${line%%|*}
+        row=( [op]="$op_type" )
 
-        # 1. OSD id within cluster range (global invariant — any pool).
-        if (( row[osd_id] < 0 || row[osd_id] > max_osd_id )); then
-            err "Found OSD id ${row[osd_id]} outside expected range [0, $max_osd_id] (op=${row[op]} pool=${row[pool]})"
-            return 1
-        fi
+        case "$op_type" in
+            op_r)
+                IFS='|' read -r _ row[osd_id] row[pool] row[pg] \
+                    row[size] row[client] row[tid] \
+                    row[throttle_lat] row[recv_lat] row[dispatch_lat] \
+                    row[queue_lat] row[osd_lat] \
+                    row[bluestore_lat] row[op_lat] <<< "$line"
+                op_r_total=$((op_r_total + 1))
+                _osdtrace_check_common || return 1
+                _osdtrace_check_sublatencies "${OP_R_SUBLATS[@]}" || return 1
+                ;;
+            subop_w)
+                IFS='|' read -r _ row[osd_id] row[pool] row[pg] \
+                    row[size] row[client] row[tid] \
+                    row[throttle_lat] row[recv_lat] row[dispatch_lat] \
+                    row[queue_lat] row[osd_lat] \
+                    row[bluestore_lat] row[prepare_lat] row[aio_wait_lat] \
+                    row[seq_wait_lat] row[kv_commit_lat] row[op_lat] <<< "$line"
+                subop_w_total=$((subop_w_total + 1))
+                _osdtrace_check_common || return 1
+                _osdtrace_check_sublatencies "${SUBOP_W_SUBLATS[@]}" || return 1
+                ;;
+            op_w)
+                IFS='|' read -r _ row[osd_id] row[pool] row[pg] \
+                    row[size] row[client] row[tid] \
+                    row[throttle_lat] row[recv_lat] row[dispatch_lat] \
+                    row[queue_lat] row[osd_lat] \
+                    row[peer0_id] row[peer0_lat] row[peer1_id] row[peer1_lat] \
+                    row[bluestore_lat] row[prepare_lat] row[aio_wait_lat] \
+                    row[seq_wait_lat] row[kv_commit_lat] row[op_lat] <<< "$line"
+                op_w_total=$((op_w_total + 1))
+                _osdtrace_check_common || return 1
+                _osdtrace_check_sublatencies "${OP_W_SUBLATS[@]}" || return 1
+                _osdtrace_check_peer peer0_id peer0_lat || return 1
+                _osdtrace_check_peer peer1_id peer1_lat || return 1
+                ;;
+            *)
+                continue  # parser only emits the three above
+                ;;
+        esac
 
-        # 2. Latency upper bound (global invariant — any pool).
-        if (( row[latency] > TRACE_MAX_LATENCY_US )); then
-            err "Found latency ${row[latency]} µs > $TRACE_MAX_LATENCY_US µs in osdtrace output (osd=${row[osd_id]} op=${row[op]} pool=${row[pool]})"
-            return 1
-        fi
-
-        # Per-pool checks: only test_pool rows.  osdtrace also captures
-        # internal MicroCeph traffic (.mgr/.osd metadata pools); we don't
-        # want to validate PG ranges against those pools' pg_num.
+        # Per-pool checks (PG range; per-pool row count): only count rows
+        # that hit the workload's test_pool.  osdtrace also captures
+        # internal pool traffic (.mgr/.osd/etc.) whose pg_num differs.
         if [ "${row[pool]}" = "$test_pool_id" ]; then
             pool_rows=$((pool_rows + 1))
+            case "$op_type" in
+                op_r)    op_r_pool=$((op_r_pool + 1)) ;;
+                subop_w) subop_w_pool=$((subop_w_pool + 1)) ;;
+                op_w)    op_w_pool=$((op_w_pool + 1)) ;;
+            esac
 
-            # 3. PG index within pg_num.  osdtrace prints PG in hex
-            #    (std::hex on op.pg.m_seed) without an `0x` prefix, so plain
-            #    decimal parsing would silently accept any hex letters as 0.
-            #    Convert with bash's `$((16#…))`.
+            # PG index within pg_num.  osdtrace prints PG in hex
+            # (std::hex on op.pg.m_seed) without an `0x` prefix, so plain
+            # decimal parsing would silently accept any hex letters as 0.
+            # Convert with bash's `$((16#…))`.
             pg_dec=$((16#${row[pg]}))
             if (( pg_dec < 0 || pg_dec >= pg_num )); then
-                err "Found PG ${row[pg]} (decimal $pg_dec) outside expected range [0, $pg_num) in osdtrace output"
+                err "Found PG ${row[pg]} (decimal $pg_dec) outside expected range [0, $pg_num) in osdtrace output (op=${row[op]} osd=${row[osd_id]} tid=${row[tid]})"
                 return 1
             fi
         fi
     done < <(_osdtrace_rows "$log")
 
-    # 4. Aggregate: enough rows for test_pool specifically.  Counting only
-    #    test_pool rows is what proves the fio workload traffic reached the
-    #    BPF program — not just internal-pool noise.
-    info "osdtrace captured $pool_rows trace rows for test_pool (pool id $test_pool_id)"
+    info "osdtrace per-op-type totals: op_r=$op_r_total subop_w=$subop_w_total op_w=$op_w_total"
+    info "osdtrace per-op-type rows on test_pool ($test_pool_id): op_r=$op_r_pool subop_w=$subop_w_pool op_w=$op_w_pool (total $pool_rows)"
     if (( pool_rows < min_rows )); then
         err "osdtrace did not capture enough trace data for test_pool (expected >= $min_rows rows, got $pool_rows)"
         return 1

--- a/tests/lib/verify-trace-output.sh
+++ b/tests/lib/verify-trace-output.sh
@@ -306,3 +306,121 @@ _verify_radostrace_output_impl() {
 
     info "✓ All radostrace output fields validated successfully"
 }
+
+
+# verify_osdtrace_rgw_output <log> <data_pool_id> <max_osd_id> <data_pool_pg_num> <min_rows>
+#
+# Variant of verify_osdtrace_output for RGW-driven workloads (S3 PUT/GET via
+# `radosgw`).  Same per-row invariants -- OSD id range, latency upper bound,
+# PG-within-pg_num -- but anchored to the data pool the RGW writes object
+# payloads into (typically `default.rgw.buckets.data`) rather than a single
+# user-created pool.  RGW also generates traffic to several internal pools
+# (.rgw.meta, .rgw.buckets.index, .rgw.log, ...); those rows are ignored
+# for the per-pool checks since their pg_num values differ.
+verify_osdtrace_rgw_output() {
+    # Implementation re-uses the rbd-bench verifier's row loop; the per-pool
+    # filter already restricts the PG check + row count to the named pool,
+    # which is exactly the semantics we want for RGW.
+    verify_osdtrace_output "$@"
+}
+
+
+# verify_radostrace_rgw_output <log> <max_osd_id> <min_rows>
+#
+# Variant of verify_radostrace_output for RGW-driven workloads.  Drops three
+# rbd-bench-specific checks that do not apply to RGW traffic:
+#   - pool id pin: RGW sprays across .rgw.meta / .rgw.buckets.index /
+#     .rgw.buckets.data / .rgw.log; there is no single canonical pool.
+#   - `^rbd_` object name prefix: RGW objects are
+#     `<bucket-marker>_<oid>` / `_shadow_.<…>` / `meta.head:user.<…>` etc.
+#   - 2 MiB IO size anchor: the S3 PUT workload uses randomised sizes.
+#
+# Kept (pool-agnostic) invariants:
+#   - row count >= min_rows
+#   - WR flag is W or R, both directions observed
+#   - every OSD id in the acting set within [0, max_osd_id]
+#   - latency <= TRACE_MAX_LATENCY_US
+verify_radostrace_rgw_output() {
+    local _xtrace=0
+    case $- in *x*) _xtrace=1; set +x;; esac
+
+    _verify_radostrace_rgw_output_impl "$@"
+    local rc=$?
+
+    (( _xtrace == 1 )) && set -x
+    return $rc
+}
+
+_verify_radostrace_rgw_output_impl() {
+    local log=$1
+    local max_osd_id=$2
+    local min_rows=$3
+
+    local total=0
+    local saw_w=0 saw_r=0
+    local -A row
+    local pid client tid pool pg acting wr size latency object
+    local acting_inner osd_id_str osd_id
+
+    while IFS='|' read -r pid client tid pool pg acting wr size latency object; do
+        [ -z "$pid" ] && continue
+
+        row=(
+            [pid]="$pid"
+            [client]="$client"
+            [tid]="$tid"
+            [pool]="$pool"
+            [pg]="$pg"
+            [acting]="$acting"
+            [wr]="$wr"
+            [size]="$size"
+            [latency]="$latency"
+            [object]="$object"
+        )
+        total=$((total + 1))
+
+        case "${row[wr]}" in
+            W) saw_w=1 ;;
+            R) saw_r=1 ;;
+            *) err "Invalid WR flag '${row[wr]}' in radostrace output (expected W or R, tid=${row[tid]})"
+               return 1 ;;
+        esac
+
+        acting_inner=${row[acting]#\[}
+        acting_inner=${acting_inner%\]}
+        local IFS_save=$IFS
+        IFS=','
+        # shellcheck disable=SC2086  # intentional word-split on commas
+        for osd_id_str in $acting_inner; do
+            osd_id=$((osd_id_str))
+            if (( osd_id < 0 || osd_id > max_osd_id )); then
+                IFS=$IFS_save
+                err "OSD id $osd_id in acting set ${row[acting]} outside valid range [0, $max_osd_id] (tid=${row[tid]})"
+                return 1
+            fi
+        done
+        IFS=$IFS_save
+
+        if (( row[latency] > TRACE_MAX_LATENCY_US )); then
+            err "Found latency ${row[latency]} µs > $TRACE_MAX_LATENCY_US µs in radostrace output (tid=${row[tid]})"
+            return 1
+        fi
+    done < <(_radostrace_rows "$log")
+
+    info "radostrace captured $total trace rows from RGW workload"
+    if (( total < min_rows )); then
+        err "radostrace did not capture enough data (expected >= $min_rows rows, got $total)"
+        return 1
+    fi
+
+    if (( saw_w == 0 )); then
+        err "radostrace output has no 'W' rows but workload issued PUTs"
+        return 1
+    fi
+    if (( saw_r == 0 )); then
+        err "radostrace output has no 'R' rows but workload issued GETs"
+        return 1
+    fi
+
+    info "✓ All radostrace output fields validated successfully"
+}

--- a/tests/local-cephadm-test.sh
+++ b/tests/local-cephadm-test.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+#
+# Run tests/functional-test-cephadm-rgw.sh inside a clean LXD VM, once per
+# Ceph release.  Use this to validate the cephadm test + binaries on the
+# developer host before pushing CI.
+#
+# Why a VM?  cephadm bootstrap installs systemd units, creates loopback
+# devices, and binds to system addresses — none of which we want touching
+# the developer's host environment.  An LXD VM (not container — cephadm
+# needs full systemd + kernel namespaces) gives a disposable scratch host
+# each run.
+#
+# Usage:
+#   tests/local-cephadm-test.sh                                # all 4 releases
+#   tests/local-cephadm-test.sh squid                          # one release
+#   tests/local-cephadm-test.sh -k squid                       # keep VM on success
+#   tests/local-cephadm-test.sh -v ubuntu:22.04 reef           # run on a 22.04 VM
+#
+# Flags:
+#   -k           Keep the VM after a successful run (always kept on failure)
+#   -v <image>   LXD image to use (default: ubuntu:24.04)
+#   -c <count>   CPU count per VM (default: 4)
+#   -m <ram>     RAM per VM (default: 8GiB)
+#   -d <disk>    Root-disk size per VM (default: 30GiB)
+#
+# On failure the VM is always preserved so you can `lxc exec <vm> -- bash`
+# and inspect the partial cluster state.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+KEEP_VM=0
+VM_IMAGE="ubuntu:24.04"
+VM_CPU=4
+VM_RAM="8GiB"
+VM_DISK="30GiB"
+
+while getopts ":kv:c:m:d:h" opt; do
+    case "$opt" in
+        k) KEEP_VM=1 ;;
+        v) VM_IMAGE="$OPTARG" ;;
+        c) VM_CPU="$OPTARG" ;;
+        m) VM_RAM="$OPTARG" ;;
+        d) VM_DISK="$OPTARG" ;;
+        h|*)
+            sed -n '4,28p' "$0"; exit 0 ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+RELEASES=("$@")
+[ "${#RELEASES[@]}" -eq 0 ] && RELEASES=(quincy reef squid tentacle)
+
+info() { printf '\033[1;34mINFO:\033[0m %s\n' "$*"; }
+err()  { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; }
+ok()   { printf '\033[1;32mOK:\033[0m %s\n' "$*"; }
+
+# Pre-flight: tooling + built binaries.
+command -v lxc >/dev/null || { err "lxc not in PATH (install lxd-client)"; exit 1; }
+for f in "$PROJECT_ROOT/osdtrace" "$PROJECT_ROOT/radostrace"; do
+    [ -x "$f" ] || { err "missing built binary $f — run 'make all' first"; exit 1; }
+done
+
+
+# run_one_release <release>
+#
+# Create a fresh ubuntu LXD VM, push the cephtrace binaries + the tests/
+# directory, and invoke functional-test-cephadm-rgw.sh inside.
+run_one_release() {
+    local release="$1"
+    local vm="cephadm-test-${release}"
+    local logf="/tmp/cephadm-test-${release}.log"
+
+    info "[${release}] step 1: provision LXD VM ${vm} (image=${VM_IMAGE} cpu=${VM_CPU} ram=${VM_RAM} disk=${VM_DISK})"
+
+    if lxc info "$vm" >/dev/null 2>&1; then
+        info "[${release}] existing VM found — deleting before fresh init"
+        lxc delete --force "$vm" >/dev/null
+    fi
+
+    lxc init "$VM_IMAGE" "$vm" --vm \
+        -c "limits.cpu=${VM_CPU}" \
+        -c "limits.memory=${VM_RAM}" \
+        -d "root,size=${VM_DISK}" >/dev/null
+    lxc start "$vm"
+
+    info "[${release}] step 2: wait for VM agent + cloud-init"
+    local i ready=0
+    for i in $(seq 1 60); do
+        if lxc exec "$vm" -- true 2>/dev/null \
+           && lxc exec "$vm" -- cloud-init status --wait >/dev/null 2>&1; then
+            ready=1
+            break
+        fi
+        sleep 5
+    done
+    if [ $ready -eq 0 ]; then
+        err "[${release}] VM never became reachable"
+        return 1
+    fi
+
+    info "[${release}] step 3: push binaries + tests/ tree"
+    lxc exec "$vm" -- mkdir -p /root/cephtrace
+    # `lxc file push` works for individual files; for the binary it preserves
+    # mode and inode is fresh, avoiding the ETXTBSY trap if something on the
+    # host happens to be holding the file open.  Use --mode=755 explicitly
+    # so the test's `[ -x ]` check passes.
+    lxc file push --mode=755 "$PROJECT_ROOT/osdtrace"   "$vm/root/cephtrace/osdtrace"
+    lxc file push --mode=755 "$PROJECT_ROOT/radostrace" "$vm/root/cephtrace/radostrace"
+    # tests/ is a small directory; tar-pipe in one shot.
+    tar -C "$PROJECT_ROOT" -cf - tests \
+        | lxc exec "$vm" -- tar -C /root/cephtrace -xf -
+
+    info "[${release}] step 4: run functional-test-cephadm-rgw.sh inside VM"
+    local rc=0
+    # NB: ${PIPESTATUS[0]} captures lxc-exec's exit, not tee's.  Without this
+    # a tee that returns 0 (always) would mask any test failure.
+    set +e
+    lxc exec "$vm" --env DEBIAN_FRONTEND=noninteractive \
+                  --env "KEEP_CLUSTER=${KEEP_CLUSTER:-0}" -- bash -c "
+        cd /root/cephtrace
+        ./tests/functional-test-cephadm-rgw.sh '$release'
+    " 2>&1 | tee "$logf"
+    rc=${PIPESTATUS[0]}
+    set -e
+
+    if [ $rc -eq 0 ]; then
+        ok "[${release}] PASSED  (log: $logf)"
+        if [ $KEEP_VM -eq 0 ]; then
+            info "[${release}] cleanup: delete VM ${vm}"
+            lxc delete --force "$vm" >/dev/null
+        else
+            info "[${release}] VM ${vm} retained (-k flag): inspect with 'lxc exec ${vm} -- bash'"
+        fi
+        return 0
+    else
+        err "[${release}] FAILED (exit ${rc})"
+        err "[${release}] VM ${vm} retained for inspection: 'lxc exec ${vm} -- bash'"
+        err "[${release}] log: $logf"
+        return $rc
+    fi
+}
+
+
+# Run releases sequentially.  Parallel would crush a single host: each
+# cluster uses 3 OSDs + MON + MGR + RGW + s3cmd, roughly 5–7 GiB RAM and
+# 10 GiB disk inside its VM.
+info "releases to run: ${RELEASES[*]}"
+OVERALL_RC=0
+FAILED=()
+for r in "${RELEASES[@]}"; do
+    if ! run_one_release "$r"; then
+        OVERALL_RC=1
+        FAILED+=("$r")
+    fi
+done
+
+echo
+if [ $OVERALL_RC -eq 0 ]; then
+    ok "all releases passed: ${RELEASES[*]}"
+else
+    err "failed: ${FAILED[*]}"
+    err "passed: $(comm -23 <(printf '%s\n' "${RELEASES[@]}" | sort) \
+                          <(printf '%s\n' "${FAILED[@]}" | sort) | xargs)"
+fi
+exit $OVERALL_RC


### PR DESCRIPTION
## Summary
- New end-to-end test that exercises **both** `osdtrace` and `radostrace` against a cephadm-deployed cluster across the full quincy / reef / squid / tentacle line (`tests/functional-test-cephadm-rgw.sh`, reusable helpers in `tests/lib/cephadm-setup.sh`, LXD-VM dev wrapper in `tests/local-cephadm-test.sh`).
- New `build-ubuntu-cephadm` matrix job in `.github/workflows/pr-build.yaml`: `ubuntu-22.04` × `ubuntu-24.04` × `{quincy, reef, squid, tentacle}`, `fail-fast: false`, 35-minute timeout per cell.
- Added quincy 17.2.8 and 17.2.9 embedded DWARF JSONs (centos-stream) for both `osdtrace` and `radostrace`. 17.2.8 matches the `quay.io/ceph/ceph:v17.2.8` image used by the cephadm test; 17.2.9 covers RPM-deployed production clusters at the latest quincy point release (no v17.2.9 container was ever published).
- Tool tweak: `osdtrace` / `radostrace` now skip the deleted-binary / deleted-library guard when `-j` (JSON export) is set, so the export path can parse the on-disk (possibly newly-upgraded) binary regardless of what's still mmap'd by the live process.

## Test plan
- [x] Local validation via `tests/local-cephadm-test.sh` on Ubuntu 24.04 host: all four releases PASS
  - squid: osdtrace 1243 rows, radostrace 2410 rows
  - reef: osdtrace 901, radostrace 1941
  - tentacle: osdtrace 1631, radostrace 3076
  - quincy: osdtrace 824, radostrace 1782
- [ ] CI matrix (`build-ubuntu-cephadm`) green across all 8 cells (2 OS × 4 releases)
- [ ] Existing CI jobs (`build-ubuntu`, `build-ubuntu-arm64`, `build-centos`, `build-rocky`, `clang-tidy`) still pass