### PR TITLE
tests: increase OSD loopback size to 3G to prevent CI storage exhaustion

### DIFF
--- a/tests/functional-test-embedded-dwarf.sh
+++ b/tests/functional-test-embedded-dwarf.sh
@@ -69,7 +69,7 @@ if [ ! -f "$PROJECT_ROOT/radostrace" ]; then
 fi
 
 info "=== Step 1: Setup MicroCeph (install + bootstrap + OSDs + wait healthy) ==="
-if ! microceph_setup_single_node 3 1G 120; then
+if ! microceph_setup_single_node 3 3G 120; then
     err "MicroCeph cluster did not become healthy within timeout"
     exit 1
 fi

--- a/tests/functional-test-microceph.sh
+++ b/tests/functional-test-microceph.sh
@@ -77,7 +77,7 @@ if [ ! -f "$PROJECT_ROOT/radostrace" ]; then
 fi
 
 info "=== Step 1: Setup MicroCeph (install + bootstrap + OSDs + wait healthy) ==="
-if ! microceph_setup_single_node 3 1G 120; then
+if ! microceph_setup_single_node 3 3G 120; then
     err "MicroCeph cluster did not become healthy within timeout"
     exit 1
 fi


### PR DESCRIPTION
This pull request increases the per-OSD loopback disk size from `1G` to `3G` in the functional test setup calls. Replicating benchmark writes in consecutive test steps easily saturated the previous tiny `3GB` raw cluster allocation, crossing Ceph's 95% OSD full-ratio safety threshold and causing transient CI timeouts/failures on the runners. This increases the total headroom to `9GB`, keeping it safely below the safety thresholds.