### PR TITLE
osdtrace: replace --id option with -n

### DIFF
--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -960,13 +960,12 @@ void print_discovered_osds(const std::vector<OsdProcessInfo>& processes) {
 }
 
 std::set<int> process_ids;  // Support multiple PIDs (set ensures deduplication)
-std::set<int> requested_osd_ids;  // Populated by --id; resolved to PIDs in main()
+std::set<int> requested_osd_ids;  // Populated by -n; resolved to PIDs in main()
 int parse_args(int argc, char **argv) {
   static struct option long_options[] = {
     {"skip-version-check", no_argument, 0, 0},
     {"version", no_argument, 0, 'V'},
     {"list", no_argument, 0, 0},
-    {"id", required_argument, 0, 0},
     {0, 0, 0, 0}
   };
 
@@ -975,7 +974,7 @@ int parse_args(int argc, char **argv) {
   // it in a plain char is unsafe on platforms where char is unsigned by
   // default (the `!= -1` test can then loop forever).  Match kfstrace.
   int opt;
-  while ((opt = getopt_long(argc, argv, ":st:bj:i:l:p:V", long_options, &option_index)) != -1) {
+  while ((opt = getopt_long(argc, argv, ":st:bj:i:l:p:n:V", long_options, &option_index)) != -1) {
     switch (opt) {
       case 0:
         // Handle long options
@@ -983,19 +982,22 @@ int parse_args(int argc, char **argv) {
           skip_version_check = true;
         } else if (strcmp(long_options[option_index].name, "list") == 0) {
           list_only = true;
-        } else if (strcmp(long_options[option_index].name, "id") == 0) {
+        }
+        break;
+      case 'n':
+        {
           std::stringstream ss(optarg);
           std::string token;
           while (std::getline(ss, token, ',')) {
             try {
               int id = stoi(token);
               if (id < 0) {
-                std::cerr << "Invalid --id value (must be non-negative): " << token << std::endl;
+                std::cerr << "Invalid -n value (must be non-negative): " << token << std::endl;
                 return -1;
               }
               requested_osd_ids.insert(id);
             } catch (...) {
-              std::cerr << "Invalid --id value: " << token << std::endl;
+              std::cerr << "Invalid -n value: " << token << std::endl;
               return -1;
             }
           }
@@ -1050,7 +1052,7 @@ int parse_args(int argc, char **argv) {
         break;
       case '?':
       case 'h':
-        std::cout << "Usage: " << argv[0] << " [-s] [-l <milliseconds>] [-b] [-j] [-i <filename>] [-t <seconds>] [-p <pid1,pid2,...>] [--id <osd-id1,osd-id2,...>] [--skip-version-check] [--list]\n";
+        std::cout << "Usage: " << argv[0] << " [-s] [-l <milliseconds>] [-b] [-j] [-i <filename>] [-t <seconds>] [-p <pid1,pid2,...>] [-n <osd-id1,osd-id2,...>] [--skip-version-check] [--list]\n";
         std::cout << "  -s                        Set probe mode to Single OP (logs PrimaryLogPG::log_op_stats only)\n";
         std::cout << "  -l <milliseconds>         Set operation latency threshold to capture\n";
         std::cout << "  -b                        Set probe mode to Bluestore\n";
@@ -1058,7 +1060,7 @@ int parse_args(int argc, char **argv) {
         std::cout << "  -i <filename>             Import DWARF info from JSON file\n";
         std::cout << "  -t <seconds>              Set execution timeout in seconds\n";
         std::cout << "  -p <pid1,pid2,...>        Probe using Process IDs (comma-separated, mandatory for tracing containerized processes)\n";
-        std::cout << "  --id <osd-id1,osd-id2,...> Probe by OSD ID (comma-separated; resolves to PIDs via discovery)\n";
+        std::cout << "  -n <osd-id1,osd-id2,...>  Probe by OSD ID (comma-separated; resolves to PIDs via discovery)\n";
         std::cout << "  --skip-version-check      Skip version check when importing DWARF JSON (currently needed for containers)\n";
         std::cout << "  --list                    List active ceph-osd processes on the host, their PIDs and OSD IDs, and exit\n";
         std::cout << "  -V, --version             Print version information and exit\n";
@@ -1220,10 +1222,10 @@ int main(int argc, char **argv) {
     return 0;
   }
 
-  // Resolve --id <osd-id,...> to PIDs via discovery and feed into process_ids.
+  // Resolve -n <osd-id,...> to PIDs via discovery and feed into process_ids.
   if (!requested_osd_ids.empty()) {
     if (!process_ids.empty()) {
-      std::cerr << "Error: --id and -p are mutually exclusive" << std::endl;
+      std::cerr << "Error: -n and -p are mutually exclusive" << std::endl;
       return 1;
     }
     auto processes = discover_ceph_osd_processes();
@@ -1245,7 +1247,7 @@ int main(int argc, char **argv) {
         return 1;
       }
       process_ids.insert(matches[0]);
-      clog << "--id " << want << " resolved to PID " << matches[0] << endl;
+      clog << "-n " << want << " resolved to PID " << matches[0] << endl;
     }
   }
 

--- a/tests/functional-test-microceph.sh
+++ b/tests/functional-test-microceph.sh
@@ -26,7 +26,7 @@ OSDTRACE_LOG="/tmp/osdtrace.log"
 OSDTRACE_ID_LOG="/tmp/osdtrace-id.log"
 RADOSTRACE_LOG="/tmp/radostrace.log"
 
-# OSD id targeted by the --id-based osdtrace run.  Must differ from the OSD
+# OSD id targeted by the -n-based osdtrace run.  Must differ from the OSD
 # the -p-based run attaches to (osd.1) so the two runs exercise distinct
 # ceph-osd PIDs; microceph creates osd.0/osd.1/osd.2 in this test's setup.
 TARGET_OSD_ID=2
@@ -46,9 +46,9 @@ cleanup() {
     fi
 
     if [[ -e $OSDTRACE_ID_LOG ]]; then
-        info "OSD trace (--id $TARGET_OSD_ID) output:"
+        info "OSD trace (-n $TARGET_OSD_ID) output:"
         cat $OSDTRACE_ID_LOG
-        info " === END of OSD trace (--id) === "
+        info " === END of OSD trace (-n) === "
     fi
 
     if [[ -e $RADOSTRACE_LOG ]]; then
@@ -177,14 +177,14 @@ OSDTRACE_PID=$(pidof osdtrace)
 info "Started osdtrace with PID $OSDTRACE_PID"
 sleep 3
 
-info "=== Step 6b: Start a second osdtrace targeting OSD $TARGET_OSD_ID via --id ==="
+info "=== Step 6b: Start a second osdtrace targeting OSD $TARGET_OSD_ID via -n ==="
 # Two osdtrace processes can attach uprobes to disjoint PIDs without
 # interference (each owns its own BPF maps/ringbuf).  This run validates
-# the --id resolver: it must enumerate ceph-osd processes, map OSD ID
+# the -n resolver: it must enumerate ceph-osd processes, map OSD ID
 # $TARGET_OSD_ID to its PID, and attach to *only* that PID — which the
 # verifier then proves by checking that every captured row carries
 # osd_id=$TARGET_OSD_ID (using verify_osdtrace_targets_only).
-timeout 30 $PROJECT_ROOT/osdtrace -i $OSD_DWARF --id $TARGET_OSD_ID --skip-version-check >$OSDTRACE_ID_LOG 2>&1 &
+timeout 30 $PROJECT_ROOT/osdtrace -i $OSD_DWARF -n $TARGET_OSD_ID --skip-version-check >$OSDTRACE_ID_LOG 2>&1 &
 OSDTRACE_ID_BG_PID=$!
 sleep 3
 
@@ -249,16 +249,16 @@ info "=== Step 11: Verify osdtrace output ==="
 # row total is several hundred.
 verify_osdtrace_output "$OSDTRACE_LOG" "$TEST_POOL_ID" "$MAX_OSD_ID" "$TOT_PG" 50
 
-info "=== Step 11b: Verify --id-based osdtrace output ==="
-# Anchor the resolver: stdout/stderr of the --id run must report the
+info "=== Step 11b: Verify -n-based osdtrace output ==="
+# Anchor the resolver: stdout/stderr of the -n run must report the
 # OSD id → PID mapping.  Then run the standard per-row invariant check
 # (lower min_rows: a single OSD sees a fraction of the bench traffic,
 # but still hundreds of subop_w + op_r rows over 20 s).  Finally pin
 # the targets-only invariant: every captured row's osd_id must equal
-# $TARGET_OSD_ID, which is the only thing that proves --id attached
+# $TARGET_OSD_ID, which is the only thing that proves -n attached
 # to *that* PID and no others.
-if ! grep -q "^--id $TARGET_OSD_ID resolved to PID " "$OSDTRACE_ID_LOG"; then
-    err "osdtrace --id $TARGET_OSD_ID log missing 'resolved to PID' line"
+if ! grep -q "^-n $TARGET_OSD_ID resolved to PID " "$OSDTRACE_ID_LOG"; then
+    err "osdtrace -n $TARGET_OSD_ID log missing 'resolved to PID' line"
     exit 1
 fi
 verify_osdtrace_output "$OSDTRACE_ID_LOG" "$TEST_POOL_ID" "$MAX_OSD_ID" "$TOT_PG" 10
@@ -269,7 +269,7 @@ verify_radostrace_output "$RADOSTRACE_LOG" "$TEST_POOL_ID" "$MAX_OSD_ID" 50
 
 info "=== Test Summary ==="
 info "✓ MicroCeph cluster deployed successfully"
-info "✓ osdtrace (-p and --id) and radostrace output validated"
+info "✓ osdtrace (-p and -n) and radostrace output validated"
 info "✓ All functional tests passed!"
 
 exit 0

--- a/tests/lib/verify-trace-output.sh
+++ b/tests/lib/verify-trace-output.sh
@@ -470,7 +470,7 @@ _verify_radostrace_output_impl() {
 
 # verify_osdtrace_targets_only <log> <target_osd_id> [target_osd_id ...]
 #
-# Anchors --id semantics: assert the set of distinct osd_id values appearing
+# Anchors -n semantics: assert the set of distinct osd_id values appearing
 # in <log>'s data rows is a subset of the given targets.  Reuses
 # _osdtrace_rows so it shares the same NF/landmark-based row parser as the
 # main verifier (truncated tail rows are filtered upstream).
@@ -478,7 +478,7 @@ _verify_radostrace_output_impl() {
 # Fails if:
 #   - any data row carries an osd_id outside the target set (proves uprobes
 #     attached to a process the user didn't ask for), or
-#   - no data rows were captured at all (proves the --id resolution → attach
+#   - no data rows were captured at all (proves the -n resolution → attach
 #     path produced *something*; the looser min_rows check is left to
 #     verify_osdtrace_output).
 verify_osdtrace_targets_only() {
@@ -502,7 +502,7 @@ verify_osdtrace_targets_only() {
     done < <(_osdtrace_rows "$log")
 
     if (( total == 0 )); then
-        err "osdtrace log $log has zero data rows; --id resolution may have failed silently"
+        err "osdtrace log $log has zero data rows; -n resolution may have failed silently"
         return 1
     fi
 

--- a/tests/test-id-option.sh
+++ b/tests/test-id-option.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 #
-# Negative-path / argument-parsing test for osdtrace's --id option.
+# Negative-path / argument-parsing test for osdtrace's -n option.
 # Validates the error branches that don't require a running ceph cluster:
 #
-#   - --id with a non-existent OSD ID fails with "no running ceph-osd
+#   - -n with a non-existent OSD ID fails with "no running ceph-osd
 #     process found"
-#   - --id combined with -p fails with "mutually exclusive"
-#   - --id with a non-numeric value fails with "Invalid --id value"
-#   - --id with a negative value fails with "must be non-negative"
+#   - -n combined with -p fails with "mutually exclusive"
+#   - -n with a non-numeric value fails with "Invalid -n value"
+#   - -n with a negative value fails with "must be non-negative"
 #   - the removed -o option is rejected by getopt
 #
 # Exit codes from `parse_args() < 0` get converted to `return 0` inside
 # osdtrace's `main()`, so we anchor on stderr substrings rather than the
-# numeric exit code for parse-time errors.  For main()-time errors (--id
-# resolution, --id/-p conflict) the binary exits 1 — those we check both.
+# numeric exit code for parse-time errors.  For main()-time errors (-n
+# resolution, -n/-p conflict) the binary exits 1 — those we check both.
 
 set -u
 
@@ -68,25 +68,25 @@ expect_stderr() {
 # the test host happens to have a Ceph OSD running.
 NONEXISTENT_OSD_ID=2147483600
 
-info "=== osdtrace --id option negative-path tests ==="
+info "=== osdtrace -n option negative-path tests ==="
 
 expect_stderr "not_found" \
     "no running ceph-osd process found with OSD ID $NONEXISTENT_OSD_ID" \
-    1 -- --id "$NONEXISTENT_OSD_ID"
+    1 -- -n "$NONEXISTENT_OSD_ID"
 
 expect_stderr "conflict_with_-p" \
-    "--id and -p are mutually exclusive" \
-    1 -- --id "$NONEXISTENT_OSD_ID" -p 1
+    "-n and -p are mutually exclusive" \
+    1 -- -n "$NONEXISTENT_OSD_ID" -p 1
 
 expect_stderr "non_numeric" \
-    "Invalid --id value: abc" \
-    -1 -- --id abc
+    "Invalid -n value: abc" \
+    -1 -- -n abc
 
 expect_stderr "negative" \
-    "Invalid --id value (must be non-negative): -1" \
-    -1 -- --id -1
+    "Invalid -n value (must be non-negative): -1" \
+    -1 -- -n -1
 
-# -o was removed when --id replaced it; getopt should print the standard
+# -o was removed when -n replaced it; getopt should print the standard
 # `invalid option` diagnostic.  Anchor on `?` being treated as the help
 # fall-through (which prints the usage banner that starts with "Usage:").
 expect_stderr "o_option_removed" \


### PR DESCRIPTION
## Summary

Renames the OSD-ID selection option in `osdtrace` from the long-only `--id` to the short `-n` flag.

## Changes
- `src/osdtrace.cc`: drop `--id` from the `long_options` table, add `n:` to the getopt string, and move the OSD-ID parsing into a `case 'n':`. Help banner, the `-n`/`-p` mutual-exclusivity error, the "resolved to PID" log line, and inline comments updated to `-n`.
- Tests updated to use `-n`: `tests/test-id-option.sh`, `tests/functional-test-microceph.sh`, `tests/lib/verify-trace-output.sh`.

## Not changed
References to the `ceph-osd --id N` daemon command-line flag (the process being traced) are intentionally left as-is — these are unrelated to the osdtrace option.

## Verification
- `make osdtrace` builds cleanly.
- `./osdtrace -h` shows `-n`; `--id` now falls through to the usage banner (fully removed).
- `tests/test-id-option.sh`: 5 passed, 0 failed.