### PR TITLE
Add --list-embedded to osdtrace and radostrace

### DIFF
--- a/src/dwarf_parser.cc
+++ b/src/dwarf_parser.cc
@@ -1144,8 +1144,8 @@ void DwarfParser::list_embedded_versions(const std::string& trace_type) {
 
     std::cout << count << " Ceph version(s) with embedded " << trace_type
               << " DWARF data:" << std::endl;
-    std::printf("  %-32s %-8s %-22s %s\n", "VERSION", "ARCH", "MODULE", "BUILD ID");
-    std::printf("  %-32s %-8s %-22s %s\n",
+    printf("  %-32s %-8s %-22s %s\n", "VERSION", "ARCH", "MODULE", "BUILD ID");
+    printf("  %-32s %-8s %-22s %s\n",
                 "--------------------------------", "--------",
                 "----------------------", "----------------------------------------");
     for (int i = 0; i < count; ++i) {
@@ -1153,7 +1153,7 @@ void DwarfParser::list_embedded_versions(const std::string& trace_type) {
         const char* ver = (v.version && *v.version) ? v.version : "(unknown)";
         const char* arch = (v.arch && *v.arch) ? v.arch : "-";
         if (v.num_modules == 0) {
-            std::printf("  %-32s %-8s %-22s %s\n", ver, arch, "-", "-");
+            printf("  %-32s %-8s %-22s %s\n", ver, arch, "-", "-");
             continue;
         }
         // One row per module; repeat version/arch only on the first row so a
@@ -1162,7 +1162,7 @@ void DwarfParser::list_embedded_versions(const std::string& trace_type) {
             const char* mod = v.modules[m].module_name ? v.modules[m].module_name : "-";
             const char* bid = (v.modules[m].build_id && *v.modules[m].build_id)
                                   ? v.modules[m].build_id : "(none)";
-            std::printf("  %-32s %-8s %-22s %s\n",
+            printf("  %-32s %-8s %-22s %s\n",
                         m == 0 ? ver : "", m == 0 ? arch : "", mod, bid);
         }
     }

--- a/src/dwarf_parser.cc
+++ b/src/dwarf_parser.cc
@@ -1127,6 +1127,47 @@ bool DwarfParser::import_from_embedded(
     return true;
 }
 
+void DwarfParser::list_embedded_versions(const std::string& trace_type) {
+    const EmbeddedVersion* versions = nullptr;
+    int count = 0;
+
+    if (trace_type == "osdtrace") {
+        versions = EMBEDDED_OSDTRACE_VERSIONS;
+        count = EMBEDDED_OSDTRACE_COUNT;
+    } else if (trace_type == "radostrace") {
+        versions = EMBEDDED_RADOSTRACE_VERSIONS;
+        count = EMBEDDED_RADOSTRACE_COUNT;
+    } else {
+        std::cerr << "Unknown trace type: " << trace_type << std::endl;
+        return;
+    }
+
+    std::cout << count << " Ceph version(s) with embedded " << trace_type
+              << " DWARF data:" << std::endl;
+    std::printf("  %-32s %-8s %-22s %s\n", "VERSION", "ARCH", "MODULE", "BUILD ID");
+    std::printf("  %-32s %-8s %-22s %s\n",
+                "--------------------------------", "--------",
+                "----------------------", "----------------------------------------");
+    for (int i = 0; i < count; ++i) {
+        const EmbeddedVersion& v = versions[i];
+        const char* ver = (v.version && *v.version) ? v.version : "(unknown)";
+        const char* arch = (v.arch && *v.arch) ? v.arch : "-";
+        if (v.num_modules == 0) {
+            std::printf("  %-32s %-8s %-22s %s\n", ver, arch, "-", "-");
+            continue;
+        }
+        // One row per module; repeat version/arch only on the first row so a
+        // multi-module entry (radostrace) reads as a single grouped record.
+        for (int m = 0; m < v.num_modules; ++m) {
+            const char* mod = v.modules[m].module_name ? v.modules[m].module_name : "-";
+            const char* bid = (v.modules[m].build_id && *v.modules[m].build_id)
+                                  ? v.modules[m].build_id : "(none)";
+            std::printf("  %-32s %-8s %-22s %s\n",
+                        m == 0 ? ver : "", m == 0 ? arch : "", mod, bid);
+        }
+    }
+}
+
 const char* DwarfParser::dwarf_attr_string(unsigned int attrnum) {
   switch (attrnum) {
     #define DWARF_ONE_KNOWN_DW_AT(NAME, CODE) case CODE: return  "DW_AT_"#NAME;

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -127,6 +127,15 @@ class DwarfParser {
       const std::string& trace_type,
       std::string* matched_version_out = nullptr);
 
+  /**
+   * Print the Ceph versions for which DWARF data is compiled into this
+   * binary (one row per embedded module, with its build-id), to stdout.
+   *
+   * @param trace_type "osdtrace" or "radostrace" — selects which embedded
+   *                   table to enumerate.
+   */
+  static void list_embedded_versions(const std::string& trace_type);
+
   static const char* dwarf_attr_string(unsigned int attrnum);
   static const char* dwarf_form_string(unsigned int form);
 };

--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -871,6 +871,7 @@ bool import_json = false;
 bool export_json = false;
 bool skip_version_check = false;
 bool list_only = false;
+bool list_embedded = false;
 
 struct OsdProcessInfo {
   int pid;
@@ -966,6 +967,7 @@ int parse_args(int argc, char **argv) {
     {"skip-version-check", no_argument, 0, 0},
     {"version", no_argument, 0, 'V'},
     {"list", no_argument, 0, 0},
+    {"list-embedded", no_argument, 0, 0},
     {"id", required_argument, 0, 0},
     {0, 0, 0, 0}
   };
@@ -983,6 +985,8 @@ int parse_args(int argc, char **argv) {
           skip_version_check = true;
         } else if (strcmp(long_options[option_index].name, "list") == 0) {
           list_only = true;
+        } else if (strcmp(long_options[option_index].name, "list-embedded") == 0) {
+          list_embedded = true;
         } else if (strcmp(long_options[option_index].name, "id") == 0) {
           std::stringstream ss(optarg);
           std::string token;
@@ -1050,7 +1054,7 @@ int parse_args(int argc, char **argv) {
         break;
       case '?':
       case 'h':
-        std::cout << "Usage: " << argv[0] << " [-s] [-l <milliseconds>] [-b] [-j] [-i <filename>] [-t <seconds>] [-p <pid1,pid2,...>] [--id <osd-id1,osd-id2,...>] [--skip-version-check] [--list]\n";
+        std::cout << "Usage: " << argv[0] << " [-s] [-l <milliseconds>] [-b] [-j] [-i <filename>] [-t <seconds>] [-p <pid1,pid2,...>] [--id <osd-id1,osd-id2,...>] [--skip-version-check] [--list] [--list-embedded]\n";
         std::cout << "  -s                        Set probe mode to Single OP (logs PrimaryLogPG::log_op_stats only)\n";
         std::cout << "  -l <milliseconds>         Set operation latency threshold to capture\n";
         std::cout << "  -b                        Set probe mode to Bluestore\n";
@@ -1061,6 +1065,7 @@ int parse_args(int argc, char **argv) {
         std::cout << "  --id <osd-id1,osd-id2,...> Probe by OSD ID (comma-separated; resolves to PIDs via discovery)\n";
         std::cout << "  --skip-version-check      Skip version check when importing DWARF JSON (currently needed for containers)\n";
         std::cout << "  --list                    List active ceph-osd processes on the host, their PIDs and OSD IDs, and exit\n";
+        std::cout << "  --list-embedded           List the Ceph versions with DWARF data compiled into this binary, and exit\n";
         std::cout << "  -V, --version             Print version information and exit\n";
         std::cout << "  -h                        Show this help message\n";
         exit(0);
@@ -1205,6 +1210,11 @@ int main(int argc, char **argv) {
   signal(SIGINT, signal_handler);
 
   if (parse_args(argc, argv) < 0) return 0;
+
+  if (list_embedded) {
+    DwarfParser::list_embedded_versions("osdtrace");
+    return 0;
+  }
 
   if (list_only) {
     if (geteuid() != 0) {

--- a/src/radostrace.cc
+++ b/src/radostrace.cc
@@ -472,17 +472,21 @@ int main(int argc, char **argv) {
           }
       } else if (arg == "--skip-version-check") {
           skip_version_check = true;
+      } else if (arg == "--list-embedded") {
+          DwarfParser::list_embedded_versions("radostrace");
+          return 0;
       } else if (arg == "-V" || arg == "--version") {
           print_tool_version("radostrace");
           return 0;
       } else if (arg == "-h" || arg == "--help") {
-          std::cout << "Usage: " << argv[0] << " [-t <timeout seconds>] [-j [filename]] [-i <filename>] [-o [filename]] [-p <pid>] [--skip-version-check]\n";
+          std::cout << "Usage: " << argv[0] << " [-t <timeout seconds>] [-j [filename]] [-i <filename>] [-o [filename]] [-p <pid>] [--skip-version-check] [--list-embedded]\n";
           std::cout << "  -t, --timeout <seconds>    Set execution timeout in seconds\n";
           std::cout << "  -j, --export-json <file>   Export DWARF info to JSON (default: radostrace_dwarf.json)\n";
           std::cout << "  -i, --import-json <file>   Import DWARF info from JSON file\n";
           std::cout << "  -o, --output <file>        Export events data info to CSV (default: radostrace_events.csv)\n";
           std::cout << "  -p, --pid <pid>            Attach uprobes only to the specified process ID (Mandatory for container based process tracing)\n";
           std::cout << "  --skip-version-check       Skip version check when importing DWARF JSON (currently needed for containers)\n";
+          std::cout << "  --list-embedded            List the Ceph versions with DWARF data compiled into this binary, and exit\n";
           std::cout << "  -V, --version              Print version information and exit\n";
           std::cout << "  -h, --help                 Show this help message\n";
           return 0;

--- a/tests/functional-test-embedded-dwarf.sh
+++ b/tests/functional-test-embedded-dwarf.sh
@@ -68,6 +68,30 @@ if [ ! -f "$PROJECT_ROOT/radostrace" ]; then
     exit 1
 fi
 
+info "=== Step 0: Verify --list-embedded lists compiled-in DWARF versions ==="
+# No cluster needed: --list-embedded just prints the DWARF versions baked into
+# the binary and exits 0.  Assert both tools succeed, print the table header,
+# and report at least one embedded version.
+for tool in osdtrace radostrace; do
+    if ! list_out=$("$PROJECT_ROOT/$tool" --list-embedded 2>&1); then
+        err "$tool --list-embedded exited non-zero"
+        echo "$list_out" >&2
+        exit 1
+    fi
+    if ! grep -q "VERSION" <<<"$list_out" || ! grep -q "BUILD ID" <<<"$list_out"; then
+        err "$tool --list-embedded missing expected table header"
+        echo "$list_out" >&2
+        exit 1
+    fi
+    count=$(sed -n 's/^\([0-9][0-9]*\) Ceph version.*/\1/p' <<<"$list_out")
+    if [ -z "$count" ] || [ "$count" -lt 1 ]; then
+        err "$tool --list-embedded reported no embedded versions"
+        echo "$list_out" >&2
+        exit 1
+    fi
+    info "✓ $tool --list-embedded: $count embedded version(s)"
+done
+
 info "=== Step 1: Setup MicroCeph (install + bootstrap + OSDs + wait healthy) ==="
 if ! microceph_setup_single_node 3 3G 120; then
     err "MicroCeph cluster did not become healthy within timeout"


### PR DESCRIPTION
## Summary

Adds a `--list-embedded` option to both `osdtrace` and `radostrace` that prints the Ceph versions whose DWARF data is **compiled into the binary**, then exits. This lets users see which versions are traceable out of the box (without supplying `-i <dwarf.json>`).

## Changes
- **`DwarfParser::list_embedded_versions(trace_type)`** (`dwarf_parser.{h,cc}`): enumerates the compiled-in `EMBEDDED_*_VERSIONS` table and prints each Ceph version with its arch, module(s), and build-id. One row per module, so multi-module entries (radostrace) read as a grouped record.
- **osdtrace**: `--list-embedded` long option (commit 1).
- **radostrace**: `--list-embedded` option (commit 2).

## Example
```
$ osdtrace --list-embedded
25 Ceph version(s) with embedded osdtrace DWARF data:
  VERSION                          ARCH     MODULE                 BUILD ID
  -------------------------------- -------- ---------------------- ----------...
  17.2.6-0ubuntu0.22.04.3          amd64    ceph-osd               82b1bd65d889f7b6eb4223a95d81da84b1d2855a
  ...

$ radostrace --list-embedded
31 Ceph version(s) with embedded radostrace DWARF data:
  VERSION                          ARCH     MODULE                 BUILD ID
  2:17.2.8-0.el9                   amd64    libceph-common.so.2    3417a3e8c2c6002da3f4516649bbd98ad641d973
                                            librados.so.2          21fa65fbb3c53fde371a55e325c31c875d5d52e2
                                            librbd.so.1            da888b6a34bdac9c35bb5c364cef562057f0a5fe
  ...
```

## Notes
- The build-id column is included since it's the identity used for embedded matching — useful groundwork for a follow-up that reports whether a specific running OSD is traceable with embedded data.
- Builds cleanly; the embedded table is generated at build time, so the listing always reflects what's actually compiled in.