### PR TITLE
osdtrace: add Traceable column to --list output

### DIFF
--- a/src/dwarf_parser.cc
+++ b/src/dwarf_parser.cc
@@ -1000,10 +1000,12 @@ bool DwarfParser::import_from_json(const std::string& filename, const std::strin
     }
 }
 
-bool DwarfParser::import_from_embedded(
+// Find the embedded entry whose per-module build-ids match the caller's set,
+// or nullptr if none.  Shared by import_from_embedded() (which then loads the
+// data) and is_embedded_traceable() (which only reports the verdict).
+static const EmbeddedVersion* find_embedded_match(
     const std::vector<std::pair<std::string, std::string>>& modules,
-    const std::string& trace_type,
-    std::string* matched_version_out) {
+    const std::string& trace_type) {
     const EmbeddedVersion* versions = nullptr;
     int count = 0;
 
@@ -1014,8 +1016,7 @@ bool DwarfParser::import_from_embedded(
         versions = EMBEDDED_RADOSTRACE_VERSIONS;
         count = EMBEDDED_RADOSTRACE_COUNT;
     } else {
-        std::cerr << "Unknown trace type: " << trace_type << std::endl;
-        return false;
+        return nullptr;
     }
 
     // Build the caller's (basename, build-id) set.  An empty build-id on
@@ -1027,12 +1028,12 @@ bool DwarfParser::import_from_embedded(
     std::set<std::pair<std::string, std::string>> want;
     for (const auto& m : modules) {
         if (m.second.empty()) {
-            return false;
+            return nullptr;
         }
         want.emplace(m.first, m.second);
     }
     if (want.empty()) {
-        return false;
+        return nullptr;
     }
 
     // Linear scan: an entry matches iff every module it lists is present in
@@ -1046,7 +1047,6 @@ bool DwarfParser::import_from_embedded(
     // confuse two different package versions.  Any empty build-id in the
     // embedded data disqualifies that entry (legacy JSONs predating the
     // build-id scheme).
-    const EmbeddedVersion* match = nullptr;
     for (int i = 0; i < count; ++i) {
         const EmbeddedVersion& v = versions[i];
         if (v.num_modules == 0) continue;
@@ -1059,11 +1059,18 @@ bool DwarfParser::import_from_embedded(
             if (it == want.end()) { all_match = false; break; }
         }
         if (all_match) {
-            match = &v;
-            break;
+            return &v;
         }
     }
 
+    return nullptr;
+}
+
+bool DwarfParser::import_from_embedded(
+    const std::vector<std::pair<std::string, std::string>>& modules,
+    const std::string& trace_type,
+    std::string* matched_version_out) {
+    const EmbeddedVersion* match = find_embedded_match(modules, trace_type);
     if (!match) {
         return false;
     }
@@ -1166,6 +1173,20 @@ void DwarfParser::list_embedded_versions(const std::string& trace_type) {
                         m == 0 ? ver : "", m == 0 ? arch : "", mod, bid);
         }
     }
+}
+
+bool DwarfParser::is_embedded_traceable(
+    const std::vector<std::pair<std::string, std::string>>& modules,
+    const std::string& trace_type,
+    std::string* matched_version_out) {
+    const EmbeddedVersion* match = find_embedded_match(modules, trace_type);
+    if (!match) {
+        return false;
+    }
+    if (matched_version_out && match->version) {
+        *matched_version_out = match->version;
+    }
+    return true;
 }
 
 const char* DwarfParser::dwarf_attr_string(unsigned int attrnum) {

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -136,6 +136,24 @@ class DwarfParser {
    */
   static void list_embedded_versions(const std::string& trace_type);
 
+  /**
+   * Report whether the compiled-in embedded DWARF data covers the given
+   * modules, without loading anything (unlike import_from_embedded, this is
+   * side-effect free and emits no log output).  Matching is by build-id with
+   * the same semantics as import_from_embedded.
+   *
+   * @param modules            (basename, hex build-id) pairs, as for
+   *                           import_from_embedded.
+   * @param trace_type         "osdtrace" or "radostrace".
+   * @param matched_version_out If non-null, set to the matched version on a
+   *                           positive verdict.
+   * @return true if the target is traceable with embedded data alone.
+   */
+  static bool is_embedded_traceable(
+      const std::vector<std::pair<std::string, std::string>>& modules,
+      const std::string& trace_type,
+      std::string* matched_version_out = nullptr);
+
   static const char* dwarf_attr_string(unsigned int attrnum);
   static const char* dwarf_form_string(unsigned int form);
 };

--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -878,6 +878,10 @@ struct OsdProcessInfo {
   int osd_id;
   std::string exe_path;
   bool is_container;
+  // Embedded-DWARF traceability verdict, populated lazily by
+  // annotate_traceability() for the --list path only: "yes", "no", "unknown"
+  // (empty until computed).
+  std::string traceable;
 };
 
 std::string get_mnt_ns(int pid) {
@@ -932,7 +936,7 @@ std::vector<OsdProcessInfo> discover_ceph_osd_processes() {
             is_container = true;
           }
           
-          results.push_back({pid, osd_id, exe_path, is_container});
+          results.push_back({pid, osd_id, exe_path, is_container, ""});
         }
       }
     }
@@ -950,13 +954,43 @@ std::vector<OsdProcessInfo> discover_ceph_osd_processes() {
   return results;
 }
 
-void print_discovered_osds(const std::vector<OsdProcessInfo>& processes) {
-  printf("  %-10s %-10s %-12s %-50s\n", "PID", "OSD ID", "Container", "Executable Path");
-  printf("  --------------------------------------------------------------------------------\n");
+void print_discovered_osds(const std::vector<OsdProcessInfo>& processes,
+                           bool show_traceable = false) {
+  if (show_traceable) {
+    printf("  %-10s %-10s %-12s %-11s %-50s\n", "PID", "OSD ID", "Container", "Traceable", "Executable Path");
+    printf("  --------------------------------------------------------------------------------------------\n");
+  } else {
+    printf("  %-10s %-10s %-12s %-50s\n", "PID", "OSD ID", "Container", "Executable Path");
+    printf("  --------------------------------------------------------------------------------\n");
+  }
   for (const auto& proc : processes) {
     std::string osd_id_str = (proc.osd_id == -1) ? "unknown" : std::to_string(proc.osd_id);
     std::string container_str = proc.is_container ? "yes" : "no";
-    printf("  %-10d %-10s %-12s %-50s\n", proc.pid, osd_id_str.c_str(), container_str.c_str(), proc.exe_path.c_str());
+    if (show_traceable) {
+      std::string traceable_str = proc.traceable.empty() ? "unknown" : proc.traceable;
+      printf("  %-10d %-10s %-12s %-11s %-50s\n", proc.pid, osd_id_str.c_str(),
+             container_str.c_str(), traceable_str.c_str(), proc.exe_path.c_str());
+    } else {
+      printf("  %-10d %-10s %-12s %-50s\n", proc.pid, osd_id_str.c_str(), container_str.c_str(), proc.exe_path.c_str());
+    }
+  }
+}
+
+// Fill in each process's `traceable` verdict by reading the build-id of the
+// binary the uprobes would attach to (bridged through /proc/<pid>/root so
+// containerized OSDs resolve to the in-container binary) and checking it
+// against the compiled-in embedded DWARF table.  Reading another process's
+// (or a container's) binary requires root; otherwise the verdict is "unknown".
+void annotate_traceability(std::vector<OsdProcessInfo>& processes) {
+  for (auto& proc : processes) {
+    std::string bridged_path = "/proc/" + std::to_string(proc.pid) + "/root" + proc.exe_path;
+    std::string build_id = get_elf_build_id(bridged_path);
+    if (build_id.empty()) {
+      proc.traceable = "unknown";
+      continue;
+    }
+    proc.traceable = DwarfParser::is_embedded_traceable(
+        {{get_basename(proc.exe_path), build_id}}, "osdtrace") ? "yes" : "no";
   }
 }
 
@@ -1224,8 +1258,29 @@ int main(int argc, char **argv) {
     if (processes.empty()) {
       std::cout << "No active ceph-osd processes detected on the host." << std::endl;
     } else {
+      annotate_traceability(processes);
       std::cout << "Detected " << processes.size() << " active ceph-osd process(es) on the host:" << std::endl;
-      print_discovered_osds(processes);
+      print_discovered_osds(processes, /*show_traceable=*/true);
+
+      // If any OSD isn't directly traceable, tell the user how to proceed.
+      bool any_no = false, any_unknown = false;
+      for (const auto& proc : processes) {
+        if (proc.traceable == "no") any_no = true;
+        else if (proc.traceable == "unknown") any_unknown = true;
+      }
+      if (any_no || any_unknown) {
+        std::cout << std::endl
+                  << "Traceable: 'yes' means this osdtrace already has matching DWARF data built in." << std::endl;
+        if (any_no) {
+          std::cout << "  'no':      no embedded DWARF matches this binary's build-id. Export a DWARF JSON" << std::endl;
+          std::cout << "             on a host that has the matching ceph-osd (osdtrace -j <file>), then trace" << std::endl;
+          std::cout << "             with: osdtrace -p <pid> -i <file> --skip-version-check" << std::endl;
+        }
+        if (any_unknown) {
+          std::cout << "  'unknown': could not read the OSD binary's build-id; re-run as root" << std::endl;
+          std::cout << "             (required for containerized OSDs)." << std::endl;
+        }
+      }
     }
     return 0;
   }


### PR DESCRIPTION
## Summary

Adds a **Traceable** column to `osdtrace --list` so users can see, per OSD, whether it can be traced with the DWARF data built into this `osdtrace` binary — and, when it can't, what to do about it.

## Behavior

```
$ sudo osdtrace --list
Detected 3 active ceph-osd process(es) on the host:
  PID        OSD ID     Container    Traceable   Executable Path
  --------------------------------------------------------------------------------------------
  272854     0          yes          yes         /usr/bin/ceph-osd
  ...
```

Verdict values:
- **yes** — the OSD binary's build-id matches an embedded DWARF entry (traceable out of the box).
- **no** — no embedded match; needs a DWARF JSON supplied via `-i`.
- **unknown** — the binary's build-id couldn't be read (re-run as root; required for containerized OSDs).

When any OSD is `no`/`unknown`, a short guidance block is printed below the table explaining how to proceed (export a JSON with `-j` on a matching host then trace with `-i ... --skip-version-check`, or re-run as root for `unknown`).

## Implementation
- New side-effect-free `DwarfParser::is_embedded_traceable()` reports the embedded-match verdict without loading data or logging. The build-id matching loop is extracted into a shared `find_embedded_match()` used by both `is_embedded_traceable()` and `import_from_embedded()` (no duplicated logic, no behavior change to the import path).
- `osdtrace.cc`: `OsdProcessInfo` gains a lazily-populated `traceable` field; `annotate_traceability()` reads each OSD binary's build-id via `/proc/<pid>/root` (so containerized OSDs resolve) and sets the verdict; `print_discovered_osds()` gains an opt-in `show_traceable` column used only by `--list`.

## Notes
- The extra column is shown only for `--list`; other callers of `print_discovered_osds()` are unaffected.
- Reading the build-id of containerized/other-user OSDs requires root; without it the verdict is honestly reported as `unknown` rather than guessed.
- Builds cleanly (no warnings).