### PR TITLE
osdtrace: add Ceph Version column to --list output

### DIFF
--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -882,6 +882,11 @@ struct OsdProcessInfo {
   // annotate_traceability() for the --list path only: "yes", "no", "unknown"
   // (empty until computed).
   std::string traceable;
+  // Ceph package version, populated alongside `traceable` by
+  // annotate_traceability() for the --list path only.  Authoritative when
+  // traceable=="yes" (taken from the matched embedded entry); best-effort host
+  // package query for a non-container, non-traceable OSD; "unknown" otherwise.
+  std::string version;
 };
 
 std::string get_mnt_ns(int pid) {
@@ -936,7 +941,7 @@ std::vector<OsdProcessInfo> discover_ceph_osd_processes() {
             is_container = true;
           }
           
-          results.push_back({pid, osd_id, exe_path, is_container, ""});
+          results.push_back({pid, osd_id, exe_path, is_container, "", ""});
         }
       }
     }
@@ -957,8 +962,8 @@ std::vector<OsdProcessInfo> discover_ceph_osd_processes() {
 void print_discovered_osds(const std::vector<OsdProcessInfo>& processes,
                            bool show_traceable = false) {
   if (show_traceable) {
-    printf("  %-10s %-10s %-12s %-11s %-50s\n", "PID", "OSD ID", "Container", "Traceable", "Executable Path");
-    printf("  --------------------------------------------------------------------------------------------\n");
+    printf("  %-10s %-10s %-12s %-11s %-24s\n", "PID", "OSD ID", "Container", "Traceable", "Ceph Version");
+    printf("  -----------------------------------------------------------------------\n");
   } else {
     printf("  %-10s %-10s %-12s %-50s\n", "PID", "OSD ID", "Container", "Executable Path");
     printf("  --------------------------------------------------------------------------------\n");
@@ -968,8 +973,9 @@ void print_discovered_osds(const std::vector<OsdProcessInfo>& processes,
     std::string container_str = proc.is_container ? "yes" : "no";
     if (show_traceable) {
       std::string traceable_str = proc.traceable.empty() ? "unknown" : proc.traceable;
-      printf("  %-10d %-10s %-12s %-11s %-50s\n", proc.pid, osd_id_str.c_str(),
-             container_str.c_str(), traceable_str.c_str(), proc.exe_path.c_str());
+      std::string version_str = proc.version.empty() ? "unknown" : proc.version;
+      printf("  %-10d %-10s %-12s %-11s %-24s\n", proc.pid, osd_id_str.c_str(),
+             container_str.c_str(), traceable_str.c_str(), version_str.c_str());
     } else {
       printf("  %-10d %-10s %-12s %-50s\n", proc.pid, osd_id_str.c_str(), container_str.c_str(), proc.exe_path.c_str());
     }
@@ -983,14 +989,31 @@ void print_discovered_osds(const std::vector<OsdProcessInfo>& processes,
 // (or a container's) binary requires root; otherwise the verdict is "unknown".
 void annotate_traceability(std::vector<OsdProcessInfo>& processes) {
   for (auto& proc : processes) {
+    proc.version = "unknown";
     std::string bridged_path = "/proc/" + std::to_string(proc.pid) + "/root" + proc.exe_path;
     std::string build_id = get_elf_build_id(bridged_path);
     if (build_id.empty()) {
       proc.traceable = "unknown";
       continue;
     }
-    proc.traceable = DwarfParser::is_embedded_traceable(
-        {{get_basename(proc.exe_path), build_id}}, "osdtrace") ? "yes" : "no";
+    std::string matched;
+    bool ok = DwarfParser::is_embedded_traceable(
+        {{get_basename(proc.exe_path), build_id}}, "osdtrace", &matched);
+    proc.traceable = ok ? "yes" : "no";
+    if (ok) {
+      // Authoritative: the matched embedded entry's version is exactly the
+      // package this binary was built from.
+      if (!matched.empty()) proc.version = matched;
+    } else if (!proc.is_container &&
+               !check_executable_deleted(proc.pid, "ceph-osd")) {
+      // Best-effort for a native (non-container) OSD whose running binary still
+      // matches what's on disk: query the host package DB.  We skip containers
+      // (host DB describes the host, not the container) and skip processes
+      // whose on-disk binary was replaced after launch (the deleted-exe check),
+      // since the package DB would then report a version we aren't running.
+      std::string pkg = get_package_version(proc.exe_path);
+      if (!pkg.empty() && pkg != "unknown") proc.version = pkg;
+    }
   }
 }
 
@@ -1280,6 +1303,11 @@ int main(int argc, char **argv) {
           std::cout << "  'unknown': could not read the OSD binary's build-id; re-run as root" << std::endl;
           std::cout << "             (required for containerized OSDs)." << std::endl;
         }
+        std::cout << std::endl
+                  << "Ceph Version: authoritative when Traceable='yes' (the matched embedded entry)." << std::endl;
+        std::cout << "             For Traceable='no' it is a best-effort host package lookup, shown only" << std::endl;
+        std::cout << "             for native OSDs whose on-disk binary still matches the running process;" << std::endl;
+        std::cout << "             'unknown' for containerized OSDs or binaries upgraded since launch." << std::endl;
       }
     }
     return 0;


### PR DESCRIPTION
## Summary

Adds a **Ceph Version** column to `osdtrace --list` so each discovered `ceph-osd` shows its package version, and removes the now-redundant **Executable Path** column from that view.

### How the version is resolved (per OSD)

| Traceability | Container? | Exe upgraded on disk? | Version shown | Source |
|---|---|---|---|---|
| `yes` | either | — | exact version | matched embedded DWARF entry (`is_embedded_traceable` → `matched_version_out`) — authoritative, container-safe |
| `no` | no | no | best-effort | host `get_package_version()` |
| `no` | no | yes | `unknown` | `check_executable_deleted()` catches the on-disk≠running case |
| `no` | yes | — | `unknown` | host package DB describes the host, not the container |
| `unknown` | — | — | `unknown` | build-id unreadable (non-root) |

The version is **authoritative and free** for traceable OSDs (including containerized ones, since the build-id is read through `/proc/<pid>/root`). For non-traceable OSDs it falls back to a host package query, but only when it can be trusted — native binary, not replaced on disk since launch.

The **Executable Path** column is dropped from `--list` (it is always `/usr/bin/ceph-osd` and carries no signal). The separate tracing-flow listing (`print_discovered_osds` without traceability) keeps it.

A footnote under the table documents these semantics.

### Example

```
Detected 11 active ceph-osd process(es) on the host:
  PID        OSD ID     Container    Traceable   Ceph Version
  -----------------------------------------------------------------------
  117249     0          yes          yes         2:17.2.6-0.el8
  124194     0          yes          yes         2:19.2.3-0.el9
  321437     3          yes          yes         19.2.3-0ubuntu0.24.04.3
```

## Scope

- One file: `src/osdtrace.cc`. Reuses existing helpers (`is_embedded_traceable`, `get_package_version`, `check_executable_deleted`) — no new dependencies, no change to the tracing path or `radostrace`.

## Testing

- `make osdtrace` — clean build; `make clang-tidy` — clean on `osdtrace.cc`.
- `sudo ./osdtrace --list` on a host with 11 containerized OSDs across multiple Ceph releases — versions resolved correctly and columns align.
- Functional test (`functional-test-embedded-dwarf.sh`) only asserts on `--list-embedded`, which is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)