### PR TITLE
radostrace: add --list, fix embedded matching, add 17.2.6-el8 DWARF

### DIFF
--- a/files/centos-stream/radostrace/rados-2:17.2.6-0.el8_dwarf.json
+++ b/files/centos-stream/radostrace/rados-2:17.2.6-0.el8_dwarf.json
@@ -1,0 +1,1156 @@
+{
+  "version": "2:17.2.6-0.el8",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "27a00ce10306ee4ce2d5f46da25c47e541a5a0dc",
+    "func2pc": {
+      "Objecter::_finish_op": 8392176,
+      "Objecter::_send_op": 8330112
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librados.so.2": {
+    "build_id": "34c9b9d2279f609952a9c1645aff0d503af6067d",
+    "func2pc": {
+      "Objecter::_finish_op": 1096128,
+      "Objecter::_send_op": 1034064
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "ccc3769725d545ea529ce9f1bd4a1ad37e2edc7e",
+    "func2pc": {
+      "Objecter::_finish_op": 7338576,
+      "Objecter::_send_op": 7276512
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/dwarf_parser.cc
+++ b/src/dwarf_parser.cc
@@ -1036,27 +1036,29 @@ static const EmbeddedVersion* find_embedded_match(
         return nullptr;
     }
 
-    // Linear scan: an entry matches iff every module it lists is present in
-    // `want` (subset semantics).  The caller always supplies one tuple per
-    // library it intends to probe; the embedded entry may legitimately
-    // cover only a strict subset of those — e.g. Ceph 20.2 moved the
-    // Objecter symbols out of librbd/librados into libceph-common, so the
-    // 20.2.x radostrace entry holds data only for libceph-common.so.2 even
-    // though the caller still passes (librbd, librados, libceph-common).
-    // The per-module build-id pins identity, so subset matching can't
-    // confuse two different package versions.  Any empty build-id in the
-    // embedded data disqualifies that entry (legacy JSONs predating the
-    // build-id scheme).
+    // Linear scan: an entry matches iff every module the caller asked for
+    // (`want`) is present in the entry with the same build-id, i.e. want is a
+    // subset of the entry's modules.  Callers pass a single identifying
+    // library — libceph-common.so.2 for radostrace, ceph-osd for osdtrace —
+    // whose build-id pins the exact package build; an entry may carry extra
+    // modules (e.g. pre-20.2 radostrace entries also hold librbd/librados,
+    // which import_from_embedded loads too) that the caller need not name.
+    // The per-module build-id pins identity, so this can't confuse two
+    // different package versions.  Any empty build-id in the embedded data is
+    // skipped, so legacy JSONs predating the build-id scheme never match.
     for (int i = 0; i < count; ++i) {
         const EmbeddedVersion& v = versions[i];
         if (v.num_modules == 0) continue;
 
-        bool all_match = true;
+        std::set<std::pair<std::string, std::string>> have;
         for (int m = 0; m < v.num_modules; ++m) {
             const char* bid = v.modules[m].build_id;
-            if (!bid || *bid == '\0') { all_match = false; break; }
-            auto it = want.find({v.modules[m].module_name, bid});
-            if (it == want.end()) { all_match = false; break; }
+            if (bid && *bid != '\0') have.emplace(v.modules[m].module_name, bid);
+        }
+
+        bool all_match = true;
+        for (const auto& w : want) {
+            if (have.find(w) == have.end()) { all_match = false; break; }
         }
         if (all_match) {
             return &v;

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -104,17 +104,19 @@ class DwarfParser {
    * Imports module function data from compiled-in embedded DWARF data,
    * matching the target binary by ELF GNU build-id.
    *
-   * An embedded entry matches iff the set of (module basename, build-id)
-   * pairs the caller supplies equals the entry's `modules[]` set exactly
-   * (same size, same content).  Any empty build-id on either side
-   * prevents that entry from matching — legacy JSONs without build-id
-   * data are therefore never selected by this path.
+   * An embedded entry matches iff every (module basename, build-id) pair the
+   * caller supplies is present in the entry's `modules[]` — i.e. the caller's
+   * set is a subset of the entry's.  The entry may carry extra modules, which
+   * import_from_embedded loads as well.  An empty caller-side build-id, or an
+   * empty build-id on the embedded module, prevents a match — legacy JSONs
+   * without build-id data are therefore never selected by this path.
    *
    * @param modules            Vector of (basename, hex-encoded build-id)
-   *                           pairs identifying the target binaries.
+   *                           pairs identifying the target build.  A single
+   *                           identifying library suffices since its build-id
+   *                           pins the package build.
    *                           For osdtrace: {{"ceph-osd", <hex>}}.
-   *                           For radostrace: three entries (librbd.so.1,
-   *                           librados.so.2, libceph-common.so.2).
+   *                           For radostrace: {{"libceph-common.so.2", <hex>}}.
    * @param trace_type         "osdtrace" or "radostrace".
    * @param matched_version_out If non-null, set to the matched entry's
    *                           version string on success (used by

--- a/src/radostrace.cc
+++ b/src/radostrace.cc
@@ -415,6 +415,93 @@ static int handle_event(void *ctx, void *data, size_t size) {
     return 0;
 }
 
+// One row of `--list` output: a client process that has libceph-common loaded.
+struct CephClientInfo {
+  int pid;
+  std::string exe_path;
+  bool is_container = false;
+  std::string traceable = "unknown";  // "yes" / "no" / "unknown"
+  std::string version = "unknown";    // authoritative only when traceable=="yes"
+};
+
+static std::string get_mnt_ns(int pid) {
+  char buf[256];
+  std::string p = "/proc/" + std::to_string(pid) + "/ns/mnt";
+  ssize_t n = readlink(p.c_str(), buf, sizeof(buf) - 1);
+  return n > 0 ? std::string(buf, n) : "";
+}
+
+// Discover client processes that have libceph-common loaded (i.e. the processes
+// radostrace can attach to) and annotate each with container status, embedded-
+// DWARF traceability, and Ceph version.  Mirrors osdtrace's --list.
+std::vector<CephClientInfo> discover_ceph_clients() {
+  std::vector<CephClientInfo> results;
+  DIR *proc_dir = opendir("/proc");
+  if (!proc_dir) {
+    std::cerr << "Error: Could not open /proc directory" << std::endl;
+    return results;
+  }
+  std::string self_ns = get_mnt_ns(getpid());
+
+  struct dirent *entry;
+  while ((entry = readdir(proc_dir)) != NULL) {
+    if (entry->d_type != DT_DIR || !isdigit(entry->d_name[0]))
+      continue;
+    int pid = atoi(entry->d_name);
+    if (pid <= 0)
+      continue;
+
+    // A process is a client iff it has libceph-common loaded; grab its path.
+    std::string lib_path;
+    std::ifstream maps("/proc/" + std::string(entry->d_name) + "/maps");
+    std::string line;
+    while (std::getline(maps, line)) {
+      size_t slash = line.find('/');
+      if (slash != std::string::npos &&
+          line.find("libceph-common.so.2", slash) != std::string::npos) {
+        lib_path = line.substr(slash);
+        break;
+      }
+    }
+    if (lib_path.empty())
+      continue;
+
+    CephClientInfo info;
+    info.pid = pid;
+    info.exe_path = get_exe_path_for_pid(pid);
+    std::string ns = get_mnt_ns(pid);
+    info.is_container = !self_ns.empty() && !ns.empty() && self_ns != ns;
+
+    // Read the build-id through /proc/<pid>/root so containerized clients
+    // resolve to the in-container library the uprobe would attach to.
+    std::string bid = get_elf_build_id(
+        "/proc/" + std::to_string(pid) + "/root" + lib_path);
+    std::string matched;
+    if (bid.empty()) {
+      info.traceable = "unknown";  // couldn't read the build-id (usually non-root)
+    } else if (DwarfParser::is_embedded_traceable(
+                   {{"libceph-common.so.2", bid}}, "radostrace", &matched)) {
+      info.traceable = "yes";
+      if (!matched.empty()) info.version = matched;
+    } else {
+      info.traceable = "no";
+      // Best-effort host package lookup for a native (non-container) client.
+      if (!info.is_container) {
+        std::string pkg = get_package_version(lib_path);
+        if (!pkg.empty() && pkg != "unknown") info.version = pkg;
+      }
+    }
+    results.push_back(info);
+  }
+  closedir(proc_dir);
+
+  std::sort(results.begin(), results.end(),
+            [](const CephClientInfo &a, const CephClientInfo &b) {
+              return a.pid < b.pid;
+            });
+  return results;
+}
+
 
 int main(int argc, char **argv) {
   signal(SIGINT, signal_handler); 
@@ -472,6 +559,29 @@ int main(int argc, char **argv) {
           }
       } else if (arg == "--skip-version-check") {
           skip_version_check = true;
+      } else if (arg == "--list") {
+          if (geteuid() != 0) {
+              std::cout << "Warning: not running as root; processes owned by other users may be missed,"
+                        << " and Traceable/Ceph Version may show as unknown." << std::endl << std::endl;
+          }
+          auto clients = discover_ceph_clients();
+          if (clients.empty()) {
+              std::cout << "No client processes using libceph-common detected on the host." << std::endl;
+          } else {
+              std::cout << "Detected " << clients.size() << " client process(es) using libceph-common:" << std::endl;
+              printf("  %-10s %-11s %-11s %-24s %s\n", "PID", "Container", "Traceable", "Ceph Version", "Executable Path");
+              printf("  --------------------------------------------------------------------------------\n");
+              for (const auto &c : clients) {
+                  printf("  %-10d %-11s %-11s %-24s %s\n", c.pid,
+                         c.is_container ? "yes" : "no", c.traceable.c_str(),
+                         c.version.c_str(), c.exe_path.empty() ? "unknown" : c.exe_path.c_str());
+              }
+              std::cout << std::endl
+                        << "Traceable: 'yes' means this radostrace has matching embedded DWARF data;"
+                        << " 'no' means it doesn't (export a DWARF JSON with -j on a matching host and"
+                        << " use -i); 'unknown' means a build-id couldn't be read (re-run as root)." << std::endl;
+          }
+          return 0;
       } else if (arg == "--list-embedded") {
           DwarfParser::list_embedded_versions("radostrace");
           return 0;
@@ -479,13 +589,14 @@ int main(int argc, char **argv) {
           print_tool_version("radostrace");
           return 0;
       } else if (arg == "-h" || arg == "--help") {
-          std::cout << "Usage: " << argv[0] << " [-t <timeout seconds>] [-j [filename]] [-i <filename>] [-o [filename]] [-p <pid>] [--skip-version-check] [--list-embedded]\n";
+          std::cout << "Usage: " << argv[0] << " [-t <timeout seconds>] [-j [filename]] [-i <filename>] [-o [filename]] [-p <pid>] [--skip-version-check] [--list] [--list-embedded]\n";
           std::cout << "  -t, --timeout <seconds>    Set execution timeout in seconds\n";
           std::cout << "  -j, --export-json <file>   Export DWARF info to JSON (default: radostrace_dwarf.json)\n";
           std::cout << "  -i, --import-json <file>   Import DWARF info from JSON file\n";
           std::cout << "  -o, --output <file>        Export events data info to CSV (default: radostrace_events.csv)\n";
           std::cout << "  -p, --pid <pid>            Attach uprobes only to the specified process ID (Mandatory for container based process tracing)\n";
           std::cout << "  --skip-version-check       Skip version check when importing DWARF JSON (currently needed for containers)\n";
+          std::cout << "  --list                     List client processes using libceph-common (PID, container, traceability, version), and exit\n";
           std::cout << "  --list-embedded            List the Ceph versions with DWARF data compiled into this binary, and exit\n";
           std::cout << "  -V, --version              Print version information and exit\n";
           std::cout << "  -h, --help                 Show this help message\n";

--- a/src/radostrace.cc
+++ b/src/radostrace.cc
@@ -676,22 +676,20 @@ int main(int argc, char **argv) {
       // When -j is used to export JSON, force live parsing so the output reflects
       // the installed binary (not a re-dump of the embedded data the header came
       // from). Otherwise try embedded DWARF data first, keyed by the on-disk
-      // ELF build-id of each library.
+      // ELF build-id of libceph-common.so.2.  That single build-id pins the
+      // exact package build (all three libs ship from it), so the matcher
+      // selects the right entry and loads whatever modules it carries.
       //
       // The library paths are reported as they appear inside the target's
       // mount namespace; for containerized rbd clients (podman / docker)
-      // those paths don't exist on the host.  Read the build-ids through
+      // those paths don't exist on the host.  Read the build-id through
       // /proc/<pid>/root/ when a target PID is specified so the read sees
-      // the same files the uprobe will attach to.
+      // the same file the uprobe will attach to.
       auto bid_path = [process_id](const std::string& p) -> std::string {
           if (process_id == -1) return p;
           return "/proc/" + std::to_string(process_id) + "/root" + p;
       };
       std::vector<std::pair<std::string, std::string>> rados_mods = {
-          {get_basename(librbd_path),
-              get_elf_build_id(bid_path(librbd_path))},
-          {get_basename(librados_path),
-              get_elf_build_id(bid_path(librados_path))},
           {get_basename(libceph_common_path),
               get_elf_build_id(bid_path(libceph_common_path))},
       };

--- a/src/version_utils.cc
+++ b/src/version_utils.cc
@@ -220,48 +220,54 @@ bool check_library_deleted(int process_id, const std::string& lib_name) {
     return false;
 }
 
-std::string find_library_path(const std::string& lib_name, int pid) {
-    int old_root_fd = -1;
-    int old_cwd_fd = -1;
-    bool did_chroot = false;
-    std::string result;
-
-    // If PID is specified, chroot to the process's root
-    if (pid != -1) {
-        // Save current working directory and root directory
-        old_cwd_fd = open(".", O_RDONLY | O_DIRECTORY);
-        old_root_fd = open("/", O_RDONLY | O_DIRECTORY);
-
-        if (old_root_fd < 0 || old_cwd_fd < 0) {
-            std::cerr << "Warning: Failed to save current directories: " << strerror(errno) << std::endl;
-            std::cerr << "Falling back to host filesystem search" << std::endl;
-            if (old_root_fd >= 0) close(old_root_fd);
-            if (old_cwd_fd >= 0) close(old_cwd_fd);
-            old_root_fd = -1;
-            old_cwd_fd = -1;
-            // Fall through to normal search
-        } else {
-            // Chroot to process's root filesystem
-            std::string proc_root = "/proc/" + std::to_string(pid) + "/root";
-            if (chroot(proc_root.c_str()) == 0) {
-                did_chroot = true;
-                if (chdir("/") != 0) {
-                    std::cerr << "Warning: Failed to chdir to new root: " << strerror(errno) << std::endl;
-                }
-                std::clog << "Chrooted to " << proc_root << " to search for " << lib_name << std::endl;
-            } else {
-                std::cerr << "Warning: chroot to " << proc_root << " failed: " << strerror(errno) << std::endl;
-                std::cerr << "This usually requires root privileges or CAP_SYS_CHROOT capability" << std::endl;
-                std::cerr << "Falling back to host filesystem search" << std::endl;
-                close(old_root_fd);
-                close(old_cwd_fd);
-                old_root_fd = -1;
-                old_cwd_fd = -1;
-            }
-        }
+// Find library path by parsing /proc/<pid>/maps.
+// This is more reliable than dlopen or a static directory search when
+// targeting a specific process: the maps name the exact file the process
+// loaded, covering containerized and snap-confined layouts (e.g. LXD's qemu
+// mapping librbd from /snap/lxd/<rev>/lib/...).  The returned path is
+// relative to the target's mount namespace; callers prefix /proc/<pid>/root.
+static std::string find_library_path_from_maps(const std::string& lib_name, int pid) {
+    std::string maps_path = "/proc/" + std::to_string(pid) + "/maps";
+    std::ifstream maps_file(maps_path);
+    if (!maps_file.is_open()) {
+        std::cerr << "Warning: Could not open " << maps_path << std::endl;
+        return "";
     }
 
-    // First try to find the library using dlopen
+    std::string line;
+    while (std::getline(maps_file, line)) {
+        // /proc/pid/maps format: address perms offset dev inode pathname
+        size_t slash = line.find('/');
+        if (slash == std::string::npos ||
+            line.find("(deleted)", slash) != std::string::npos)
+            continue;
+        std::string path = line.substr(slash);
+        std::string base = path.substr(path.find_last_of('/') + 1);
+        // Match the soname as a prefix so versioned filenames resolve too
+        // (librbd.so.1 -> librbd.so.1.17.0).
+        if (base.compare(0, lib_name.size(), lib_name) == 0) {
+            std::clog << "Found library " << lib_name << " from maps at: "
+                      << path << std::endl;
+            return path;
+        }
+    }
+    return "";
+}
+
+std::string find_library_path(const std::string& lib_name, int pid) {
+    // If a PID is specified, the process's maps are authoritative: a library
+    // that isn't mapped there can't be uprobed in that process anyway, so no
+    // filesystem fallback is attempted.
+    if (pid != -1) {
+        std::string result = find_library_path_from_maps(lib_name, pid);
+        if (result.empty()) {
+            std::cerr << "Could not find " << lib_name << " in /proc/" << pid
+                      << "/maps" << std::endl;
+        }
+        return result;
+    }
+
+    // No PID: find the library on the host.  First try dlopen.
     void* handle = dlopen(lib_name.c_str(), RTLD_LAZY | RTLD_NOLOAD);
     if (!handle) {
         // If not loaded, try to load it
@@ -276,81 +282,52 @@ std::string find_library_path(const std::string& lib_name, int pid) {
             dlclose(handle);
             if (!path.empty() && path != lib_name) {
                 std::clog << "Found library " << lib_name << " at: " << path << std::endl;
-                result = path;
-                goto cleanup;
+                return path;
             }
+        } else {
+            dlclose(handle);
         }
-        dlclose(handle);
     }
 
     // Fallback: search in common library directories
-    {
-        std::vector<std::string> search_dirs = {
-            "./lib",
-            "/lib",
-            "/lib64",
-            "/lib64/ceph",
-            "/usr/lib",
-            "/usr/lib64",
-            "/usr/lib64/ceph",
-            "/lib/x86_64-linux-gnu",
-            "/usr/lib/x86_64-linux-gnu",
-            "/usr/lib/x86_64-linux-gnu/ceph",
-            "/usr/local/lib",
-            "/snap/microceph/current/lib/x86_64-linux-gnu",
-            "/snap/microceph/current/lib/x86_64-linux-gnu/ceph"
-        };
+    std::vector<std::string> search_dirs = {
+        "./lib",
+        "/lib",
+        "/lib64",
+        "/lib64/ceph",
+        "/usr/lib",
+        "/usr/lib64",
+        "/usr/lib64/ceph",
+        "/lib/x86_64-linux-gnu",
+        "/usr/lib/x86_64-linux-gnu",
+        "/usr/lib/x86_64-linux-gnu/ceph",
+        "/usr/local/lib",
+        "/snap/microceph/current/lib/x86_64-linux-gnu",
+        "/snap/microceph/current/lib/x86_64-linux-gnu/ceph"
+    };
 
-        // Try different possible filenames for the library
-        std::vector<std::string> possible_names;
-        if (lib_name.find(".so") == std::string::npos) {
-            // If no .so extension, try common patterns
-            possible_names.push_back("lib" + lib_name + ".so");
-            possible_names.push_back("lib" + lib_name + ".so.1");
-            possible_names.push_back("lib" + lib_name + ".so.2");
-        } else {
-            possible_names.push_back(lib_name);
-        }
+    // Try different possible filenames for the library
+    std::vector<std::string> possible_names;
+    if (lib_name.find(".so") == std::string::npos) {
+        // If no .so extension, try common patterns
+        possible_names.push_back("lib" + lib_name + ".so");
+        possible_names.push_back("lib" + lib_name + ".so.1");
+        possible_names.push_back("lib" + lib_name + ".so.2");
+    } else {
+        possible_names.push_back(lib_name);
+    }
 
-        for (const auto& dir : search_dirs) {
-            for (const auto& name : possible_names) {
-                std::string full_path = dir + "/" + name;
-                if (access(full_path.c_str(), F_OK) == 0) {
-                    std::clog << "Found library " << lib_name << " at: " << full_path << std::endl;
-                    result = full_path;
-                    goto cleanup;
-                }
+    for (const auto& dir : search_dirs) {
+        for (const auto& name : possible_names) {
+            std::string full_path = dir + "/" + name;
+            if (access(full_path.c_str(), F_OK) == 0) {
+                std::clog << "Found library " << lib_name << " at: " << full_path << std::endl;
+                return full_path;
             }
         }
     }
 
-cleanup:
-    // Restore original root and working directory if we chrooted
-    if (did_chroot && old_root_fd >= 0) {
-        // First restore the root filesystem
-        if (fchdir(old_root_fd) != 0) {
-            std::cerr << "Error: Failed to fchdir back to original root: " << strerror(errno) << std::endl;
-        }
-        if (chroot(".") != 0) {
-            std::cerr << "Error: Failed to chroot back to original root: " << strerror(errno) << std::endl;
-        }
-        // Then restore the original working directory
-        if (old_cwd_fd >= 0) {
-            if (fchdir(old_cwd_fd) != 0) {
-                std::cerr << "Error: Failed to restore original working directory: " << strerror(errno) << std::endl;
-            }
-        }
-        std::clog << "Restored original root filesystem and working directory" << std::endl;
-    }
-
-    if (old_root_fd >= 0) {
-        close(old_root_fd);
-    }
-    if (old_cwd_fd >= 0) {
-        close(old_cwd_fd);
-    }
-
-    return result;
+    return "";
 }
 
 std::string find_executable_path(const std::string& exe_name) {

--- a/src/version_utils.cc
+++ b/src/version_utils.cc
@@ -246,6 +246,19 @@ static std::string find_library_path_from_maps(const std::string& lib_name, int 
         // Match the soname as a prefix so versioned filenames resolve too
         // (librbd.so.1 -> librbd.so.1.17.0).
         if (base.compare(0, lib_name.size(), lib_name) == 0) {
+            // Prefer the soname symlink next to the real file when it exists
+            // (librbd.so.1.19.0 -> librbd.so.1): the DWARF function tables
+            // are keyed by soname basename (mod_func2pc/mod_func2vf), so a
+            // versioned basename would make every lookup miss and silently
+            // skip the uprobes on that library.
+            if (base != lib_name) {
+                std::string soname_path =
+                    path.substr(0, path.find_last_of('/') + 1) + lib_name;
+                std::string host_view =
+                    "/proc/" + std::to_string(pid) + "/root" + soname_path;
+                if (access(host_view.c_str(), F_OK) == 0)
+                    path = soname_path;
+            }
             std::clog << "Found library " << lib_name << " from maps at: "
                       << path << std::endl;
             return path;

--- a/src/version_utils.cc
+++ b/src/version_utils.cc
@@ -267,42 +267,11 @@ static std::string find_library_path_from_maps(const std::string& lib_name, int 
     return "";
 }
 
-std::string find_library_path(const std::string& lib_name, int pid) {
-    // If a PID is specified, the process's maps are authoritative: a library
-    // that isn't mapped there can't be uprobed in that process anyway, so no
-    // filesystem fallback is attempted.
-    if (pid != -1) {
-        std::string result = find_library_path_from_maps(lib_name, pid);
-        if (result.empty()) {
-            std::cerr << "Could not find " << lib_name << " in /proc/" << pid
-                      << "/maps" << std::endl;
-        }
-        return result;
-    }
-
-    // No PID: find the library on the host.  First try dlopen.
-    void* handle = dlopen(lib_name.c_str(), RTLD_LAZY | RTLD_NOLOAD);
-    if (!handle) {
-        // If not loaded, try to load it
-        handle = dlopen(lib_name.c_str(), RTLD_LAZY);
-    }
-
-    if (handle) {
-        // Get the path using dlinfo
-        struct link_map* link_map;
-        if (dlinfo(handle, RTLD_DI_LINKMAP, &link_map) == 0 && link_map) {
-            std::string path = link_map->l_name;
-            dlclose(handle);
-            if (!path.empty() && path != lib_name) {
-                std::clog << "Found library " << lib_name << " at: " << path << std::endl;
-                return path;
-            }
-        } else {
-            dlclose(handle);
-        }
-    }
-
-    // Fallback: search in common library directories
+// Search the common library directories under root_prefix (empty for the
+// host, "/proc/<pid>/root" for a target process's mount namespace).  The
+// returned path excludes the prefix, i.e. it is namespace-relative.
+static std::string search_library_dirs(const std::string& lib_name,
+                                       const std::string& root_prefix) {
     std::vector<std::string> search_dirs = {
         "./lib",
         "/lib",
@@ -333,7 +302,7 @@ std::string find_library_path(const std::string& lib_name, int pid) {
     for (const auto& dir : search_dirs) {
         for (const auto& name : possible_names) {
             std::string full_path = dir + "/" + name;
-            if (access(full_path.c_str(), F_OK) == 0) {
+            if (access((root_prefix + full_path).c_str(), F_OK) == 0) {
                 std::clog << "Found library " << lib_name << " at: " << full_path << std::endl;
                 return full_path;
             }
@@ -341,6 +310,48 @@ std::string find_library_path(const std::string& lib_name, int pid) {
     }
 
     return "";
+}
+
+std::string find_library_path(const std::string& lib_name, int pid) {
+    // If a PID is specified, prefer the process's maps: they name the exact
+    // file it loaded.  Fall back to searching the common directories inside
+    // its mount namespace (via /proc/<pid>/root) for a library that is on
+    // the target's filesystem but not mapped — e.g. librbd.so.1 when the
+    // target is a radosgw; uprobes attach to the file, so that still works.
+    if (pid != -1) {
+        std::string result = find_library_path_from_maps(lib_name, pid);
+        if (!result.empty())
+            return result;
+        std::clog << "Could not find " << lib_name << " in /proc/" << pid
+                  << "/maps, searching its filesystem" << std::endl;
+        return search_library_dirs(
+            lib_name, "/proc/" + std::to_string(pid) + "/root");
+    }
+
+    // No PID: find the library on the host.  First try dlopen.
+    void* handle = dlopen(lib_name.c_str(), RTLD_LAZY | RTLD_NOLOAD);
+    if (!handle) {
+        // If not loaded, try to load it
+        handle = dlopen(lib_name.c_str(), RTLD_LAZY);
+    }
+
+    if (handle) {
+        // Get the path using dlinfo
+        struct link_map* link_map;
+        if (dlinfo(handle, RTLD_DI_LINKMAP, &link_map) == 0 && link_map) {
+            std::string path = link_map->l_name;
+            dlclose(handle);
+            if (!path.empty() && path != lib_name) {
+                std::clog << "Found library " << lib_name << " at: " << path << std::endl;
+                return path;
+            }
+        } else {
+            dlclose(handle);
+        }
+    }
+
+    // Fallback: search in common library directories
+    return search_library_dirs(lib_name, "");
 }
 
 std::string find_executable_path(const std::string& exe_name) {


### PR DESCRIPTION
## Summary

Adds a `--list` subcommand to **radostrace** and fixes embedded-DWARF matching so it works when keyed on a single identifying library. Discovered and closed a real coverage gap: 17.2.6-0.el8 rbd/rados clients were untraceable.

### Commits
1. **radostrace: add `--list`** — lists every host process that has `libceph-common` loaded (the processes radostrace can attach to), mirroring `osdtrace --list`. Columns: PID, Container, Traceable, Ceph Version, Executable Path.
2. **embedded: match by identifying lib alone (`want ⊆ entry`)** — reverses the embedded matcher so a caller can identify a build by one library's build-id (`libceph-common.so.2` for radostrace, `ceph-osd` for osdtrace) instead of having to supply every module an entry lists. The matched entry's extra modules are still loaded. Without this, `--list`'s libceph-common-only check reported every pre-20.2 client as `Traceable=no` even though their DWARF data is embedded.
3. **files: add quincy 17.2.6 el8 radostrace embedded DWARF** — the osdtrace side already shipped (38ee2fb) but the radostrace counterpart was missing, so 17.2.6-0.el8 clients (e.g. a cephadm `ceph-exporter`) showed `Traceable=no` / version `unknown`.

## Verification

On a host running mixed cephadm containers, `sudo ./radostrace --list` now resolves every client to its version:

```
PID        Container   Traceable   Ceph Version             Executable Path
5340       yes         yes         2:17.2.6-0.el8           /usr/bin/ceph-exporter
1404652    yes         yes         2:19.2.4-0.el9           /usr/bin/ceph-mgr
2028561    yes         yes         2:20.2.1-0.el9           /usr/bin/ceph-mds
3134       yes         yes         17.2.9-0ubuntu0.22.04.2  .../qemu-system-x86_64
4009145    yes         yes         2:17.2.7-0.el8           /usr/bin/ceph-mgr
```

The new 17.2.6-0.el8 entry's `libceph-common.so.2` build-id is `27a00ce10306ee4ce2d5f46da25c47e541a5a0dc`. All DWARF JSONs pass `tools/validate_dwarf_json.py`; osdtrace/radostrace/kfstrace all build clean.
