### PR TITLE
doc: update for v1.6 CLI surface and embedded DWARF workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Cephtrace is a suite of **eBPF-based dynamic tracing tools** that provide **micr
 - **📊 Per-IO Latency Breakdown** - See exactly where each operation spends its time
 - **🔄 No Downtime Required** - Attach and detach from running processes dynamically
 - **⚙️  No Configuration Needed** - Just start tracing on the fly, no service restarts or config changes
+- **🔋 Batteries Included** - DWARF data for many Ceph releases is compiled into the binaries and matched by ELF build-id; use `--list` to discover traceable processes and `--list-embedded` to see covered versions
 - **📦 Works with Containers** - Full support for cephadm, Rook, Docker, lxd and MicroCeph
 - **🚀 Low Overhead in Production** - eBPF with the kernel uprobe dynamic instrumentation
 
@@ -76,23 +77,23 @@ Get up and running in under 2 minutes - monitor VM I/O operations hitting your C
 wget https://github.com/taodd/cephtrace/releases/latest/download/radostrace
 chmod +x radostrace
 
-# Check your librados version on the host
-dpkg -l | grep librados2
-
-# Download matching DWARF file (example for Ubuntu 22.04, Ceph 17.2.6)
-wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/ubuntu/radostrace/17.2.6-0ubuntu0.22.04.2_dwarf.json
-
-# Find the QEMU process for your VM
-ps aux | grep qemu
+# Discover the Ceph client processes on the host (qemu VMs, rgw, ...).
+# Traceable=yes means the binary's embedded DWARF data covers that version -
+# no DWARF file or debug symbols needed.
+sudo ./radostrace --list
 
 # Start tracing the VM's RBD operations (replace <qemu-pid> with actual PID)
-sudo ./radostrace -i 17.2.6-0ubuntu0.22.04.2_dwarf.json -p <qemu-pid>
+sudo ./radostrace -p <qemu-pid>
 
-# Or trace all VMs on the host
-sudo ./radostrace -i 17.2.6-0ubuntu0.22.04.2_dwarf.json
+# Or trace all librados clients on the host
+sudo ./radostrace
+
+# For Ceph versions without embedded coverage (Traceable=no), import a
+# matching DWARF JSON from the files/ directory instead:
+sudo ./radostrace -i 17.2.9-0ubuntu0.22.04.3_dwarf.json -p <qemu-pid>
 ```
 
-### Sampl Output:
+### Sample Output:
 
 ```
      pid  client     tid  pool  pg     acting       w/r    size  latency     object[ops][offset,length]
@@ -101,7 +102,7 @@ sudo ./radostrace -i 17.2.6-0ubuntu0.22.04.2_dwarf.json
    19015   34206  419359     2  39     [0,121,11]     R     4096    1240     rbd_data.374de3730ad0.0000000000000000[read ][0, 4096]
    19015   34206  419360     2  39     [0,121,11]     R     4096    1705     rbd_data.374de3730ad0.0000000000000000[read ][4096, 4096]
    19015   34206  419361     2  39     [0,121,11]     R     4096    1334     rbd_data.374de3730ad0.0000000000000000[read ][12288, 4096]
-   19015   34206  419362     2  2b     [77,11,1]     iR     4096    2180     rbd_data.374de3730ad0.00000000000000ff[read ][4128768, 4096]
+   19015   34206  419362     2  2b     [77,11,1]      R     4096    2180     rbd_data.374de3730ad0.00000000000000ff[read ][4128768, 4096]
 ```
 
 📖 **Detailed guide:** [Getting Started](doc/getting-started.md)
@@ -139,7 +140,7 @@ See cephtrace in action troubleshooting real performance issues.
 
 ## Requirements
 - **Kernel:** Linux 5.8 or later
-- **Architecture:** x86_64
+- **Architecture:** x86_64, ARM64
 
 ## 🤝 Contributing
 

--- a/doc/analyze-osdtrace.md
+++ b/doc/analyze-osdtrace.md
@@ -53,7 +53,7 @@ When using `-f` option, you can analyze these latency components:
 
 ```bash
 # Capture osdtrace output
-sudo ./osdtrace -x -t 300 > osdtrace.log
+sudo ./osdtrace -a -t 300 > osdtrace.log
 
 # Analyze all operations
 ./tools/analyze_osdtrace_output.py osdtrace.log
@@ -180,8 +180,8 @@ as described in example 1 or 2 (but with `-f bluestore_lat`)
 ### Step 1: Capture Detailed Trace
 
 ```bash
-# Use -x for extended BlueStore breakdown
-sudo ./osdtrace -x -t 300 > osdtrace-$(date +%Y%m%d-%H%M%S).log
+# Full tracing mode (default) includes the BlueStore breakdown
+sudo ./osdtrace -a -t 300 > osdtrace-$(date +%Y%m%d-%H%M%S).log
 ```
 
 ### Step 2: Quick Overview of Latency Contributions
@@ -236,14 +236,14 @@ done
 
 ```bash
 # Before tuning
-sudo ./osdtrace -x -t 300 > before.log
+sudo ./osdtrace -a -t 300 > before.log
 ./tools/analyze_osdtrace_output.py before.log -f kv_commit > before-analysis.txt
 
 # Apply tuning (e.g., RocksDB settings)
 ceph config set osd bluestore_rocksdb_options "..."
 
 # After tuning
-sudo ./osdtrace -x -t 300 > after.log
+sudo ./osdtrace -a -t 300 > after.log
 ./tools/analyze_osdtrace_output.py after.log -f kv_commit > after-analysis.txt
 
 # Compare

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -35,9 +35,10 @@ cephtrace/
 Each tool follows this pattern:
 
 ```
-1. Parse DWARF information
-   ├─ Read debug symbols from installed packages
-   ├─ Or import from pre-generated JSON file
+1. Resolve DWARF information (radostrace/osdtrace)
+   ├─ Match embedded DWARF data by the target's ELF build-id
+   ├─ Or import from a pre-generated JSON file (-i)
+   ├─ Or parse debug symbols from installed packages
    └─ Extract struct layouts and function addresses
 
 2. Load and attach eBPF program

--- a/doc/building.md
+++ b/doc/building.md
@@ -40,3 +40,21 @@ cd cephtrace
 git submodule update --init --recursive
 make
 ```
+
+## Kernel BTF requirement (kfstrace)
+
+The `GEN-BTF` build step generates `src/ceph_btf_local.h` from the **ceph
+kernel module** of the newest kernel installed under `/lib/modules`, using
+that kernel's vmlinux BTF as the base. The build host therefore needs:
+
+- a kernel package providing `ceph.ko` (on Ubuntu:
+  `linux-modules-extra-<version>`), and
+- a readable base BTF for that same kernel - one of
+  `/lib/modules/<ver>/vmlinux`, `/usr/lib/debug/.../vmlinux`,
+  `/boot/vmlinux-<ver>`, or `/sys/kernel/btf/vmlinux` when the installed
+  kernel is also the running one.
+
+This works in containers and CI runners as long as a matching kernel package
+is installed - the kernel does not have to be running. The generated header is
+CO-RE relocatable: binaries built against one kernel's `ceph.ko` run on other
+kernels with BTF support (the field offsets are re-resolved at load time).

--- a/doc/dwarf-json-files.md
+++ b/doc/dwarf-json-files.md
@@ -2,6 +2,40 @@
 
 DWARF JSON files allow you to use cephtrace tools without installing debug symbols on every target machine. This guide explains how to generate, use, and manage these files.
 
+> **Check the embedded data first:** release binaries already contain the DWARF
+> data for many Ceph versions (see below). You only need a separate JSON file
+> when your version is not embedded.
+
+## Embedded DWARF Data
+
+Since v1.6, the radostrace and osdtrace release binaries ship with the DWARF
+data of many common Ceph releases **compiled in**. At startup the tool reads
+the ELF build-id of the target binary/library (through `/proc/<pid>/root` for
+containerized or snap-confined targets, so the in-container file is the one
+identified) and selects the matching embedded entry automatically:
+
+- **radostrace** matches on the `libceph-common.so.2` build-id
+- **osdtrace** matches on the `ceph-osd` build-id
+
+```bash
+# See which versions are compiled into your binary
+./radostrace --list-embedded
+./osdtrace --list-embedded
+
+# See whether the processes on this host are covered (Traceable column)
+sudo ./radostrace --list
+sudo ./osdtrace --list
+```
+
+When a build-id matches, no JSON file, no debug symbols, and no
+`--skip-version-check` are needed - this includes cephadm/Rook containers and
+MicroCeph/LXD snaps. When there is no match, the tools fall back to live DWARF
+parsing (requires debug symbols) or an imported JSON file (`-i`).
+
+Embedded coverage is refreshed automatically as new Ceph point releases ship.
+If your version is missing, generate a JSON file as described below - and
+consider submitting it as a PR to the `files/` directory.
+
 ## What are DWARF Files?
 
 DWARF is a debugging data format that contains information about:
@@ -49,19 +83,26 @@ File naming format: `<version>_dwarf.json`
 
 Location: `files/centos-stream/{radostrace,osdtrace}/`
 
-Available versions:
-- Ceph 18.2.7 (CentOS Stream 9)
-- Ceph 19.2.3 (CentOS Stream 9)
+Available versions include the el8/el9 builds used by cephadm container
+images, covering the Quincy (17.2.x), Reef (18.2.x), Squid (19.2.x), and
+Tentacle (20.2.x) series.
 
 File naming format: `{rados,osd}-<version>_dwarf.json`
 - Example: `rados-2:19.2.3-0.el9_dwarf.json`
 - Example: `osd-2:19.2.3-0.el9_dwarf.json`
+
+### Debian
+
+Location: `files/debian/{radostrace,osdtrace}/`
+
+Covers the Debian-packaged Ceph releases (e.g. 18.2.7+ds-1 on trixie).
 
 > To check available DWARF files, browse the repository:
 > - [Ubuntu radostrace files](https://github.com/taodd/cephtrace/tree/main/files/ubuntu/radostrace)
 > - [Ubuntu osdtrace files](https://github.com/taodd/cephtrace/tree/main/files/ubuntu/osdtrace)
 > - [CentOS Stream radostrace files](https://github.com/taodd/cephtrace/tree/main/files/centos-stream/radostrace)
 > - [CentOS Stream osdtrace files](https://github.com/taodd/cephtrace/tree/main/files/centos-stream/osdtrace)
+> - [Debian files](https://github.com/taodd/cephtrace/tree/main/files/debian)
 
 ## Generating DWARF JSON Files
 
@@ -111,6 +152,8 @@ sudo ./osdtrace -j osdtrace_dwarf.json
 
 The generated JSON file contains:
 - **Version information:** Package name and version string
+- **Architecture and build-ids:** Target architecture plus the ELF build-id of
+  each module (used to key the embedded-DWARF matching)
 - **Function addresses:** Locations of functions to probe
 - **Struct layouts:** Member offsets and sizes for Ceph internal structures
 - **Type information:** Data types and their properties
@@ -128,7 +171,7 @@ Use the `-i` flag to import a DWARF JSON file:
 sudo ./radostrace -i radostrace_dwarf.json
 
 # osdtrace with DWARF JSON
-sudo ./osdtrace -i osdtrace_dwarf.json -x
+sudo ./osdtrace -i osdtrace_dwarf.json
 ```
 
 ### Version Compatibility Checking
@@ -190,6 +233,6 @@ dwarf-files/
 ## See Also
 
 - [Getting Started Guide](getting-started.md) - Installation and basic usage
-- [radostrace Documentation](tools/radostrace.md) - Detailed radostrace usage
-- [osdtrace Documentation](tools/osdtrace.md) - Detailed osdtrace usage
-- [Containerized Ceph](deployment/containerized-ceph.md) - Using DWARF files with containers
+- [radostrace Documentation](radostrace.md) - Detailed radostrace usage
+- [osdtrace Documentation](osdtrace.md) - Detailed osdtrace usage
+- [Containerized Ceph](tracing-containerized-ceph.md) - Using DWARF files with containers

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -15,21 +15,33 @@ The fastest way to start tracing on Ubuntu is using pre-built binaries and DWARF
 
 ### Quick Start: radostrace
 
-Run on machines with Ceph clients (VMs with RBD volumes, OpenStack services, RGW gateways):
+Run on machines with Ceph clients (VMs with RBD volumes, OpenStack services, RGW gateways).
+DWARF data for many Ceph releases is **compiled into the binary**, so for covered versions
+you don't need DWARF files or debug symbols:
 
 ```bash
 # Download the binary
 wget https://github.com/taodd/cephtrace/releases/latest/download/radostrace
 chmod +x radostrace
 
+# Discover Ceph client processes (Traceable=yes means no extra setup needed)
+sudo ./radostrace --list
+
+# Start tracing a client (e.g. a VM's qemu process)
+sudo ./radostrace -p <PID>
+```
+
+If your version shows `Traceable = no`, download a matching DWARF file and pass it with `-i`:
+
+```bash
 # Check your Ceph version
 dpkg -l | grep librados
 
-# Download corresponding DWARF file (example for 17.2.6-0ubuntu0.22.04.2)
-wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/ubuntu/radostrace/17.2.6-0ubuntu0.22.04.2_dwarf.json
+# Download corresponding DWARF file (example for 17.2.9-0ubuntu0.22.04.3)
+wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/ubuntu/radostrace/17.2.9-0ubuntu0.22.04.3_dwarf.json
 
 # Start tracing
-sudo ./radostrace -i 17.2.6-0ubuntu0.22.04.2_dwarf.json
+sudo ./radostrace -i 17.2.9-0ubuntu0.22.04.3_dwarf.json
 ```
 
 ### Quick Start: osdtrace
@@ -41,14 +53,25 @@ Run on Ceph OSD nodes:
 wget https://github.com/taodd/cephtrace/releases/latest/download/osdtrace
 chmod +x osdtrace
 
+# Discover the OSDs on this host
+sudo ./osdtrace --list
+
+# Trace one OSD by ID, or all of them
+sudo ./osdtrace --id 0
+sudo ./osdtrace -a
+```
+
+If your version is not embedded (check with `--list-embedded`), use a DWARF file:
+
+```bash
 # Check your ceph-osd version
 dpkg -l | grep ceph-osd
 
 # Download corresponding DWARF file
-wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/ubuntu/osdtrace/17.2.6-0ubuntu0.22.04.2_dwarf.json
+wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.3_dwarf.json
 
 # Start tracing
-sudo ./osdtrace -i 17.2.6-0ubuntu0.22.04.2_dwarf.json -x
+sudo ./osdtrace -i osd-17.2.9-0ubuntu0.22.04.3_dwarf.json
 ```
 
 ### Quick Start: kfstrace
@@ -91,7 +114,7 @@ git submodule update --init --recursive
 #### Debian/Ubuntu
 
 ```bash
-sudo apt-get install g++ clang libelf-dev libc6-dev libc6-dev-i386 libdw-dev
+sudo apt-get install g++ clang libelf-dev libc6-dev libc6-dev-i386 libdw-dev libssl-dev make
 ```
 
 #### RHEL/CentOS/Rocky Linux
@@ -151,7 +174,7 @@ sudo apt-get install ceph-osd-dbgsym
 ### Supported Architectures
 
 - x86_64 (AMD64)
-- Currently focused on x86_64; other architectures may require modifications
+- ARM64 (AArch64)
 
 ### Ceph Versions
 
@@ -161,6 +184,7 @@ Cephtrace has been tested with:
 - Ceph Quincy (17.x)
 - Ceph Reef (18.x)
 - Ceph Squid (19.x)
+- Ceph Tentacle (20.x)
 
 > While newer Ceph versions should work, you may need to generate DWARF JSON files for your specific version. See [DWARF JSON Files](dwarf-json-files.md) for details.
 
@@ -168,7 +192,7 @@ Cephtrace has been tested with:
 
 ## Next Steps
 
-- **Learn about each tool:** [radostrace](tools/radostrace.md) | [osdtrace](tools/osdtrace.md) | [kfstrace](tools/kfstrace.md)
+- **Learn about each tool:** [radostrace](radostrace.md) | [osdtrace](osdtrace.md) | [kfstrace](kfstrace.md)
 - **DWARF JSON files:** [Generation and usage guide](dwarf-json-files.md)
-- **Deployment scenarios:** [Containerized Ceph](deployment/containerized-ceph.md) | [Production best practices](deployment/production-best-practices.md)
-- **Development:** [Building](development/building.md) | [Architecture](development/architecture.md) | [Contributing](development/contributing.md)
+- **Deployment scenarios:** [Containerized Ceph](tracing-containerized-ceph.md) | [MicroCeph](tracing-microceph-snap.md)
+- **Development:** [Building](building.md) | [Architecture](architecture.md)

--- a/doc/man/8/osdtrace.rst
+++ b/doc/man/8/osdtrace.rst
@@ -14,57 +14,83 @@ probe and trace OSD(s) on given nodes
 SYNOPSIS
 ========
 
-| **osdtrace** [-t <seconds>] [-j [filename]] [-i <filename>] [-o [filename]] [-p <pid>] -h
+| **osdtrace** [-s] [-b] [-l <milliseconds>] [-t <seconds>] [-j <filename>] [-i <filename>] [-a] [-p <pid1,pid2,...>] [--id <osd-id1,osd-id2,...>] [--skip-version-check] [--list] [--list-embedded] [-V] [-h]
 
 
 DESCRIPTION
 ===========
 
-**osdtrace** osdtrace can probe and trace OSD(s) directly on given nodes.
-  installed ``cephtrace``.
+**osdtrace** probes and traces ceph-osd processes directly on a given node,
+printing a per-operation latency breakdown across the messenger, OSD
+processing, and BlueStore layers. DWARF data for many Ceph releases is
+compiled into the binary (matched by the ceph-osd ELF build-id), so covered
+versions - including containerized OSDs - can be traced without debug symbols
+or DWARF JSON files.
 
 
 OPTIONS
 =======
 
--d <seconds>
+-s
 
-   Set probe duration in seconds to calculate average latency
+   Single OP probe mode: log PrimaryLogPG::log_op_stats only (lower overhead).
+   The default mode is full tracing with the complete latency breakdown.
 
--m <avg|max>
+-b
 
-   Set operation latency collection mode
+   Bluestore probe mode: BlueStore-layer probes only.
 
 -l <milliseconds>
 
    Set operation latency threshold to capture
 
--o <osd-id>
-
-   Only probe a specific OSD
-
--x
-
-   Set probe mode to Full OPs. See below for details
-
--b
-
-   Set probe mode to Bluestore. See below for details
-
--t
+-t <seconds>
 
    Set execution timeout in seconds
 
--j
+-j <filename>
 
-   Export DWARF parsing data
+   Export DWARF parsing data to a JSON file and exit
 
 -i <file>
 
    Import JSON DWARF data from file
 
+-a, --all
+
+   Trace ALL traceable ceph-osd processes on the host (native and
+   containerized)
+
+-p <pid1,pid2,...>
+
+   Probe using process IDs (comma-separated; mandatory for tracing
+   containerized processes by PID)
+
+--id <osd-id1,osd-id2,...>
+
+   Probe by OSD ID (comma-separated; resolves to PIDs via automatic
+   discovery)
+
+--skip-version-check
+
+   Skip the version check when importing DWARF JSON (needed when the host and
+   container package versions differ)
+
+--list
+
+   List active ceph-osd processes on the host (PID, OSD ID, container status,
+   traceability, Ceph version) and exit
+
+--list-embedded
+
+   List the Ceph versions with DWARF data compiled into this binary and exit
+
+-V, --version
+
+   Print version information and exit
+
 -h, --help
-   
+
    Show this help message
 
 

--- a/doc/man/8/radostrace.rst
+++ b/doc/man/8/radostrace.rst
@@ -14,21 +14,24 @@ trace any librados based Ceph client
 SYNOPSIS
 ========
 
-| **radostrace** [-t <seconds>] [-j [filename]] [-i <filename>] [-o [filename]] [-p <pid>] -h
+| **radostrace** [-t <seconds>] [-j [filename]] [-i <filename>] [-o [filename]] [-p <pid>] [--skip-version-check] [--list] [--list-embedded] [-V] [-h]
 
 
 DESCRIPTION
 ===========
 
-**radostrace** radostrace can trace any librados based Ceph client, including
-virtual machines using rbd backed volumes attached, rgw, cinder and glance.
-installed ``cephtrace``.
+**radostrace** can trace any librados based Ceph client, including
+virtual machines with rbd backed volumes attached, rgw, cinder and glance.
+DWARF data for many Ceph releases is compiled into the binary (matched by the
+libceph-common ELF build-id), so covered versions - including clients running
+in containers or snaps - can be traced without debug symbols or DWARF JSON
+files.
 
 
 OPTIONS
 =======
 
--t, --timeout
+-t, --timeout <seconds>
 
    Set execution timeout in seconds
 
@@ -46,7 +49,26 @@ OPTIONS
 
 -p, --pid <pid>
 
-   Attach uprobes only to the specified process ID
+   Attach uprobes only to the specified process ID (mandatory for
+   container-based process tracing)
+
+--skip-version-check
+
+   Skip the version check when importing DWARF JSON (needed when the host and
+   container package versions differ)
+
+--list
+
+   List client processes using libceph-common (PID, container status,
+   traceability, Ceph version) and exit
+
+--list-embedded
+
+   List the Ceph versions with DWARF data compiled into this binary and exit
+
+-V, --version
+
+   Print version information and exit
 
 -h, --help
 

--- a/doc/osdtrace.md
+++ b/doc/osdtrace.md
@@ -31,21 +31,45 @@ Run osdtrace on **Ceph OSD nodes** to:
 
 ## Quick Start
 
-### With Pre-built Binary and DWARF File (Ubuntu)
+### With Pre-built Binary (Ubuntu)
+
+osdtrace ships with DWARF data for many Ceph releases **compiled into the binary**
+(keyed by the `ceph-osd` ELF build-id), so for covered versions no DWARF download
+or debug symbols are needed:
 
 ```bash
 # Download osdtrace
 wget https://github.com/taodd/cephtrace/releases/latest/download/osdtrace
 chmod +x osdtrace
 
+# Discover the OSDs on this host and whether they are traceable as-is
+sudo ./osdtrace --list
+#  PID        OSD ID     Container    Traceable   Ceph Version
+#  -----------------------------------------------------------------------
+#  4373       0          yes          yes         19.2.3-0ubuntu0.24.04.3
+
+# Trace one OSD by ID
+sudo ./osdtrace --id 0
+
+# Or trace every traceable ceph-osd on the host
+sudo ./osdtrace -a
+```
+
+Use `./osdtrace --list-embedded` to see all Ceph versions with compiled-in DWARF
+data. If your version is not embedded, fall back to a DWARF JSON file (`-i`) or
+debug symbols (below).
+
+### With a DWARF JSON File
+
+```bash
 # Check your ceph-osd version
 dpkg -l | grep ceph-osd
 
 # Download matching DWARF file
-wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/ubuntu/osdtrace/17.2.6-0ubuntu0.22.04.2_dwarf.json
+wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.3_dwarf.json
 
-# Start tracing with extended output (-x flag)
-sudo ./osdtrace -i 17.2.6-0ubuntu0.22.04.2_dwarf.json -x
+# Start tracing
+sudo ./osdtrace -i osd-17.2.9-0ubuntu0.22.04.3_dwarf.json
 ```
 
 ### With Debug Symbols Installed
@@ -54,49 +78,81 @@ sudo ./osdtrace -i 17.2.6-0ubuntu0.22.04.2_dwarf.json -x
 # Install debug symbols
 sudo apt-get install ceph-osd-dbgsym
 
-# Run osdtrace
-sudo ./osdtrace -x
+# Run osdtrace (parses DWARF from the installed binary at startup)
+sudo ./osdtrace
 ```
 
 ## Command-Line Options
 
-### Basic Options
+```
+-p <pid1,pid2,...>         Probe using process IDs (comma-separated; mandatory
+                           for tracing containerized processes by PID)
+--id <osd-id1,osd-id2,...> Probe by OSD ID (comma-separated; resolves to PIDs
+                           via automatic discovery)
+-a, --all                  Trace ALL traceable ceph-osd processes on the host
+                           (native and containerized)
+-t <seconds>               Set execution timeout in seconds
+-s                         Single OP probe mode (logs PrimaryLogPG::log_op_stats
+                           only - lower overhead, one line per op)
+-b                         Bluestore probe mode (BlueStore-layer probes only)
+-l <milliseconds>          Only capture operations slower than this threshold
+-i <filename>              Import DWARF info from JSON file
+-j <filename>              Export DWARF info to JSON file and exit
+--skip-version-check       Skip version check when importing DWARF JSON
+                           (needed when host/container package versions differ)
+--list                     List active ceph-osd processes (PID, OSD ID,
+                           container status, traceability, version) and exit
+--list-embedded            List Ceph versions with DWARF data compiled into
+                           this binary and exit
+-V, --version              Print version information and exit
+-h                         Show help message
+```
 
-```
--p, --pid <PID>          Trace specific OSD process ID only
--t, --time <seconds>     Run for specified duration then exit
--x, --extended           Show extended latency breakdown
--i, --import <file>      Import DWARF data from JSON file
--j, --json <file>        Export DWARF data to JSON file and exit
---skip-version-check     Skip version compatibility check when importing
--h, --help              Show help message
-```
+By default osdtrace runs in **full tracing mode**, printing the complete latency
+breakdown (messenger, OSD, peers, BlueStore sub-latencies) for every operation.
+The former `-x` flag is gone - its output is now the default; the `-d` and `-m`
+aggregation options were removed at the same time.
 
 ### Examples
 
-#### Trace all OSDs with extended output
+#### Discover OSDs, then trace by OSD ID
 ```bash
-sudo ./osdtrace -x
+sudo ./osdtrace --list
+sudo ./osdtrace --id 3          # one OSD
+sudo ./osdtrace --id 3,5,7      # several OSDs
 ```
 
-#### Trace a specific OSD
+#### Trace all traceable OSDs on the host
 ```bash
-# Find the OSD process ID
-ps aux | grep ceph-osd
+sudo ./osdtrace -a
+```
 
-# Trace that specific OSD
-sudo ./osdtrace -p 12345 -x
+#### Trace specific PIDs
+```bash
+sudo ./osdtrace -p 12345
+sudo ./osdtrace -p 12345,12399
+```
+
+#### Only show slow operations
+```bash
+# Capture only ops slower than 50 ms
+sudo ./osdtrace --id 0 -l 50
+```
+
+#### Low-overhead single-line mode
+```bash
+sudo ./osdtrace --id 0 -s
 ```
 
 #### Trace for a limited time
 ```bash
 # Trace for 60 seconds then exit
-sudo ./osdtrace -t 60 -x
+sudo ./osdtrace --id 0 -t 60
 ```
 
 #### Use DWARF JSON file
 ```bash
-sudo ./osdtrace -i /path/to/osdtrace_dwarf.json -x
+sudo ./osdtrace -i /path/to/osdtrace_dwarf.json
 ```
 
 #### Generate DWARF JSON file
@@ -107,11 +163,16 @@ sudo ./osdtrace -j osdtrace_dwarf.json
 
 #### Trace containerized OSD
 ```bash
-# Find the ceph-osd process ID on the host
-ps aux | grep ceph-osd
+# Discover containerized OSDs (Container column = yes)
+sudo ./osdtrace --list
 
-# Skip version check for container mismatch
-sudo ./osdtrace -p 12345 -i dwarf.json --skip-version-check -x
+# Embedded DWARF data is matched by build-id even inside containers,
+# so for covered versions this just works:
+sudo ./osdtrace --id 2
+
+# For versions without embedded data, import a JSON matching the
+# *container's* Ceph version and skip the host version check:
+sudo ./osdtrace -p 12345 -i dwarf.json --skip-version-check
 ```
 
 ## Output Format
@@ -153,11 +214,11 @@ Each operation is labeled by type:
 | **osd_lat** | OSD processing time | μs | All ops |
 | **peers** | Replica wait times | [(osd, μs), ...] | op_w only |
 | **bluestore_lat** | Total BlueStore time | μs | All ops |
-| **prepare** | Transaction prep | μs | Extended (-x) |
-| **aio_wait** | Async I/O wait | μs | Extended (-x) |
-| **aio_size** | Async I/O size | bytes | Extended (-x) |
-| **seq_wait** | Sequencer wait | μs | Extended (-x) |
-| **kv_commit** | KV store commit | μs | Extended (-x) |
+| **prepare** | Transaction prep | μs | Write ops |
+| **aio_wait** | Async I/O wait | μs | Write ops |
+| **aio_size** | Async I/O size | bytes | Write ops |
+| **seq_wait** | Sequencer wait | μs | Write ops |
+| **kv_commit** | KV store commit | μs | Write ops |
 | **op_lat / subop_lat** | Total end-to-end latency | μs | All ops |
 
 Note:
@@ -218,7 +279,7 @@ osd 38 pg 20.16b op_w size 12288 client 179589331 tid 24057 throttle_lat 2 recv_
 
 **bluestore_lat: 10639μs (10.6ms)** - Total BlueStore processing
 
-With `-x` flag, broken down into:
+For write operations this is broken down into:
 
 **prepare: 107μs**
 - Transaction preparation
@@ -295,13 +356,10 @@ osd_lat 100 peers [(5, 5000), (10, 48000)] bluestore_lat 2000 ...
 ### Scenario 1: Diagnosing Slow Ops
 
 ```bash
-# Start tracing with extended output
-sudo ./osdtrace -x > /tmp/osdtrace.log
+# Trace every traceable OSD on the host; only capture ops slower than 10 ms
+sudo ./osdtrace -a -l 10 > /tmp/osdtrace.log
 
 # Let it run during slow ops, then analyze
-# Find operations with high latency
-awk '$NF > 10000' /tmp/osdtrace.log | head -20
-
 # Look for patterns in the latency breakdown
 ```
 
@@ -309,14 +367,14 @@ awk '$NF > 10000' /tmp/osdtrace.log | head -20
 
 ```bash
 # Trace a specific OSD that's showing issues
-sudo ./osdtrace -p $OSD_PID -x -t 300 > osd5_trace.log
+sudo ./osdtrace --id 5 -t 300 > osd5_trace.log
 ```
 
 ### Scenario 3: Comparing Primary vs Replica Performance
 
 ```bash
 # Trace all OSDs, then filter
-sudo ./osdtrace -x > full_trace.log
+sudo ./osdtrace -a > full_trace.log
 
 # Analyze primary operations (op_r, op_w)
 grep -E "op_r|op_w" full_trace.log > primary_ops.log

--- a/doc/radostrace.md
+++ b/doc/radostrace.md
@@ -28,24 +28,47 @@ Run radostrace on machines acting as Ceph clients:
 
 ## Quick Start
 
-### With Pre-built Binary and DWARF File (Ubuntu)
+### With Pre-built Binary (Ubuntu)
+
+radostrace ships with DWARF data for many Ceph releases **compiled into the
+binary** (keyed by the `libceph-common.so.2` ELF build-id), so for covered
+versions no DWARF download or debug symbols are needed - including clients
+running in containers or snaps:
 
 ```bash
 # Download radostrace
 wget https://github.com/taodd/cephtrace/releases/latest/download/radostrace
 chmod +x radostrace
 
+# Discover the Ceph client processes on this host
+sudo ./radostrace --list
+#  PID        Container   Traceable   Ceph Version             Executable Path
+#  --------------------------------------------------------------------------------
+#  3134       yes         yes         17.2.9-0ubuntu0.22.04.2  /snap/lxd/.../qemu-system-x86_64
+#  5340       yes         yes         2:17.2.6-0.el8           /usr/bin/ceph-exporter
+
+# Trace one client (e.g. a VM's qemu process)
+sudo ./radostrace -p 3134
+```
+
+Use `./radostrace --list-embedded` to see all Ceph versions with compiled-in
+DWARF data. If your version is not embedded (`Traceable = no` in `--list`),
+fall back to a DWARF JSON file (`-i`) or debug symbols (below).
+
+### With a DWARF JSON File
+
+```bash
 # Check your librados version
 dpkg -l | grep librados
 
 # Download matching DWARF file
-wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/ubuntu/radostrace/17.2.6-0ubuntu0.22.04.2_dwarf.json
+wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/ubuntu/radostrace/17.2.9-0ubuntu0.22.04.3_dwarf.json
 
 # Start tracing all librados clients
-sudo ./radostrace -i 17.2.6-0ubuntu0.22.04.2_dwarf.json
+sudo ./radostrace -i 17.2.9-0ubuntu0.22.04.3_dwarf.json
 ```
 
-### With Debug Symbols Installed (When no mathcing DWARF json file)
+### With Debug Symbols Installed (when no matching DWARF JSON file)
 
 ```bash
 # Install debug symbols
@@ -57,18 +80,30 @@ sudo ./radostrace
 
 ## Command-Line Options
 
-### Basic Options
-
 ```
--p, --pid <PID>          Trace specific process ID only
--t, --time <seconds>     Run for specified duration then exit
--i, --import <file>      Import DWARF data from JSON file
--j, --json <file>        Export DWARF data to JSON file and exit
---skip-version-check     Skip version compatibility check when importing
--h, --help              Show help message
+-p, --pid <pid>            Attach uprobes only to the specified process ID
+                           (mandatory for container-based process tracing)
+-t, --timeout <seconds>    Run for specified duration then exit
+-i, --import-json <file>   Import DWARF data from JSON file
+-j, --export-json <file>   Export DWARF data to JSON (default:
+                           radostrace_dwarf.json) and exit
+-o, --output <file>        Also export captured events to CSV (default:
+                           radostrace_events.csv)
+--skip-version-check       Skip version compatibility check when importing
+--list                     List client processes using libceph-common (PID,
+                           container status, traceability, version) and exit
+--list-embedded            List Ceph versions with DWARF data compiled into
+                           this binary and exit
+-V, --version              Print version information and exit
+-h, --help                 Show help message
 ```
 
 ### Examples
+
+#### Discover client processes
+```bash
+sudo ./radostrace --list
+```
 
 #### Trace all librados clients
 ```bash
@@ -77,7 +112,7 @@ sudo ./radostrace
 
 #### Trace a specific process
 ```bash
-# Find the process ID for a VM
+# Find the process ID for a VM (or use --list)
 ps aux | grep qemu-system
 
 # Trace that specific VM
@@ -88,6 +123,11 @@ sudo ./radostrace -p 12345
 ```bash
 # Trace for 60 seconds then exit
 sudo ./radostrace -t 60
+```
+
+#### Export events to CSV while tracing
+```bash
+sudo ./radostrace -p 12345 -o events.csv
 ```
 
 #### Use DWARF JSON file
@@ -103,10 +143,15 @@ sudo ./radostrace -j radostrace_dwarf.json
 
 #### Trace containerized process
 ```bash
-# Find the process ID on the host
-ps aux | grep ceph-client
+# Discover containerized clients (Container column = yes)
+sudo ./radostrace --list
 
-# Skip version check for container mismatch
+# Embedded DWARF data is matched by the in-container library's build-id,
+# so for covered versions this just works:
+sudo ./radostrace -p 12345
+
+# For versions without embedded data, import a JSON matching the
+# *container's* Ceph version and skip the host version check:
 sudo ./radostrace -p 12345 -i dwarf.json --skip-version-check
 ```
 

--- a/doc/tracing-containerized-ceph.md
+++ b/doc/tracing-containerized-ceph.md
@@ -7,9 +7,27 @@ When Ceph is deployed using containers (e.g., cephadm, Docker, Podman), tracing 
 **Key Challenges:**
 - Binary runs on host, traced process runs in container
 - Process namespaces require PID translation
-- DWARF files must match the container's Ceph version, not the host's
+- DWARF data must match the container's Ceph version, not the host's
 
-**Solutions:**
+**The easy path (v1.6+): embedded DWARF data.** Both tools compile in the
+DWARF data for many common Ceph releases and match it by the ELF build-id of
+the binary *inside the container* (read through `/proc/<pid>/root`). For
+covered versions - including the CentOS Stream images used by cephadm and
+Rook - tracing a container needs no DWARF download and no
+`--skip-version-check`:
+
+```bash
+# Discover containerized processes and check coverage (Traceable column)
+sudo ./radostrace --list     # clients (radosgw, qemu, ceph-mgr, ...)
+sudo ./osdtrace --list       # ceph-osd processes, with their OSD IDs
+
+# Trace directly
+sudo ./radostrace -p <HOST_PID>
+sudo ./osdtrace --id <OSD_ID>       # or: -p <HOST_PID>, or: -a for all
+```
+
+The rest of this guide covers the manual DWARF-file flow, needed only when
+your container's Ceph version is not embedded (check with `--list-embedded`):
 - Use `--skip-version-check` flag
 - Specify exact process ID with `-p`
 - Generate or download DWARF files matching container's Ceph version
@@ -94,10 +112,10 @@ chmod +x osdtrace
 wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/centos-stream/osdtrace/osd-2:19.2.3-0.el9_dwarf.json
 
 # Find the ceph-osd process PID on the host
-ps aux | grep ceph-osd 
+sudo ./osdtrace --list
 
-# Trace with --skip-version-check and extended output
-sudo ./osdtrace -i osd-2:19.2.3-0.el9_dwarf.json -p <HOST_PID> --skip-version-check -x
+# Trace with --skip-version-check
+sudo ./osdtrace -i osd-2:19.2.3-0.el9_dwarf.json -p <HOST_PID> --skip-version-check
 ```
 
 ### Tracing with Ubuntu Containers

--- a/doc/tracing-microceph-snap.md
+++ b/doc/tracing-microceph-snap.md
@@ -7,13 +7,30 @@ MicroCeph deploys Ceph using snap packages, which provides a self-contained Ceph
 **Key Points:**
 - Tracing process is similar to containerized Ceph deployments
 - Binary runs on host, traced process runs inside snap namespace
-- DWARF files must match the snap's Ceph version, not the host's
-- **Critical:** Use snap manifest to determine exact Ceph package version
+- DWARF data must match the snap's Ceph version, not the host's
 
-**Solutions:**
+**The easy path (v1.6+): embedded DWARF data.** The tools resolve the
+libraries a snap-confined process actually loaded from `/proc/<pid>/maps`
+(e.g. `/snap/microceph/<rev>/lib/...` or LXD's qemu under `/snap/lxd/<rev>/...`)
+and match the embedded DWARF data by ELF build-id. For covered versions no
+manifest lookup, DWARF download, or `--skip-version-check` is needed:
+
+```bash
+# Discover snap-confined clients / OSDs and check coverage (Traceable column)
+sudo ./radostrace --list
+sudo ./osdtrace --list
+
+# Trace directly
+sudo ./radostrace -p <HOST_PID>
+sudo ./osdtrace --id <OSD_ID>
+```
+
+The rest of this guide covers the manual DWARF-file flow, needed only when the
+snap's Ceph version is not embedded (check with `--list-embedded`):
 - Use `--skip-version-check` flag
 - Specify exact process ID with `-p`
 - Generate or download DWARF files matching snap's Ceph version
+- **Critical:** Use snap manifest to determine exact Ceph package version
 
 ## Determining Snap's Ceph Version
 
@@ -97,13 +114,13 @@ wget https://github.com/taodd/cephtrace/releases/latest/download/osdtrace
 chmod +x osdtrace
 
 # 3. Download DWARF file matching the snap's ceph-osd version
-wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/ubuntu/osdtrace/17.2.6-0ubuntu0.22.04.3_dwarf.json
+wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/ubuntu/osdtrace/osd-17.2.6-0ubuntu0.22.04.3_dwarf.json
 
 # 4. Find the ceph-osd process PID on the host
 ps aux | grep ceph-osd
 
-# 5. Trace with --skip-version-check and extended output
-sudo ./osdtrace -i 17.2.6-0ubuntu0.22.04.3_dwarf.json -p <HOST_PID> --skip-version-check -x
+# 5. Trace with --skip-version-check
+sudo ./osdtrace -i osd-17.2.6-0ubuntu0.22.04.3_dwarf.json -p <HOST_PID> --skip-version-check
 ```
 
 ## Generating DWARF Files for MicroCeph


### PR DESCRIPTION
## Summary

Refreshes all user-facing documentation to match the current binaries ahead of the v1.6 release. The docs still described the v1.5-era workflow (manual DWARF downloads, removed `-x`/`-d`/`-m` flags).

### Highlights

- **Tool guides + man pages match `--help` exactly** — added `--list`, `--list-embedded`, `--id`, `-a/--all`, `-s`, `-b`, `-l`, comma-separated `-p`, radostrace `-o` (CSV export); removed the dead `-x`, `-d`, `-m`, `-o <osd-id>` options (the osdtrace man page still documented four of them). Noted full latency breakdown is now the default output.
- **Embedded-DWARF-first Quick Starts** — download binary → `--list` → trace; DWARF JSON (`-i`) and dbgsym demoted to fallbacks, with real `--list` output samples.
- **Container/MicroCeph guides** — covered versions now need no DWARF download and no `--skip-version-check` (build-id matched through `/proc/<pid>/root`, snap libraries resolved from `/proc/<pid>/maps`); the manual flow is kept for uncovered versions.
- **dwarf-json-files.md** — new *Embedded DWARF Data* section, arch/build-id JSON metadata, coverage updated (el8/el9 quincy..tentacle, new Debian section).
- **building.md** — documents GEN-BTF requirements (newest installed kernel's `ceph.ko` + base vmlinux BTF; container/CI builds work with a kernel package installed).
- **Fixes** — broken `tools/`/`deployment/` relative links, ARM64 + Tentacle in supported matrices, `libssl-dev`/`make` in deps, README `Sampl` typo and a bogus `iR` value in sample output (the w/r column only ever prints `W`/`R`).

## Verification

- Every documented flag cross-checked against the binaries' `--help` **and** the getopt option strings (caught that `osdtrace -j` requires a filename despite its usage line saying `[-j]`)
- Every referenced `files/**/*_dwarf.json` path verified to exist in the repo
- All three man pages re-rendered cleanly with `rst2man`
- Stale-flag sweeps (`-x`, `--detect`, `-d`, `-m`) come back clean

### Follow-up (not in this PR, code change)
`osdtrace`'s own usage string prints `[-j]` without the required `<filename>` argument — one-line help-text fix in `src/osdtrace.cc` worth doing before tagging v1.6.