### PR TITLE
tests: add functional test for radostrace tracing a qemu VM on an RBD disk

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -42,6 +42,9 @@ jobs:
       - name: Embedded DWARF data test - verify integrity and E2E
         run: sudo ./tests/functional-test-embedded-dwarf.sh
 
+      - name: Functional test - radostrace tracing a qemu VM on an RBD disk
+        run: sudo ./tests/functional-test-qemu-rbd.sh
+
   build-ubuntu-cephadm:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35

--- a/tests/functional-test-qemu-rbd.sh
+++ b/tests/functional-test-qemu-rbd.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+
+# Functional test: radostrace tracing a qemu VM backed by an RBD disk.
+#
+# This covers the "VM with an rbd device" scenario end to end:
+#   - a cirros guest boots from rbd:<pool>/<image> through the *host* librbd
+#     (qemu links the distro librbd, not the cluster's), and runs an in-guest
+#     dd write + read workload driven over the serial console
+#   - radostrace attaches to the qemu process with NO -i and NO
+#     --skip-version-check, which exercises the two v1.6 code paths users
+#     hit with VMs: embedded DWARF matched by the host librbd's ELF
+#     build-id, and library path resolution from /proc/<pid>/maps
+#
+# Defaults assume the MicroCeph cluster set up by functional-test-microceph.sh
+# (the CI job runs that first).  For a non-snap cluster set:
+#   SKIP_CLUSTER_SETUP=1 CEPH_CMD=ceph RBD_CMD=rbd SKIP_CONF_EXPORT=1
+
+set -e
+# Run with `bash -x` for command-level tracing when debugging.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/log.sh
+source "$SCRIPT_DIR/lib/log.sh"
+# shellcheck source=lib/microceph-setup.sh
+source "$SCRIPT_DIR/lib/microceph-setup.sh"
+# shellcheck source=lib/verify-trace-output.sh
+source "$SCRIPT_DIR/lib/verify-trace-output.sh"
+
+CEPH_CMD=${CEPH_CMD:-microceph.ceph}
+RBD_CMD=${RBD_CMD:-microceph.rbd}
+SKIP_CLUSTER_SETUP=${SKIP_CLUSTER_SETUP:-0}
+SKIP_CONF_EXPORT=${SKIP_CONF_EXPORT:-0}
+POOL=${POOL:-test_pool}
+IMAGE=${IMAGE:-vmdisk}
+
+RADOSTRACE_LOG=/tmp/radostrace-qemu.log
+CONSOLE_LOG=/tmp/qemu-console.log
+CIRROS_IMG=${CIRROS_IMG:-/tmp/cirros-0.6.2-x86_64-disk.img}
+CIRROS_URL=https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
+
+# Row thresholds.  A cirros boot + 32 MiB write + 80 MiB read produced
+# 200-400 rows in validation runs across octopus..tentacle; require a
+# conservative floor so the test fails loudly if tracing breaks.
+MIN_TOTAL_ROWS=50
+MIN_WRITE_ROWS=10
+MIN_READ_ROWS=10
+
+echo "=== qemu + RBD disk functional test for radostrace ==="
+echo "Project root: $PROJECT_ROOT"
+
+# The cirros image (and therefore qemu-system-x86_64) is x86_64-only.
+if [ "$(uname -m)" != "x86_64" ]; then
+    info "SKIP: test requires x86_64 (got $(uname -m))"
+    exit 0
+fi
+
+cleanup() {
+    info "=== Cleanup ==="
+    pkill -f qemu-system-x86_64 || true
+    pkill -f radostrace || true
+
+    if [[ -e $RADOSTRACE_LOG ]]; then
+        info "radostrace output (tail):"
+        tail -50 $RADOSTRACE_LOG
+        info " === END of radostrace output === "
+    fi
+    if [[ -e $CONSOLE_LOG ]]; then
+        info "guest console (tail):"
+        tail -30 $CONSOLE_LOG
+        info " === END of guest console === "
+    fi
+}
+trap cleanup EXIT
+
+info "=== Step 1: Install qemu and expect ==="
+export DEBIAN_FRONTEND=noninteractive
+apt-get install -y -q qemu-system-x86 qemu-utils qemu-block-extra expect >/dev/null
+
+info "=== Step 2: Ensure cluster is up ==="
+if [ "$SKIP_CLUSTER_SETUP" != "1" ]; then
+    microceph_setup_single_node
+fi
+
+if [ "$SKIP_CONF_EXPORT" != "1" ]; then
+    # qemu/qemu-img run against the *host* librbd, which reads /etc/ceph.
+    # Export microceph's conf + admin keyring so host clients can reach the
+    # snap-confined cluster.
+    info "Exporting microceph conf to /etc/ceph for the host librbd"
+    mkdir -p /etc/ceph
+    cp /var/snap/microceph/current/conf/ceph.conf /etc/ceph/ceph.conf
+    cp /var/snap/microceph/current/conf/ceph.keyring \
+        /etc/ceph/ceph.client.admin.keyring
+fi
+
+info "=== Step 3: Check embedded DWARF coverage for the host librbd ==="
+LIBRBD_VER=$(dpkg-query -W -f='${Version}' librbd1)
+info "Host librbd1 version: $LIBRBD_VER"
+if ! "$PROJECT_ROOT/radostrace" --list-embedded | grep -qF "$LIBRBD_VER"; then
+    err "radostrace has no embedded DWARF for host librbd $LIBRBD_VER."
+    err "The embedded-DWARF refresh bot should add it; until then this"
+    err "host's qemu VMs are not traceable without -i."
+    exit 1
+fi
+
+info "=== Step 4: Create the RBD boot image ==="
+if ! $CEPH_CMD osd pool ls | grep -q "^${POOL}$"; then
+    $CEPH_CMD osd pool create "$POOL" 32
+    $CEPH_CMD osd pool application enable "$POOL" rbd
+fi
+# layering-only (no object-map): reads of unallocated regions must reach
+# RADOS or radostrace sees no read ops for them.
+$RBD_CMD rm "$POOL/$IMAGE" 2>/dev/null || true
+$RBD_CMD create --image-feature layering --size 1G "$POOL/$IMAGE"
+
+if [ ! -s "$CIRROS_IMG" ]; then
+    info "Downloading cirros guest image..."
+    curl -fsSL --retry 3 -o "$CIRROS_IMG" "$CIRROS_URL"
+fi
+# -n: write into the pre-created image, preserving its feature set
+qemu-img convert -n -O raw "$CIRROS_IMG" "rbd:$POOL/$IMAGE"
+
+info "=== Step 5: Boot the guest from the RBD disk ==="
+ACCEL=tcg
+[ -w /dev/kvm ] && ACCEL=kvm
+info "Using qemu accelerator: $ACCEL"
+# rbd_cache=false in the URI: cached reads never reach RADOS and would
+# hide the read path from radostrace (same rationale as the bench test).
+expect "$SCRIPT_DIR/lib/qemu-guest-io.exp" "$ACCEL" \
+    "rbd:$POOL/$IMAGE:rbd_cache=false" >"$CONSOLE_LOG" 2>&1 &
+EXPECT_PID=$!
+
+# Wait for the qemu process and confirm it mapped librbd (it opens the rbd
+# drive at startup, before the guest even boots).
+# pgrep -f, not -x: the comm name is truncated to 15 chars
+# ("qemu-system-x86"), so an exact-name match never fires.
+QEMU_PID=""
+for _ in $(seq 1 60); do
+    for pid in $(pgrep -f qemu-system-x86_64 2>/dev/null); do
+        if grep -q "librbd" "/proc/$pid/maps" 2>/dev/null; then
+            QEMU_PID=$pid
+            break 2
+        fi
+    done
+    sleep 0.5
+done
+if [ -z "$QEMU_PID" ]; then
+    err "Could not find a qemu-system-x86_64 process with librbd mapped"
+    exit 1
+fi
+info "Attaching radostrace to qemu PID $QEMU_PID (confirmed librbd-loaded)"
+
+info "=== Step 6: Trace the qemu process with radostrace ==="
+# No -i, no --skip-version-check: embedded DWARF matched by build-id.
+# The 600 s ceiling comfortably outlasts a TCG boot; the trace is stopped
+# as soon as the guest powers off.
+timeout 600 "$PROJECT_ROOT/radostrace" -p "$QEMU_PID" >"$RADOSTRACE_LOG" 2>&1 &
+RADOSTRACE_BG=$!
+sleep 3
+if ! kill -0 $RADOSTRACE_BG 2>/dev/null; then
+    err "radostrace exited prematurely"
+    exit 1
+fi
+
+if ! wait $EXPECT_PID; then
+    err "Guest session failed (boot/login/dd did not complete)"
+    exit 1
+fi
+# Both I/O phases must have actually run inside the guest.
+for marker in DD_WRITE_OK DD_READ_OK; do
+    if ! grep -q $marker "$CONSOLE_LOG"; then
+        err "Guest console is missing the $marker marker"
+        exit 1
+    fi
+done
+info "Guest completed its write+read workload"
+
+sleep 1
+kill -INT $RADOSTRACE_BG 2>/dev/null || true
+wait $RADOSTRACE_BG 2>/dev/null || true
+
+info "=== Step 7: Verify radostrace output ==="
+# `osd pool ls detail` quotes the pool name: pool 3 'rbd' replicated ...
+POOL_ID=$($CEPH_CMD osd pool ls detail | awk -v p="'$POOL'" '$1 == "pool" && $3 == p {print $2}')
+info "Pool $POOL has id ${POOL_ID:-unknown}"
+
+total=0; writes=0; reads=0; rbd_data_rows=0; bad_pool=0
+while IFS='|' read -r pid _client _tid pool _pg _acting wr _size _latency object; do
+    [ -z "$pid" ] && continue
+    total=$((total + 1))
+    case "$wr" in
+        W) writes=$((writes + 1)) ;;
+        R) reads=$((reads + 1)) ;;
+    esac
+    case "$object" in rbd_data.*) rbd_data_rows=$((rbd_data_rows + 1));; esac
+    if [ -n "$POOL_ID" ] && [ "$pool" != "$POOL_ID" ]; then
+        bad_pool=$((bad_pool + 1))
+    fi
+done < <(_radostrace_rows "$RADOSTRACE_LOG")
+
+info "radostrace captured: total=$total writes=$writes reads=$reads rbd_data_rows=$rbd_data_rows bad_pool=$bad_pool"
+
+fail=0
+if [ "$total" -lt "$MIN_TOTAL_ROWS" ]; then
+    err "Too few rows: $total < $MIN_TOTAL_ROWS"
+    fail=1
+fi
+if [ "$writes" -lt "$MIN_WRITE_ROWS" ]; then
+    err "Too few write rows: $writes < $MIN_WRITE_ROWS"
+    fail=1
+fi
+if [ "$reads" -lt "$MIN_READ_ROWS" ]; then
+    err "Too few read rows: $reads < $MIN_READ_ROWS (rbd cache short-circuit?)"
+    fail=1
+fi
+if [ "$rbd_data_rows" -lt "$MIN_TOTAL_ROWS" ]; then
+    err "Too few rbd_data object rows: $rbd_data_rows"
+    fail=1
+fi
+if [ "$bad_pool" -gt 0 ]; then
+    err "$bad_pool rows targeted a pool other than $POOL (id $POOL_ID)"
+    fail=1
+fi
+[ "$fail" -eq 0 ] || exit 1
+
+info "✓ radostrace traced the qemu VM's RBD I/O successfully"
+echo "=== qemu + RBD disk functional test PASSED ==="

--- a/tests/functional-test-qemu-rbd.sh
+++ b/tests/functional-test-qemu-rbd.sh
@@ -131,25 +131,33 @@ expect "$SCRIPT_DIR/lib/qemu-guest-io.exp" "$ACCEL" \
     "rbd:$POOL/$IMAGE:rbd_cache=false" >"$CONSOLE_LOG" 2>&1 &
 EXPECT_PID=$!
 
-# Wait for the qemu process and confirm it mapped librbd (it opens the rbd
-# drive at startup, before the guest even boots).
-# pgrep -f, not -x: the comm name is truncated to 15 chars
-# ("qemu-system-x86"), so an exact-name match never fires.
+# Discover the qemu process with radostrace --list, the same way a user
+# would.  qemu maps libceph-common.so.2 (via librbd) as soon as it opens
+# the rbd drive at startup, so it appears in --list before the guest even
+# boots.  This also covers --list end to end: process discovery plus the
+# Traceable column's embedded build-id resolution for the qemu row.
+# Columns: PID  Container  Traceable  Ceph-Version  Executable-Path
 QEMU_PID=""
+QEMU_TRACEABLE=""
 for _ in $(seq 1 60); do
-    for pid in $(pgrep -f qemu-system-x86_64 2>/dev/null); do
-        if grep -q "librbd" "/proc/$pid/maps" 2>/dev/null; then
-            QEMU_PID=$pid
-            break 2
-        fi
-    done
+    # `|| true`: read returns 1 on an empty poll (qemu not registered in
+    # --list yet), which set -e would otherwise turn into a silent exit.
+    read -r QEMU_PID QEMU_TRACEABLE < <("$PROJECT_ROOT/radostrace" --list 2>/dev/null \
+        | awk '$5 ~ /qemu-system-x86_64$/ {print $1, $3; exit}') || true
+    [ -n "$QEMU_PID" ] && break
     sleep 0.5
 done
 if [ -z "$QEMU_PID" ]; then
-    err "Could not find a qemu-system-x86_64 process with librbd mapped"
+    err "radostrace --list did not report a qemu-system-x86_64 process"
+    "$PROJECT_ROOT/radostrace" --list || true
     exit 1
 fi
-info "Attaching radostrace to qemu PID $QEMU_PID (confirmed librbd-loaded)"
+if [ "$QEMU_TRACEABLE" != "yes" ]; then
+    err "radostrace --list reports qemu PID $QEMU_PID as Traceable=$QEMU_TRACEABLE"
+    "$PROJECT_ROOT/radostrace" --list || true
+    exit 1
+fi
+info "radostrace --list found qemu PID $QEMU_PID (Traceable=yes)"
 
 info "=== Step 6: Trace the qemu process with radostrace ==="
 # No -i, no --skip-version-check: embedded DWARF matched by build-id.

--- a/tests/functional-test-qemu-rbd.sh
+++ b/tests/functional-test-qemu-rbd.sh
@@ -36,6 +36,7 @@ POOL=${POOL:-test_pool}
 IMAGE=${IMAGE:-vmdisk}
 
 RADOSTRACE_LOG=/tmp/radostrace-qemu.log
+RADOSTRACE_ERR=/tmp/radostrace-qemu.err
 CONSOLE_LOG=/tmp/qemu-console.log
 CIRROS_IMG=${CIRROS_IMG:-/tmp/cirros-0.6.2-x86_64-disk.img}
 CIRROS_URL=https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
@@ -65,6 +66,11 @@ cleanup() {
         info "radostrace output (tail):"
         tail -50 $RADOSTRACE_LOG
         info " === END of radostrace output === "
+    fi
+    if [[ -e $RADOSTRACE_ERR ]]; then
+        info "radostrace stderr (tail):"
+        tail -20 $RADOSTRACE_ERR
+        info " === END of radostrace stderr === "
     fi
     if [[ -e $CONSOLE_LOG ]]; then
         info "guest console (tail):"
@@ -163,7 +169,11 @@ info "=== Step 6: Trace the qemu process with radostrace ==="
 # No -i, no --skip-version-check: embedded DWARF matched by build-id.
 # The 600 s ceiling comfortably outlasts a TCG boot; the trace is stopped
 # as soon as the guest powers off.
-timeout 600 "$PROJECT_ROOT/radostrace" -p "$QEMU_PID" >"$RADOSTRACE_LOG" 2>&1 &
+# stderr goes to its own file: tool log lines (e.g. "Caught signal 2" on
+# our SIGINT) otherwise interleave mid-row with stdout in the shared file
+# and the split fragments confuse the row parser.
+timeout 600 "$PROJECT_ROOT/radostrace" -p "$QEMU_PID" \
+    >"$RADOSTRACE_LOG" 2>"$RADOSTRACE_ERR" &
 RADOSTRACE_BG=$!
 sleep 3
 if ! kill -0 $RADOSTRACE_BG 2>/dev/null; then
@@ -193,9 +203,19 @@ info "=== Step 7: Verify radostrace output ==="
 POOL_ID=$($CEPH_CMD osd pool ls detail | awk -v p="'$POOL'" '$1 == "pool" && $3 == p {print $2}')
 info "Pool $POOL has id ${POOL_ID:-unknown}"
 
-total=0; writes=0; reads=0; rbd_data_rows=0; bad_pool=0
+total=0; writes=0; reads=0; rbd_data_rows=0; bad_pool=0; malformed=0
 while IFS='|' read -r pid _client _tid pool _pg _acting wr _size _latency object; do
     [ -z "$pid" ] && continue
+    # Reject fragments that slipped past the loose row filter (e.g. a row
+    # split by an interleaved log line, or cut by an unclean kill): a real
+    # row always has W/R in the wr column and a numeric pool id.
+    case "$wr" in
+        W|R) ;;
+        *) malformed=$((malformed + 1)); continue ;;
+    esac
+    case "$pool" in
+        ''|*[!0-9]*) malformed=$((malformed + 1)); continue ;;
+    esac
     total=$((total + 1))
     case "$wr" in
         W) writes=$((writes + 1)) ;;
@@ -207,7 +227,7 @@ while IFS='|' read -r pid _client _tid pool _pg _acting wr _size _latency object
     fi
 done < <(_radostrace_rows "$RADOSTRACE_LOG")
 
-info "radostrace captured: total=$total writes=$writes reads=$reads rbd_data_rows=$rbd_data_rows bad_pool=$bad_pool"
+info "radostrace captured: total=$total writes=$writes reads=$reads rbd_data_rows=$rbd_data_rows bad_pool=$bad_pool malformed=$malformed"
 
 fail=0
 if [ "$total" -lt "$MIN_TOTAL_ROWS" ]; then
@@ -228,6 +248,12 @@ if [ "$rbd_data_rows" -lt "$MIN_TOTAL_ROWS" ]; then
 fi
 if [ "$bad_pool" -gt 0 ]; then
     err "$bad_pool rows targeted a pool other than $POOL (id $POOL_ID)"
+    fail=1
+fi
+# A couple of malformed fragments can result from stopping the tool
+# mid-write; more than that points at an output-format regression.
+if [ "$malformed" -gt 5 ]; then
+    err "$malformed malformed rows (output format regression?)"
     fail=1
 fi
 [ "$fail" -eq 0 ] || exit 1

--- a/tests/functional-test-qemu-rbd.sh
+++ b/tests/functional-test-qemu-rbd.sh
@@ -39,7 +39,12 @@ RADOSTRACE_LOG=/tmp/radostrace-qemu.log
 RADOSTRACE_ERR=/tmp/radostrace-qemu.err
 CONSOLE_LOG=/tmp/qemu-console.log
 CIRROS_IMG=${CIRROS_IMG:-/tmp/cirros-0.6.2-x86_64-disk.img}
-CIRROS_URL=https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
+# GitHub releases first: download.cirros-cloud.net regularly stalls from CI
+# runners (a 9-minute hang before curl's exit 28 took down one run).
+CIRROS_URLS=(
+    "https://github.com/cirros-dev/cirros/releases/download/0.6.2/cirros-0.6.2-x86_64-disk.img"
+    "https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img"
+)
 
 # Row thresholds.  A cirros boot + 32 MiB write + 80 MiB read produced
 # 200-400 rows in validation runs across octopus..tentacle; require a
@@ -121,8 +126,18 @@ $RBD_CMD rm "$POOL/$IMAGE" 2>/dev/null || true
 $RBD_CMD create --image-feature layering --size 1G "$POOL/$IMAGE"
 
 if [ ! -s "$CIRROS_IMG" ]; then
-    info "Downloading cirros guest image..."
-    curl -fsSL --retry 3 -o "$CIRROS_IMG" "$CIRROS_URL"
+    for url in "${CIRROS_URLS[@]}"; do
+        info "Downloading cirros guest image from $url ..."
+        if curl -fsSL --retry 3 --connect-timeout 15 --max-time 180 \
+            -o "$CIRROS_IMG" "$url"; then
+            break
+        fi
+        rm -f "$CIRROS_IMG"
+    done
+    if [ ! -s "$CIRROS_IMG" ]; then
+        err "Could not download the cirros image from any mirror"
+        exit 1
+    fi
 fi
 # -n: write into the pre-created image, preserving its feature set
 qemu-img convert -n -O raw "$CIRROS_IMG" "rbd:$POOL/$IMAGE"

--- a/tests/lib/qemu-guest-io.exp
+++ b/tests/lib/qemu-guest-io.exp
@@ -1,0 +1,59 @@
+#!/usr/bin/expect -f
+# Boot a cirros guest from an RBD-backed virtio disk and generate guest I/O.
+#
+# Usage: qemu-guest-io.exp <accel> <drive-file-uri>
+#   accel          qemu -machine accel= value (kvm or tcg)
+#   drive-file-uri qemu block URI, e.g. rbd:test_pool/vmdisk:rbd_cache=false
+#
+# The guest writes 32 MiB (fsync'd) and then reads 80 MiB straight from
+# /dev/vda; each phase echoes a marker (DD_WRITE_OK / DD_READ_OK) that the
+# caller greps for in the captured console log to prove the I/O really ran.
+set accel [lindex $argv 0]
+set drive [lindex $argv 1]
+
+# TCG boots are slow; give the whole session a generous ceiling.
+set timeout 480
+
+# -nic none: without it qemu adds a default user-mode NIC, and cirros's
+# cloud-metadata probe (169.254.169.254) then hangs ~50 s per retry x20
+# before giving up - far past any reasonable expect timeout.  With no NIC
+# the probe fails instantly and the login prompt appears in seconds.
+spawn qemu-system-x86_64 -machine accel=$accel -cpu max -m 512 \
+    -drive format=raw,file=$drive,if=virtio,cache=none \
+    -nic none -nographic -monitor none
+
+# The cirros banner prints "login as 'cirros' user" before the real prompt,
+# so match the exact prompt string instead of bare "login:".
+expect {
+    -ex "cirros login:" {}
+    timeout { puts "EXPECT_TIMEOUT waiting for login prompt"; exit 1 }
+    eof     { puts "EXPECT_EOF before login prompt"; exit 1 }
+}
+sleep 1
+send "cirros\r"
+expect {
+    -ex "Password:" {}
+    timeout { puts "EXPECT_TIMEOUT waiting for password prompt"; exit 1 }
+}
+send "gocubsgo\r"
+expect {
+    -ex "$ " {}
+    timeout { puts "EXPECT_TIMEOUT waiting for shell"; exit 1 }
+}
+
+send "sudo sh -c 'dd if=/dev/zero of=/root/ddfile bs=4096 count=8192 conv=fsync && sync && echo DD_WRITE_OK'\r"
+expect {
+    -ex "DD_WRITE_OK" {}
+    timeout { puts "EXPECT_TIMEOUT waiting for guest write"; exit 1 }
+}
+expect -ex "$ "
+
+send "sudo sh -c 'dd if=/dev/vda of=/dev/null bs=4096 count=20000 && echo DD_READ_OK'\r"
+expect {
+    -ex "DD_READ_OK" {}
+    timeout { puts "EXPECT_TIMEOUT waiting for guest read"; exit 1 }
+}
+expect -ex "$ "
+
+send "sudo poweroff\r"
+expect eof


### PR DESCRIPTION
## Summary

Adds CI coverage for the most common real radostrace target — a **VM with an rbd device** — which no existing test exercised (`rbd bench` covers the snap-confined CLI client, the cephadm job covers a containerized radosgw).

### What it does

1. Creates a layering-only RBD image and writes a cirros guest image into it with `qemu-img convert -n` (host librbd)
2. Boots a qemu guest from `rbd:<pool>/<image>:rbd_cache=false` — KVM when `/dev/kvm` is available (GitHub's Ubuntu runners expose it), TCG fallback otherwise; non-x86_64 hosts skip
3. Drives the guest over the serial console with expect: login → 32 MiB fsync'd dd write → 80 MiB dd read of /dev/vda, each phase proven by a `DD_WRITE_OK`/`DD_READ_OK` console marker
4. Attaches `radostrace -p <qemu-pid>` with **no `-i` and no `--skip-version-check`** — deliberately exercising the embedded DWARF build-id match against the host librbd and the `/proc/<pid>/maps` library resolution, the two paths VM users depend on
5. Verifies ≥50 rows / ≥10 writes / ≥10 reads, all rows in the test pool, with `rbd_data.*` object names

A Step-3 precheck fails loudly if the runner's own librbd version is missing from the embedded data, so distro coverage gaps surface here instead of as silent zero-row runs.

### Wiring

New step in the `build-ubuntu` job after the MicroCeph tests, reusing that cluster. `CEPH_CMD`/`RBD_CMD`/`SKIP_CLUSTER_SETUP`/`SKIP_CONF_EXPORT` env overrides allow running against any non-snap cluster.

### Pitfalls encountered and handled

- `pgrep -x qemu-system-x86_64` never matches (comm truncates to 15 chars) → `pgrep -f`
- qemu's default user-mode NIC makes cirros's cloud-metadata probe hang ~50 s × 20 retries before the login prompt → `-nic none` boots to login in seconds
- image is layering-only and opened with `rbd_cache=false` so neither object-map nor client cache can short-circuit the read path (same rationale as the bench test)

## Verification

Run end-to-end against a package-based squid 19.2.3 cluster on a noble VM (nested KVM), using a focal-built radostrace:

```
radostrace captured: total=1697 writes=350 reads=1347 rbd_data_rows=1687 bad_pool=0
=== qemu + RBD disk functional test PASSED ===
```

shellcheck-clean at the same level as the sibling functional tests.