### PR TITLE
tests/cephadm: verify --list output over a multi-client host

### DIFF
--- a/tests/functional-test-cephadm-rgw.sh
+++ b/tests/functional-test-cephadm-rgw.sh
@@ -27,6 +27,8 @@ source "$SCRIPT_DIR/lib/log.sh"
 source "$SCRIPT_DIR/lib/cephadm-setup.sh"
 # shellcheck source=lib/verify-trace-output.sh
 source "$SCRIPT_DIR/lib/verify-trace-output.sh"
+# shellcheck source=lib/verify-list-output.sh
+source "$SCRIPT_DIR/lib/verify-list-output.sh"
 
 OSDTRACE_LOG="/tmp/osdtrace-cephadm-${CEPH_RELEASE}.log"
 RADOSTRACE_LOG="/tmp/radostrace-cephadm-${CEPH_RELEASE}.log"
@@ -50,6 +52,7 @@ cleanup() {
     pkill -f "$PROJECT_ROOT/osdtrace" 2>/dev/null || true
     pkill -f "$PROJECT_ROOT/radostrace" 2>/dev/null || true
     pkill -f "s3cmd" 2>/dev/null || true
+    pkill -f "rados bench" 2>/dev/null || true
     if [[ -e "$OSDTRACE_LOG" ]]; then
         info "--- osdtrace tail (last 50 lines) ---"
         tail -50 "$OSDTRACE_LOG" || true
@@ -249,6 +252,53 @@ OSD_PID=$(pgrep -f "^[^ ]*ceph-osd .*-n[[:space:]]+osd\.1\b" | head -1)
 [ -n "$OSD_PID" ] || { err "could not find ceph-osd PID"; pgrep -af ceph-osd; exit 1; }
 
 info "RGW PID=$RGW_PID, OSD PID=$OSD_PID"
+
+
+############################################################################
+info "=== Step 10b: verify --list output over a multi-client host ==="
+# At this point the host runs a containerized MON, MGR, 3 OSDs, and the
+# radosgw.  Add one *native* (non-container) librados client - a host-side
+# rados bench - so --list must classify a mixed population: containerized
+# daemons (Container=yes, version = the container image's Ceph) alongside
+# a native client (Container=no, version = the host package).
+apt-get install -y -q ceph-common
+
+# quincy=17 reef=18 squid=19 tentacle=20: the containerized rows must all
+# report a version of this major.
+case "$CEPH_RELEASE" in
+    quincy)   EXPECTED_MAJOR=17 ;;
+    reef)     EXPECTED_MAJOR=18 ;;
+    squid)    EXPECTED_MAJOR=19 ;;
+    tentacle) EXPECTED_MAJOR=20 ;;
+    *) err "unknown release $CEPH_RELEASE"; exit 1 ;;
+esac
+
+cephadm shell --fsid "$FSID" -- ceph osd pool create list-test 8 >>"$WORKLOAD_LOG" 2>&1
+cephadm shell --fsid "$FSID" -- ceph osd pool application enable list-test rados >>"$WORKLOAD_LOG" 2>&1
+
+# Long-running native client; killed + cleaned up right after the checks.
+# The host rados CLI may be a different (newer/older) major than the
+# cluster - fine for bench I/O, and exactly the mixed-version situation
+# --list's per-process version resolution must get right.
+rados bench -p list-test 120 write -b 4096 --no-cleanup >>"$WORKLOAD_LOG" 2>&1 &
+BENCH_PID=$!
+sleep 3   # let it connect so libceph-common is mapped
+kill -0 "$BENCH_PID" 2>/dev/null || { err "native rados bench died at startup"; tail -5 "$WORKLOAD_LOG"; exit 1; }
+
+HOST_LIBRADOS_VER=$(dpkg-query -W -f='${Version}' librados2)
+info "native client: rados bench pid=$BENCH_PID, host librados2=$HOST_LIBRADOS_VER"
+
+verify_radostrace_list_multiclient "$PROJECT_ROOT/radostrace" \
+    "$EXPECTED_MAJOR" "$BENCH_PID" "$HOST_LIBRADOS_VER"
+verify_osdtrace_list_multiosd "$PROJECT_ROOT/osdtrace" "$EXPECTED_MAJOR" 3
+
+kill "$BENCH_PID" 2>/dev/null || true
+wait "$BENCH_PID" 2>/dev/null || true
+# No benchmark objects left behind; drop the throwaway pool entirely.
+rados -p list-test cleanup >>"$WORKLOAD_LOG" 2>&1 || true
+cephadm shell --fsid "$FSID" -- ceph config set mon mon_allow_pool_delete true >>"$WORKLOAD_LOG" 2>&1 || true
+cephadm shell --fsid "$FSID" -- ceph osd pool rm list-test list-test \
+    --yes-i-really-really-mean-it >>"$WORKLOAD_LOG" 2>&1 || true
 
 
 ############################################################################

--- a/tests/lib/verify-list-output.sh
+++ b/tests/lib/verify-list-output.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+#
+# Verifiers for `radostrace --list` and `osdtrace --list` output.
+# Sourced by functional tests; follows the conventions of
+# verify-trace-output.sh (xtrace silencing around per-row loops, row
+# extraction helpers prefixed with _).
+
+# Emit radostrace --list data rows, one per line:
+#   pid|container|traceable|version|path
+# Data rows start with a numeric PID and have exactly the 5 columns
+# (PID, Container, Traceable, Ceph Version, Executable Path); the
+# header, separator, and preamble lines all fail the predicate.
+_radostrace_list_rows() {
+    "$1" --list 2>/dev/null | awk '
+        $1 ~ /^[0-9]+$/ && NF >= 5 {
+            print $1 "|" $2 "|" $3 "|" $4 "|" $5
+        }'
+}
+
+# Emit osdtrace --list data rows, one per line:
+#   pid|osd_id|container|traceable|version
+_osdtrace_list_rows() {
+    "$1" --list 2>/dev/null | awk '
+        $1 ~ /^[0-9]+$/ && NF >= 5 {
+            print $1 "|" $2 "|" $3 "|" $4 "|" $5
+        }'
+}
+
+# Strip an optional epoch ("2:19.2.4-0.el9" -> "19.2.4-0.el9") and return
+# the major version number ("19").
+_version_major() {
+    echo "$1" | sed 's/^[0-9]*://' | cut -d. -f1
+}
+
+# verify_radostrace_list_multiclient <binary> <expected_major> \
+#     <native_pid> <native_version>
+#
+# Asserts the --list output over a mixed-client host:
+#   - containerized daemons (radosgw, ceph-mon, ceph-mgr) all report
+#     Container=yes, Traceable=yes, and one uniform version whose major
+#     matches expected_major
+#   - the native client <native_pid> reports Container=no, Traceable=yes,
+#     and exactly <native_version> (the host package version)
+#   - no PID appears twice
+#
+# ceph-osd processes are deliberately NOT expected here: ceph-osd links
+# the common code statically and maps no libceph-common.so.2, so it is
+# not a librados client and never appears in radostrace --list (it is
+# osdtrace --list's job, keyed on the ceph-osd binary's build-id).
+verify_radostrace_list_multiclient() {
+    local _xtrace=0
+    case $- in *x*) _xtrace=1; set +x;; esac
+
+    _verify_radostrace_list_multiclient_impl "$@"
+    local rc=$?
+
+    (( _xtrace == 1 )) && set -x
+    return $rc
+}
+
+_verify_radostrace_list_multiclient_impl() {
+    local binary=$1
+    local expected_major=$2
+    local native_pid=$3
+    local native_version=$4
+
+    local total=0 osd_rows=0 dup=0
+    local saw_rgw=0 saw_mon=0 saw_mgr=0 saw_native=0
+    local container_version=""
+    local fail=0
+    local pid container traceable version path base
+    local -A seen_pid
+
+    while IFS='|' read -r pid container traceable version path; do
+        [ -z "$pid" ] && continue
+        total=$((total + 1))
+
+        if [ -n "${seen_pid[$pid]:-}" ]; then
+            err "radostrace --list: PID $pid listed more than once"
+            dup=$((dup + 1))
+        fi
+        seen_pid[$pid]=1
+
+        base=${path##*/}
+
+        if [ "$pid" = "$native_pid" ]; then
+            saw_native=1
+            if [ "$container" != "no" ]; then
+                err "native client $pid ($base): Container=$container, expected no"
+                fail=1
+            fi
+            if [ "$traceable" != "yes" ]; then
+                err "native client $pid ($base): Traceable=$traceable, expected yes"
+                fail=1
+            fi
+            if [ "$version" != "$native_version" ]; then
+                err "native client $pid ($base): version '$version' != host package '$native_version'"
+                fail=1
+            fi
+            continue
+        fi
+
+        # Containerized daemons we explicitly expect on a cephadm host.
+        case "$base" in
+            radosgw)  saw_rgw=1 ;;
+            ceph-mon) saw_mon=1 ;;
+            ceph-mgr) saw_mgr=1 ;;
+            ceph-osd) osd_rows=$((osd_rows + 1)) ;;
+            *) continue ;;  # crash agents etc. — presence not asserted
+        esac
+
+        if [ "$container" != "yes" ]; then
+            err "containerized $base (pid $pid): Container=$container, expected yes"
+            fail=1
+        fi
+        if [ "$traceable" != "yes" ]; then
+            err "containerized $base (pid $pid): Traceable=$traceable, expected yes"
+            fail=1
+        fi
+        if [ -z "$container_version" ]; then
+            container_version=$version
+        elif [ "$version" != "$container_version" ]; then
+            err "containerized $base (pid $pid): version '$version' differs from '$container_version'"
+            fail=1
+        fi
+    done < <(_radostrace_list_rows "$binary")
+
+    info "radostrace --list: total=$total rgw=$saw_rgw mon=$saw_mon mgr=$saw_mgr" \
+         "osd_rows=$osd_rows native=$saw_native container_version=${container_version:-none}"
+
+    [ "$saw_rgw" -eq 1 ]  || { err "radostrace --list: no radosgw row";  fail=1; }
+    [ "$saw_mon" -eq 1 ]  || { err "radostrace --list: no ceph-mon row"; fail=1; }
+    [ "$saw_mgr" -eq 1 ]  || { err "radostrace --list: no ceph-mgr row"; fail=1; }
+    [ "$saw_native" -eq 1 ] || { err "radostrace --list: native client pid $native_pid missing"; fail=1; }
+    [ "$dup" -eq 0 ] || fail=1
+    # ceph-osd statically links the common code (no libceph-common.so.2 in
+    # its maps), so it must NOT be listed as a librados client.
+    if [ "$osd_rows" -ne 0 ]; then
+        err "radostrace --list: $osd_rows ceph-osd rows; OSDs are not librados clients"
+        fail=1
+    fi
+    if [ -n "$container_version" ] && \
+       [ "$(_version_major "$container_version")" != "$expected_major" ]; then
+        err "radostrace --list: container version '$container_version' major != $expected_major"
+        fail=1
+    fi
+
+    if [ "$fail" -ne 0 ]; then
+        "$binary" --list 2>&1 || true
+        return 1
+    fi
+    info "✓ radostrace --list multi-client output verified"
+    return 0
+}
+
+# verify_osdtrace_list_multiosd <binary> <expected_major> <expected_osd_count>
+#
+# Asserts the --list output on a host whose OSDs are all containerized:
+#   - the listed PID set equals the live ceph-osd PID set (pgrep -x)
+#   - exactly <expected_osd_count> rows with distinct OSD IDs
+#   - every row: Container=yes, Traceable=yes, one uniform version whose
+#     major matches expected_major
+verify_osdtrace_list_multiosd() {
+    local _xtrace=0
+    case $- in *x*) _xtrace=1; set +x;; esac
+
+    _verify_osdtrace_list_multiosd_impl "$@"
+    local rc=$?
+
+    (( _xtrace == 1 )) && set -x
+    return $rc
+}
+
+_verify_osdtrace_list_multiosd_impl() {
+    local binary=$1
+    local expected_major=$2
+    local expected_count=$3
+
+    local total=0 fail=0
+    local pid osd_id container traceable version
+    local container_version=""
+    local -A seen_pid seen_id
+
+    while IFS='|' read -r pid osd_id container traceable version; do
+        [ -z "$pid" ] && continue
+        total=$((total + 1))
+
+        if [ -n "${seen_pid[$pid]:-}" ]; then
+            err "osdtrace --list: PID $pid listed more than once"
+            fail=1
+        fi
+        seen_pid[$pid]=1
+        if [ -n "${seen_id[$osd_id]:-}" ]; then
+            err "osdtrace --list: OSD ID $osd_id listed more than once"
+            fail=1
+        fi
+        seen_id[$osd_id]=1
+
+        if ! kill -0 "$pid" 2>/dev/null; then
+            err "osdtrace --list: PID $pid (osd.$osd_id) is not a live process"
+            fail=1
+        fi
+        if [ "$container" != "yes" ]; then
+            err "osdtrace --list: osd.$osd_id (pid $pid): Container=$container, expected yes"
+            fail=1
+        fi
+        if [ "$traceable" != "yes" ]; then
+            err "osdtrace --list: osd.$osd_id (pid $pid): Traceable=$traceable, expected yes"
+            fail=1
+        fi
+        if [ -z "$container_version" ]; then
+            container_version=$version
+        elif [ "$version" != "$container_version" ]; then
+            err "osdtrace --list: osd.$osd_id (pid $pid): version '$version' differs from '$container_version'"
+            fail=1
+        fi
+    done < <(_osdtrace_list_rows "$binary")
+
+    info "osdtrace --list: total=$total expected=$expected_count" \
+         "container_version=${container_version:-none}"
+
+    if [ "$total" -ne "$expected_count" ]; then
+        err "osdtrace --list: $total rows, expected exactly $expected_count"
+        fail=1
+    fi
+
+    # Every live ceph-osd process must be listed (comm is exactly
+    # "ceph-osd", 8 chars, so -x is safe here).
+    local live
+    for live in $(pgrep -x ceph-osd 2>/dev/null); do
+        if [ -z "${seen_pid[$live]:-}" ]; then
+            err "osdtrace --list: live ceph-osd PID $live not listed"
+            fail=1
+        fi
+    done
+
+    if [ -n "$container_version" ] && \
+       [ "$(_version_major "$container_version")" != "$expected_major" ]; then
+        err "osdtrace --list: container version '$container_version' major != $expected_major"
+        fail=1
+    fi
+
+    if [ "$fail" -ne 0 ]; then
+        "$binary" --list 2>&1 || true
+        return 1
+    fi
+    info "✓ osdtrace --list multi-OSD output verified"
+    return 0
+}


### PR DESCRIPTION
## Summary

Adds row-level verification of `radostrace --list` and `osdtrace --list` to the cephadm matrix job, over a deliberately **mixed client population**: the containerized MON/MGR/3×OSD/radosgw the job already deploys, plus a **native host-package `rados bench`** started just for the check.

### What is asserted

**`radostrace --list`**
- radosgw / ceph-mon / ceph-mgr rows: `Container=yes`, `Traceable=yes`, one uniform version whose major matches the release under test (quincy=17 … tentacle=20)
- the native client row: `Container=no`, `Traceable=yes`, version **exactly equal** to the host's `librados2` package — intentionally a *different* version than the cluster, so the per-process build-id resolution through `/proc/<pid>/root` is what's being proven
- `ceph-osd` must **not** appear: ceph-osd links the common code statically (no `libceph-common.so.2` in its maps), so it is not a librados client — the first draft of this check wrongly expected OSD rows and failed, which is now locked in as a negative assertion
- no duplicate PIDs

**`osdtrace --list`**
- exactly 3 rows, distinct OSD IDs, PIDs live and covering every `ceph-osd` process on the host
- all `Container=yes` / `Traceable=yes`, uniform version, major matched

### Mechanics

- New `tests/lib/verify-list-output.sh` (row parsers + the two verifiers, xtrace-silenced like the existing verify libs)
- New Step 10b in `functional-test-cephadm-rgw.sh`, between cluster readiness and the trace window; the bench pool is cleaned up and removed so later steps see an unchanged cluster
- No workflow changes needed — runs across the whole 2×4 matrix (22.04/24.04 × quincy/reef/squid/tentacle), i.e. eight container-version × host-version combinations per CI run

## Verification

Full run via `tests/local-cephadm-test.sh squid` (disposable LXD VM, real cephadm bootstrap):

```
INFO: native client: rados bench pid=25076, host librados2=19.2.3-0ubuntu0.24.04.3
INFO: radostrace --list: total=6 rgw=1 mon=1 mgr=1 osd_rows=0 native=1 container_version=2:19.2.3-0.el9
INFO: ✓ radostrace --list multi-client output verified
INFO: osdtrace --list: total=3 expected=3 container_version=2:19.2.3-0.el9
INFO: ✓ osdtrace --list multi-OSD output verified
```

…followed by all pre-existing rgw/osd trace checks passing.