### PR TITLE
doc: drop -i from default radostrace usage scenarios

### DIFF
--- a/doc/radostrace.md
+++ b/doc/radostrace.md
@@ -266,7 +266,7 @@ Typical latencies:
 
 ```bash
 # On the host that the VM is running
-sudo ./radostrace -p <pid of the vm> -i <dwarf_json> -t 300 > /tmp/radostrace_output.txt
+sudo ./radostrace -p <pid of the vm> -t 300 > /tmp/radostrace_output.txt
 
 # Look for operations with high latency (over 100ms) values
 awk '$9 > 100000' /tmp/radostrace_output.txt
@@ -279,7 +279,7 @@ awk '$9 > 100000' /tmp/radostrace_output.txt
 ps aux | grep cinder-volume
 
 # Trace that specific process
-sudo ./radostrace -p <PID> -i <dwarf_json>
+sudo ./radostrace -p <PID>
 ```
 
 ### Scenario 3: Analyzing RGW traffic 


### PR DESCRIPTION
## Summary

In `doc/radostrace.md` → **Common Usage Scenarios**, two examples still passed an explicit `-i <dwarf_json>` as if it were required. Since radostrace parses embedded DWARF data from the client binary's build-id by default, `-i` is not needed for covered versions.

- **Scenario 1 (Troubleshooting Slow VM):** `sudo ./radostrace -p <pid> -t 300 > …`
- **Scenario 2 (Monitoring OpenStack Cinder):** `sudo ./radostrace -p <PID>`

The DWARF JSON example, the `-i` example, and the containerized-process example still pass `-i` where it is genuinely required (versions without embedded data).

Doc-only change.