### PR TITLE
doc: restructure containerized guide into embedded vs non-embedded parts

### DIFF
--- a/doc/tracing-containerized-ceph.md
+++ b/doc/tracing-containerized-ceph.md
@@ -1,195 +1,147 @@
 # Tracing Containerized Ceph Deployments
 
-When Ceph is deployed using containers (e.g., cephadm, Docker, Podman), tracing requires special considerations since the cephtrace binary runs on the host while the target process runs inside a container.
+When Ceph runs in containers (cephadm, Rook/k8s, Docker, Podman), the cephtrace
+binary runs on the host while the target process runs inside a container. The
+procedure is the **same regardless of orchestrator** - cephtrace reads the
+in-container binary through `/proc/<pid>/root`, so cephadm and Rook/k8s need no
+different steps. What actually matters is only one thing: whether your
+container's Ceph version has **embedded DWARF data**.
 
-## Overview
+**Key points:**
+- The binary runs on the host; the traced process runs in a container.
+- DWARF data must match the *container's* Ceph version, not the host's.
+- If the version is embedded (Part 1), there is nothing to download or
+  configure. If it is not (Part 2), supply a matching DWARF file and skip the
+  host version check.
 
-**Key Challenges:**
-- Binary runs on host, traced process runs in container
-- Process namespaces require PID translation
-- DWARF data must match the container's Ceph version, not the host's
+---
 
-**The easy path (v1.6+): embedded DWARF data.** Both tools compile in the
-DWARF data for many common Ceph releases and match it by the ELF build-id of
-the binary *inside the container* (read through `/proc/<pid>/root`). For
+## Part 1: Default - Embedded DWARF (no setup)
+
+cephtrace ships with DWARF data for many common Ceph releases compiled into the
+binary, matched by the ELF build-id of the binary *inside the container*. For
 covered versions - including the CentOS Stream images used by cephadm and
-Rook - tracing a container needs no DWARF download and no
-`--skip-version-check`:
+Rook - tracing needs no DWARF download and no `--skip-version-check`.
+
+### 1. Discover processes and check coverage
+
+`--list` shows each process's host PID, container status, Ceph version, and a
+`Traceable` column - `yes` means embedded DWARF data already covers this version.
 
 ```bash
-# Discover containerized processes and check coverage (Traceable column)
-sudo ./radostrace --list     # clients (radosgw, qemu, ceph-mgr, ...)
-sudo ./osdtrace --list       # ceph-osd processes, with their OSD IDs
-
-# Trace directly
-sudo ./radostrace -p <HOST_PID>
-sudo ./osdtrace --id <OSD_ID>       # or: -p <HOST_PID>, or: -a for all
-```
-
-The rest of this guide covers the manual DWARF-file flow, needed only when
-your container's Ceph version is not embedded (check with `--list-embedded`):
-- Use `--skip-version-check` flag
-- Specify exact process ID with `-p`
-- Generate or download DWARF files matching container's Ceph version
-
-## cephadm Deployments
-
-cephadm is the recommended Ceph deployment tool that uses containers (typically Podman or Docker).
-
-### Identifying Container Processes
-
-#### Find Client Processes (for radostrace)
-
-```bash
-# List Ceph client processes (host PID, container status, traceability, version)
+# Clients (radosgw, qemu, ceph-mgr, ...)
 sudo ./radostrace --list
-
-# Example output:
 #  PID        Container   Traceable   Ceph Version    Executable Path
 #  ---------------------------------------------------------------------
 #  12345      yes         yes         2:19.2.3-0.el9  /usr/bin/radosgw
-```
 
-The PID shown (12345) is the host PID, which is what you'll pass with `-p`. The
-`Traceable` column tells you whether this radostrace already has matching
-embedded DWARF data - `yes` means you can trace directly with no DWARF file.
-
-#### Find OSD Processes (for osdtrace)
-
-```bash
-# List ceph-osd processes with their OSD IDs (host PID, container, traceability)
+# ceph-osd processes, with their OSD IDs
 sudo ./osdtrace --list
-
-# Example output:
 #  PID        OSD ID     Container    Traceable   Ceph Version
 #  -----------------------------------------------------------------------
 #  23456      0          yes          yes         2:19.2.3-0.el9
 #  23457      1          yes          yes         2:19.2.3-0.el9
 ```
 
-Each OSD runs as a separate process; trace it by OSD ID with `--id` or by host
-PID with `-p`.
+Use `--list-embedded` to see every Ceph version with compiled-in DWARF data.
 
-### Determine Container's Ceph Version
+### 2. Trace directly
+
+Use the host PID (and, for OSDs, the OSD ID) reported by `--list`:
 
 ```bash
-# Check Ceph version in container
+# Client process - -p is mandatory for container-based tracing
+sudo ./radostrace -p <HOST_PID>
+
+# OSD - by OSD ID, by host PID, or every traceable OSD on the host
+sudo ./osdtrace --id <OSD_ID>
+sudo ./osdtrace -p <HOST_PID>
+sudo ./osdtrace -a
+```
+
+If the `Traceable` column shows `yes`, you are done - skip Part 2 entirely.
+
+---
+
+## Part 2: Non-embedded versions (manual DWARF data)
+
+When `--list` shows `Traceable = no` (your container's Ceph version isn't in
+`--list-embedded`), supply DWARF data matching the *container's* Ceph version
+and trace a specific PID with `--skip-version-check`.
+
+### 1. Determine the container's Ceph version
+
+```bash
+# cephadm
 cephadm shell -- ceph version
+cephadm shell -- rpm -q ceph-osd        # RHEL / CentOS Stream
+cephadm shell -- dpkg -l | grep ceph    # Ubuntu / Debian
 
-# Or check specific package version
-cephadm shell -- rpm -q ceph-osd     # For RHEL-based
-cephadm shell -- dpkg -l | grep ceph # For Debian-based
+# Rook/k8s - exec into the OSD/RGW pod and run the same commands
+kubectl -n rook-ceph exec <pod> -- ceph version
 ```
 
-### Tracing with CentOS Stream Containers
+### 2. Get a DWARF file matching that version
 
-CentOS Stream is common in cephadm deployments.
-
-> **Check coverage first.** Run `sudo ./radostrace --list` (or `sudo ./osdtrace
-> --list`). If the `Traceable` column shows `yes`, your container's Ceph version
-> is already embedded - skip the DWARF download below and trace directly with
-> `-p <HOST_PID>` (or `--id <OSD_ID>` for osdtrace). The manual DWARF flow below
-> is only needed when `Traceable = no`.
-
-#### radostrace for CentOS Stream
+Pre-generated files live in the repo under `files/<distro>/<tool>/`, named by
+the container's Ceph package version:
 
 ```bash
-# Download radostrace binary
-wget https://github.com/taodd/cephtrace/releases/latest/download/radostrace
-chmod +x radostrace
-
-# Download DWARF file matching container's Ceph version
-# Example for Ceph 19.2.3 on CentOS Stream 9
+# CentOS Stream example (Ceph 19.2.3, el9)
 wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/centos-stream/radostrace/rados-2:19.2.3-0.el9_dwarf.json
-
-# Find the client process PID on the host
-ps aux | grep radosgw
-
-# Trace with --skip-version-check
-sudo ./radostrace -i rados-2:19.2.3-0.el9_dwarf.json -p <HOST_PID> --skip-version-check
-```
-
-**Why skip version check?**
-- The tool checks the host's library version
-- Container has different library version
-- Version check would fail even though DWARF file is correct for the container
-
-#### osdtrace for CentOS Stream
-
-```bash
-# Download osdtrace binary
-wget https://github.com/taodd/cephtrace/releases/latest/download/osdtrace
-chmod +x osdtrace
-
-# Download DWARF file matching container's Ceph version
 wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/centos-stream/osdtrace/osd-2:19.2.3-0.el9_dwarf.json
 
-# Find the ceph-osd process PID on the host
-sudo ./osdtrace --list
+# Ubuntu example (Ceph 17.2.6, 22.04)
+wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/ubuntu/radostrace/17.2.6-0ubuntu0.22.04.2_dwarf.json
+```
 
-# Trace with --skip-version-check
+If no matching file exists, generate one (see [Generating DWARF data](#generating-dwarf-data) below).
+
+### 3. Trace with --skip-version-check
+
+```bash
+# Client
+sudo ./radostrace -i rados-2:19.2.3-0.el9_dwarf.json -p <HOST_PID> --skip-version-check
+
+# OSD
 sudo ./osdtrace -i osd-2:19.2.3-0.el9_dwarf.json -p <HOST_PID> --skip-version-check
 ```
 
-### Tracing with Ubuntu Containers
+**Why `--skip-version-check`?** The tool compares against the host's library
+version, which differs from the container's. The check would otherwise fail
+even though the DWARF file is correct for the container, so it must be skipped.
 
-If using Ubuntu-based Ceph containers (again, only needed when `--list` shows
-`Traceable = no`):
+### Generating DWARF data
 
-```bash
-# Determine container's Ubuntu Ceph version
-cephadm shell -- dpkg -l | grep librados
+If no pre-generated DWARF file exists for your container's version:
 
-# Download matching DWARF file
-wget https://raw.githubusercontent.com/taodd/cephtrace/main/files/ubuntu/radostrace/17.2.6-0ubuntu0.22.04.2_dwarf.json
-
-# Trace
-sudo ./radostrace -i 17.2.6-0ubuntu0.22.04.2_dwarf.json -p <HOST_PID> --skip-version-check
-```
-
-## k8s/rook Deployments
-The steps are the same as tracing a cephadm-deployed cluster.
-
-## Generating DWARF Files for Containers
-
-If pre-generated DWARF files aren't available for your container's Ceph version:
-
-### Method 1: Generate Inside Container
+#### Option A: generate inside the container
 
 ```bash
-# Enter container
-docker exec -it ceph-osd-0 /bin/bash
-
-# Inside container, install debug symbols
-# For Ubuntu:
-apt-get install ceph-osd-dbgsym
-
-# Copy cephtrace binary into container
-docker cp ./osdtrace ceph-osd-0:/tmp/
-
-# Generate DWARF file inside container
-docker exec ceph-osd-0 /tmp/osdtrace -j /tmp/osd_dwarf.json
-
-# Copy DWARF file out
-docker cp ceph-osd-0:/tmp/osd_dwarf.json ./
+# Copy the cephtrace binary in, install debug symbols, export the JSON, copy it out
+docker cp ./osdtrace <container>:/tmp/
+docker exec <container> apt-get install -y ceph-osd-dbgsym   # use the matching debuginfo package for the distro
+docker exec <container> /tmp/osdtrace -j /tmp/osd_dwarf.json
+docker cp <container>:/tmp/osd_dwarf.json ./
 ```
 
-### Method 2: Use Matching Development Environment
+For Rook/k8s, use `kubectl cp` and `kubectl exec` in place of `docker cp`/`docker exec`.
 
-```bash
-# Set up a VM/Host with same OS and Ceph version as your container
-# Install debug symbols
-# Run radostrace/osdtrace with -j to generate DWARF JSON
+#### Option B: matching development environment
 
-# Copy DWARF file to production host
-# Use with --skip-version-check
-```
+Set up a VM/host with the same OS and Ceph version as the container, install
+debug symbols, and run `radostrace`/`osdtrace -j` to export the DWARF JSON. Copy
+it to the production host and use it with `--skip-version-check`.
+
+See [DWARF JSON Files](dwarf-json-files.md) for more on generating and managing DWARF data.
+
+---
 
 ## kfstrace with Containers
 
-**Good news:** kfstrace works normally with containerized Ceph!
-**Why?** kfstrace traces the kernel module (`ceph.ko`), not the container processes. The kernel module runs on the host, so there's no container complexity.
-
+**kfstrace works normally with containerized Ceph - no special steps.** It
+traces the kernel module (`ceph.ko`), which runs on the host rather than inside
+the container, so none of the above container complexity applies.
 
 ## See Also
 


### PR DESCRIPTION
## Summary

Restructures `doc/tracing-containerized-ceph.md` around the only thing that determines the workflow — whether the container's Ceph version has **embedded DWARF data** — instead of per-orchestrator sections.

- **Part 1 — Default (embedded DWARF):** discover processes with `--list` (host PID, container status, OSD ID, `Traceable` column), then trace directly with `-p <HOST_PID>` / `--id <OSD_ID>` / `-a`. No download, no `--skip-version-check`.
- **Part 2 — Non-embedded versions:** determine the container's Ceph version, fetch a matching DWARF file (or generate one), and trace a specific PID with `--skip-version-check`. Includes the "why skip the version check" explanation and the two DWARF-generation options.

**cephadm and Rook/k8s are no longer separate sections** — the steps are identical, so orchestrator-specific commands appear inline only where they differ (`cephadm shell` vs `kubectl exec`, `docker cp/exec` vs `kubectl cp/exec`). The CentOS Stream / Ubuntu specifics are folded into generic DWARF-download examples.

## Verified
- All example DWARF download URLs resolve to real files in `files/`.
- Flag usage is correct (`-p` mandatory for container client tracing; `-a` never paired with `-i`).

Doc-only change. Builds on the `--list` discovery cleanup already merged in #143.