### PR TITLE
tests/microceph: verify --list for both tools in the snap environment

### DIFF
--- a/tests/functional-test-microceph.sh
+++ b/tests/functional-test-microceph.sh
@@ -18,6 +18,8 @@ source "$SCRIPT_DIR/lib/log.sh"
 source "$SCRIPT_DIR/lib/microceph-setup.sh"
 # shellcheck source=lib/verify-trace-output.sh
 source "$SCRIPT_DIR/lib/verify-trace-output.sh"
+# shellcheck source=lib/verify-list-output.sh
+source "$SCRIPT_DIR/lib/verify-list-output.sh"
 
 echo "=== MicroCeph Functional Test for osdtrace and radostrace ==="
 echo "Project root: $PROJECT_ROOT"
@@ -156,6 +158,13 @@ if [ -z "$OSD_PID" ]; then
 fi
 info "Found OSD process: PID $OSD_PID"
 
+info "=== Step 4b: Verify osdtrace --list discovers the snap-confined OSDs ==="
+# MicroCeph deploys 3 OSDs (see microceph_setup_single_node call above), each
+# snap-confined.  --list must enumerate all three, mark them Container=yes
+# (snap mount ns), resolve a non-"unknown" traceability verdict through the
+# snap namespace, and - when traceable - report the snap's exact Ceph version.
+verify_osdtrace_list_microceph "$PROJECT_ROOT/osdtrace" 3 "$CEPH_VERSION"
+
 info "=== Step 5: Create RBD pool and image for testing ==="
 if ! microceph.ceph osd pool ls | grep -q "^test_pool$"; then
     microceph.ceph osd pool create test_pool 32
@@ -230,6 +239,14 @@ timeout 30 $PROJECT_ROOT/radostrace -p $RBD_ACTUAL_PID -i $RADOS_DWARF --skip-ve
 sleep 2 # ensure radostrace starts before we get its PID
 RADOSTRACE_PID=$(pidof radostrace)
 info "Started radostrace with PID $RADOSTRACE_PID"
+
+info "=== Step 8b: Verify radostrace --list while the snap client is live ==="
+# The rbd bench client is snap-confined and only exists during the bench, so
+# this check runs now (before the Step 9 wait).  --list must discover that
+# client (Container=yes, libraries resolved under /snap/microceph/...) and
+# also surface the snap ceph-mon/mgr/mds daemons, proving daemon discovery -
+# not just the transient bench process.
+verify_radostrace_list_microceph "$PROJECT_ROOT/radostrace" "$RBD_ACTUAL_PID" "$CEPH_VERSION"
 
 info "=== Step 9: Wait for bench + traces to complete"
 wait

--- a/tests/lib/verify-list-output.sh
+++ b/tests/lib/verify-list-output.sh
@@ -247,3 +247,147 @@ _verify_osdtrace_list_multiosd_impl() {
     info "✓ osdtrace --list multi-OSD output verified"
     return 0
 }
+
+# ---------------------------------------------------------------------------
+# MicroCeph (snap) variants.
+#
+# MicroCeph runs every daemon snap-confined: each process lives in the snap's
+# own mount namespace with its libraries under /snap/microceph/<rev>/...,
+# which is a different resolution path than podman/docker containers.  These
+# verifiers assert what --list must get right for that snap path:
+#   - Container = yes               (the snap mount ns differs from the host's)
+#   - Traceable != "unknown"        ("unknown" means the ELF build-id could not
+#                                     be read through /proc/<pid>/root, i.e. the
+#                                     snap-namespace resolution failed - the bug
+#                                     these guard)
+#   - version exact-match only when Traceable=yes, so a MicroCeph release that
+#     has moved ahead of the embedded DWARF set (Traceable=no) does not make
+#     the test flaky.
+# ---------------------------------------------------------------------------
+
+# verify_osdtrace_list_microceph <binary> <expected_count> <expected_version>
+verify_osdtrace_list_microceph() {
+    local _xtrace=0
+    case $- in *x*) _xtrace=1; set +x;; esac
+    _verify_osdtrace_list_microceph_impl "$@"
+    local rc=$?
+    (( _xtrace == 1 )) && set -x
+    return $rc
+}
+
+_verify_osdtrace_list_microceph_impl() {
+    local binary=$1 expected_count=$2 expected_version=$3
+    local total=0 fail=0
+    local pid osd_id container traceable version
+    local -A seen_pid seen_id
+
+    while IFS='|' read -r pid osd_id container traceable version; do
+        [ -z "$pid" ] && continue
+        total=$((total + 1))
+
+        [ -z "${seen_pid[$pid]:-}" ] || {
+            err "osdtrace --list: PID $pid listed more than once"; fail=1; }
+        seen_pid[$pid]=1
+        [ -z "${seen_id[$osd_id]:-}" ] || {
+            err "osdtrace --list: OSD ID $osd_id listed more than once"; fail=1; }
+        seen_id[$osd_id]=1
+
+        kill -0 "$pid" 2>/dev/null || {
+            err "osdtrace --list: PID $pid (osd.$osd_id) not a live process"
+            fail=1; }
+        [ "$container" = "yes" ] || {
+            err "osdtrace --list: osd.$osd_id (pid $pid) Container=$container, expected yes (snap)"
+            fail=1; }
+        [ "$traceable" != "unknown" ] || {
+            err "osdtrace --list: osd.$osd_id (pid $pid) Traceable=unknown - build-id read through the snap namespace failed"
+            fail=1; }
+        if [ "$traceable" = "yes" ] && [ "$version" != "$expected_version" ]; then
+            err "osdtrace --list: osd.$osd_id traceable but version '$version' != '$expected_version'"
+            fail=1
+        fi
+    done < <(_osdtrace_list_rows "$binary")
+
+    info "osdtrace --list (microceph): total=$total expected=$expected_count"
+
+    [ "$total" -eq "$expected_count" ] || {
+        err "osdtrace --list: $total rows, expected $expected_count"; fail=1; }
+
+    local live
+    for live in $(pgrep -x ceph-osd 2>/dev/null); do
+        [ -n "${seen_pid[$live]:-}" ] || {
+            err "osdtrace --list: live ceph-osd PID $live not listed"; fail=1; }
+    done
+
+    if [ "$fail" -ne 0 ]; then
+        "$binary" --list 2>&1 || true
+        return 1
+    fi
+    info "✓ osdtrace --list (microceph) verified"
+    return 0
+}
+
+# verify_radostrace_list_microceph <binary> <client_pid> <expected_version>
+#
+# Asserts the snap-confined librados client <client_pid> (an rbd process) is
+# discovered, and that --list also surfaces the snap ceph daemons (mon/mgr/
+# mds), proving daemon discovery - not just the bench client.
+verify_radostrace_list_microceph() {
+    local _xtrace=0
+    case $- in *x*) _xtrace=1; set +x;; esac
+    _verify_radostrace_list_microceph_impl "$@"
+    local rc=$?
+    (( _xtrace == 1 )) && set -x
+    return $rc
+}
+
+_verify_radostrace_list_microceph_impl() {
+    local binary=$1 client_pid=$2 expected_version=$3
+    local total=0 fail=0 saw_client=0 saw_daemon=0
+    local pid container traceable version path base
+    local -A seen_pid
+
+    while IFS='|' read -r pid container traceable version path; do
+        [ -z "$pid" ] && continue
+        total=$((total + 1))
+        [ -z "${seen_pid[$pid]:-}" ] || {
+            err "radostrace --list: PID $pid listed more than once"; fail=1; }
+        seen_pid[$pid]=1
+        base=${path##*/}
+
+        if [ "$pid" = "$client_pid" ]; then
+            saw_client=1
+            [ "$container" = "yes" ] || {
+                err "rbd client $pid: Container=$container, expected yes (snap)"
+                fail=1; }
+            case "$path" in
+                /snap/*) ;;
+                *) err "rbd client $pid: path '$path' not under /snap (snap lib resolution?)"
+                   fail=1;;
+            esac
+            [ "$traceable" != "unknown" ] || {
+                err "rbd client $pid: Traceable=unknown - snap-namespace build-id read failed"
+                fail=1; }
+            if [ "$traceable" = "yes" ] && [ "$version" != "$expected_version" ]; then
+                err "rbd client $pid: traceable but version '$version' != '$expected_version'"
+                fail=1
+            fi
+        fi
+        case "$base" in
+            ceph-mon|ceph-mgr|ceph-mds) saw_daemon=1 ;;
+        esac
+    done < <(_radostrace_list_rows "$binary")
+
+    info "radostrace --list (microceph): total=$total client=$saw_client daemons=$saw_daemon"
+
+    [ "$saw_client" -eq 1 ] || {
+        err "radostrace --list: snap rbd client pid $client_pid not listed"; fail=1; }
+    [ "$saw_daemon" -eq 1 ] || {
+        err "radostrace --list: no snap ceph-mon/mgr/mds daemon listed"; fail=1; }
+
+    if [ "$fail" -ne 0 ]; then
+        "$binary" --list 2>&1 || true
+        return 1
+    fi
+    info "✓ radostrace --list (microceph) verified"
+    return 0
+}


### PR DESCRIPTION
## Summary

`--list` was covered in CI only on **cephadm** (containers, PR #139). The **MicroCeph** functional job ran `--id`/`-p` but never `--list` — leaving the **snap path** of `--list` untested. That path is distinct from containers in exactly the code `--list` relies on:
- the `Container`/`Traceable` columns come from mount-namespace comparison + an ELF build-id read through `/proc/<pid>/root`
- snap-confined daemons load their libraries from `/snap/microceph/<rev>/...`, a different resolution than podman/docker

## What's added

Two snap-tailored verifiers in `tests/lib/verify-list-output.sh` (the existing cephadm ones hard-assert radosgw/mon/mgr + `Traceable=yes`, which don't fit a snap host), wired into `functional-test-microceph.sh`:

- **Step 4b — `osdtrace --list`**: discovers all 3 snap-confined OSDs (distinct IDs, live PIDs covering every `ceph-osd`), each `Container=yes` (snap mount ns)
- **Step 8b — `radostrace --list`** (run while the bench client is alive): discovers the snap `rbd` client **and** the snap `ceph-mon/mgr/mds` daemons; the client is `Container=yes` with libraries under `/snap/microceph/...`

### Robustness

Both assert `Traceable != "unknown"` — an "unknown" verdict means the build-id read **through the snap namespace** failed, which is precisely the snap-path regression these guard. The exact Ceph version is pinned only when `Traceable=yes`, so a MicroCeph release that has moved ahead of the embedded DWARF set (`Traceable=no`) won't make the test flaky.

## Verification

Validated on a **real squid 19.2.3 MicroCeph cluster** (3 OSDs) in a fresh VM. The full `functional-test-microceph.sh` ran and both new steps passed:

```
INFO: osdtrace --list (microceph): total=3 expected=3
INFO: ✓ osdtrace --list (microceph) verified
INFO: radostrace --list (microceph): total=4 client=1 daemons=1
INFO: ✓ radostrace --list (microceph) verified
```

(observed real output: snap OSDs and mon/mgr/mds/rbd all `Container=yes`, `Traceable=yes`, version `19.2.3-0ubuntu0.24.04.3`, paths under `/snap/microceph/1735/bin/`.)

shellcheck-clean. CI runs the full microceph test with the standard 3G OSDs end-to-end.