### PR TITLE
tests/cephadm: accept a version-number release arg in the --list check

### DIFF
--- a/tests/functional-test-cephadm-rgw.sh
+++ b/tests/functional-test-cephadm-rgw.sh
@@ -263,14 +263,17 @@ info "=== Step 10b: verify --list output over a multi-client host ==="
 # a native client (Container=no, version = the host package).
 apt-get install -y -q ceph-common
 
-# quincy=17 reef=18 squid=19 tentacle=20: the containerized rows must all
-# report a version of this major.
+# The argument is a release name from PR CI (quincy/reef/squid/tentacle) but a
+# bare version number from the embedded-DWARF refresh bot (e.g. "20.2.2", with
+# CEPH_IMAGE pinned).  Map either form to the expected Ceph major - the
+# containerized rows must all report a version of this major.
 case "$CEPH_RELEASE" in
     quincy)   EXPECTED_MAJOR=17 ;;
     reef)     EXPECTED_MAJOR=18 ;;
     squid)    EXPECTED_MAJOR=19 ;;
     tentacle) EXPECTED_MAJOR=20 ;;
-    *) err "unknown release $CEPH_RELEASE"; exit 1 ;;
+    [0-9]*)   EXPECTED_MAJOR=$(_version_major "$CEPH_RELEASE") ;;  # 20.2.2 -> 20
+    *) err "unknown release '$CEPH_RELEASE'"; exit 1 ;;
 esac
 
 cephadm shell --fsid "$FSID" -- ceph osd pool create list-test 8 >>"$WORKLOAD_LOG" 2>&1


### PR DESCRIPTION
## Summary

Fixes a regression that breaks the **embedded-DWARF refresh bot** on every new Ceph point release.

`functional-test-cephadm-rgw.sh` is invoked with its first arg in two conventions:
- **PR CI** (`pr-build.yaml`) passes a release **name** — `quincy|reef|squid|tentacle`
- **the refresh bot** (`refresh-embedded-dwarf.yaml`) passes a bare **version number** — e.g. `20.2.2`, with `CEPH_IMAGE` pinned

The `EXPECTED_MAJOR` mapping added for the `--list` verification (PR #139) only handled the four names, so a version-number arg fell through to the default branch and aborted the verify job:

```
INFO: === Step 10b: verify --list output over a multi-client host ===
ERROR: unknown release 20.2.2
```

(Observed in [refresh run 27670101850, job `verify (20.2.2)`](https://github.com/taodd/cephtrace/actions/runs/27670101850/job/81835953396).)

### Why it hits every new release, never old ones
The refresh bot's `verify` job runs a **dynamic matrix of only the just-generated versions** — i.e. releases *missing* embedded DWARF (brand-new point releases). Those are always passed as **version numbers**. Old releases (e.g. 20.2.1) already have DWARF, so they never enter the matrix. So this isn't version-specific — it breaks for *every* future release until fixed.

## Fix

Add a numeric `case` arm that derives the major via the existing `_version_major` helper (the exact extraction the verifier already applies to `--list` output), so both arg forms map correctly:

```
20.2.2 -> 20,   19.2.3 -> 19,   2:19.2.3-0.el9 -> 19
```

A non-matching arg still errors out.

## Verification

Unit-tested the mapping for every form:

| arg | EXPECTED_MAJOR |
|---|---|
| quincy / reef / squid / tentacle | 17 / 18 / 19 / 20 |
| 20.2.2 / 19.2.3 / 17.2.9 | 20 / 19 / 17 |
| 2:19.2.3-0.el9 | 19 |
| bogus | rejected (exit 1) |

No new shellcheck findings (the only notes are pre-existing SC1091/SC2317/SC2015, none on the changed lines). The `--list` verification logic itself is unchanged — this only fixes how its expected major is derived from the input.