### PR TITLE
Support 26.04 amd64v3 and recover parameters from degraded DWARF

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-latest]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, ubuntu-latest]
     steps:
       - name: Checkout code and submodules
         uses: actions/checkout@v4

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -45,6 +45,55 @@ jobs:
       - name: Functional test - radostrace tracing a qemu VM on an RBD disk
         run: sudo ./tests/functional-test-qemu-rbd.sh
 
+  # 26.04 ships ceph-osd as baseline amd64 and an amd64v3 variant; the hosted
+  # runner opts the latter in by default.  Run dwarf-compare against each,
+  # forcing the variant via the apt config (the -o override does not work) and
+  # asserting the resolved .deb so a wrong variant fails loudly instead of
+  # comparing against the wrong reference.
+  dwarf-compare-ubuntu-2604:
+    name: build-ubuntu-cephadm (ubuntu-26.04, ${{ matrix.release }}, ${{ matrix.variant }})
+    runs-on: ubuntu-26.04
+    strategy:
+      fail-fast: false
+      matrix:
+        release: [tentacle]
+        variant: [baseline, amd64v3]
+    steps:
+      - name: Checkout code and submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install build dependencies
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y g++ clang libelf-dev libc6-dev-i386 libdw-dev python3
+
+      - name: Run Makefile build
+        run: make -j all
+
+      - name: Select ceph architecture variant and assert
+        run: |
+            if [ "${{ matrix.variant }}" = amd64v3 ]; then
+                echo 'APT::Architecture-Variants "amd64v3";' | \
+                    sudo tee /etc/apt/apt.conf.d/99cephtrace-variant
+                expect=_amd64v3.deb
+            else
+                # Drop the runner image's amd64v3 opt-in -> baseline amd64.
+                sudo grep -rl 'Architecture-Variants' /etc/apt/ 2>/dev/null | \
+                    sudo xargs -r rm -f
+                expect=_amd64.deb
+            fi
+            sudo apt-get update
+            got=$(apt-get install --print-uris -y ceph-osd | \
+                  grep -oE '_amd64(v3)?\.deb' | head -1)
+            echo "variant=${{ matrix.variant }} expect=$expect got=$got"
+            [ "$got" = "$expect" ] || { echo "::error::ceph-osd resolved to $got, expected $expect for ${{ matrix.variant }}"; exit 1; }
+
+      - name: Unit test - verify dwarf output is consistent (${{ matrix.variant }})
+        run: ./tests/dwarf-compare.sh
+
   build-ubuntu-cephadm:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,17 +10,13 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ['3.8', '3.10', '3.12']
-        os: [ubuntu-22.04, ubuntu-24.04]
-        exclude:
+        include:
           - os: ubuntu-22.04
-            python-version: '3.8'
-          - os: ubuntu-22.04
-            python-version: '3.12'
-          - os: ubuntu-24.04
-            python-version: '3.8'
-          - os: ubuntu-24.04
             python-version: '3.10'
+          - os: ubuntu-24.04
+            python-version: '3.12'
+          - os: ubuntu-26.04
+            python-version: '3.14'
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/doc/dwarf-json-files.md
+++ b/doc/dwarf-json-files.md
@@ -75,6 +75,7 @@ Available versions include:
 - Ubuntu 20.04: Ceph 15.2.17, 17.2.x series
 - Ubuntu 22.04: Ceph 17.2.x, 19.2.x series
 - Ubuntu 24.04: Ceph 19.2.x series
+- Ubuntu 26.04: Ceph 20.x series
 
 File naming format: `<version>_dwarf.json`
 - Example: `17.2.6-0ubuntu0.22.04.2_dwarf.json`

--- a/files/ubuntu/osdtrace/osd-20.2.0-0ubuntu2_amd64v3_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-20.2.0-0ubuntu2_amd64v3_dwarf.json
@@ -1,0 +1,1295 @@
+{
+  "version": "20.2.0-0ubuntu2",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "20bbaa35a85fc9fad7534f286a7087f81cc35074",
+    "func2pc": {
+      "BlueStore::_do_write": 15689168,
+      "BlueStore::_txc_apply_kv": 15260720,
+      "BlueStore::_txc_calc_cost": 15783056,
+      "BlueStore::_txc_state_proc": 15473408,
+      "BlueStore::_wctx_finish": 15461328,
+      "BlueStore::log_latency": 15991728,
+      "BlueStore::log_latency_fn": 15992512,
+      "BlueStore::queue_transactions": 15783664,
+      "ECBackend::submit_transaction": 13522672,
+      "OSD::dequeue_op": 8814848,
+      "OSD::enqueue_op": 8886928,
+      "OpRequest::mark_flag_point": 21325232,
+      "OpRequest::mark_flag_point_string": 21325648,
+      "PrimaryLogPG::execute_ctx": 10560928,
+      "PrimaryLogPG::log_op_stats": 10142560,
+      "ReplicatedBackend::do_repop_reply": 11072736,
+      "ReplicatedBackend::generate_subop": 11047760,
+      "ReplicatedBackend::repop_commit": 11084096
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 764,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 320,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 640,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 320,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 640,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 764,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 456,
+                "pointer": true
+              },
+              {
+                "offset": 160,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 320,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 640,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/files/ubuntu/osdtrace/osd-20.2.0-0ubuntu2_amd64v3_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-20.2.0-0ubuntu2_amd64v3_dwarf.json
@@ -21,7 +21,8 @@
       "PrimaryLogPG::log_op_stats": 10142560,
       "ReplicatedBackend::do_repop_reply": 11072736,
       "ReplicatedBackend::generate_subop": 11047760,
-      "ReplicatedBackend::repop_commit": 11084096
+      "ReplicatedBackend::repop_commit": 11084096,
+      "ReplicatedBackend::submit_transaction": 11068640
     },
     "func2vf": {
       "BlueStore::_do_write": {
@@ -1284,6 +1285,48 @@
               },
               {
                 "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/radostrace/20.2.0-0ubuntu2_amd64v3_dwarf.json
+++ b/files/ubuntu/radostrace/20.2.0-0ubuntu2_amd64v3_dwarf.json
@@ -1,0 +1,388 @@
+{
+  "version": "20.2.0-0ubuntu2",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "23210fa68b1390b171725207eae4eb202e0ecf4e",
+    "func2pc": {
+      "Objecter::_finish_op": 9960176,
+      "Objecter::_send_op": 9897728
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/dwarf_parser.cc
+++ b/src/dwarf_parser.cc
@@ -611,6 +611,94 @@ bool DwarfParser::recover_param_location_from_abi(Dwarf_Die *func,
   return false;
 }
 
+// LTO represents a function as an address-less abstract subprogram plus one or
+// more out-of-line concrete instances (with DW_AT_ranges and parameter location
+// lists) linked by DW_AT_abstract_origin.  Index the concretes by their abstract
+// origin so handle_function can read real locations from them when it reaches
+// the address-less abstract.
+void DwarfParser::index_concrete_instances(Dwarf *dw) {
+  Dwarf_Off offset = 0, next_offset;
+  size_t header_size;
+  Dwarf_Die cu_die;
+
+  while (dwarf_nextcu(dw, offset, &next_offset, &header_size, NULL, NULL,
+                      NULL) == 0) {
+    if (dwarf_offdie(dw, offset + header_size, &cu_die) != NULL) {
+      Dwarf_Die child;
+      if (dwarf_child(&cu_die, &child) == 0) {
+        do {
+          if (dwarf_tag(&child) != DW_TAG_subprogram) continue;
+          if (!dwarf_hasattr(&child, DW_AT_abstract_origin)) continue;
+          if (!dwarf_hasattr(&child, DW_AT_low_pc) &&
+              !dwarf_hasattr(&child, DW_AT_ranges))
+            continue;
+
+          Dwarf_Attribute ao_mem;
+          Dwarf_Attribute *ao_attr =
+              dwarf_attr_integrate(&child, DW_AT_abstract_origin, &ao_mem);
+          Dwarf_Die ao;
+          if (ao_attr != NULL && dwarf_formref_die(ao_attr, &ao) != NULL)
+            abstract_to_concrete[dwarf_dieoffset(&ao)].push_back(child);
+        } while (dwarf_siblingof(&child, &child) == 0);
+      }
+    }
+    offset = next_offset;
+  }
+}
+
+// LTO can emit several concrete instances (and cold-split fragments) for one
+// abstract function, so pick the one whose address ranges contain the entry PC.
+bool DwarfParser::select_concrete_instance(Dwarf_Off abstract_off, Dwarf_Addr pc,
+                                           Dwarf_Die &out) {
+  auto it = abstract_to_concrete.find(abstract_off);
+  if (it == abstract_to_concrete.end() || it->second.empty()) return false;
+  for (Dwarf_Die &c : it->second) {
+    if (dwarf_haspc(&c, pc) == 1) {
+      out = c;
+      return true;
+    }
+  }
+  out = it->second.front();
+  return true;
+}
+
+// Read a parameter's location from a concrete instance.  Its formal_parameter
+// children carry the real DW_AT_location (a loclist that, at the entry PC,
+// resolves to the incoming ABI slot); dwarf_diename resolves their name through
+// DW_AT_abstract_origin.
+bool DwarfParser::find_concrete_param_location(Dwarf_Die *concrete,
+                                               string symbol, Dwarf_Addr pc,
+                                               Dwarf_Die &vardie,
+                                               VarLocation &varloc) {
+  Dwarf_Die child;
+  if (dwarf_child(concrete, &child) != 0) return false;
+
+  do {
+    if (dwarf_tag(&child) != DW_TAG_formal_parameter) continue;
+
+    const char *name = dwarf_diename(&child);
+    if (name == NULL || symbol != name) continue;
+
+    Dwarf_Attribute loc_mem;
+    Dwarf_Attribute *loc = dwarf_attr_integrate(&child, DW_AT_location, &loc_mem);
+    if (loc == NULL) return false;
+
+    Dwarf_Op *expr;
+    size_t len;
+    if (dwarf_getlocation_addr(loc, pc, &expr, &len, 1) != 1 || len == 0)
+      return false;
+
+    Dwarf_Attribute fb_mem;
+    Dwarf_Attribute *fb = find_func_frame_base(concrete, &fb_mem);
+    if (!translate_expr(fb, expr, pc, varloc)) return false;
+
+    vardie = child;
+    return true;
+  } while (dwarf_siblingof(&child, &child) == 0);
+
+  return false;
+}
+
 Dwarf_Attribute *DwarfParser::find_func_frame_base(
     Dwarf_Die *func, Dwarf_Attribute *fb_attr_mem) {
   assert(dwarf_tag(func) == DW_TAG_subprogram);
@@ -966,14 +1054,23 @@ static int handle_function(Dwarf_Die *die, void *data) {
   // TODO need to check if the class name matches
   Dwarf_Addr pc;
   bool pc_recovered_from_symbol = false;
+  bool use_concrete = false;
+  Dwarf_Die concrete;
   if (!dp->find_prologue(die, pc)) {
-    // LTO optimization will not generate the low_pc/high_pc/ranges for the
-    // abstract function.  If the concrete function still exists in the ELF
-    // symbol table, the symbol value is the exact uprobe entry PC.
+    // LTO leaves the abstract instance without addresses.  The ELF symbol value
+    // is the real entry PC (the uprobe point); read the concrete instance's
+    // location lists at it, where the frame base (call_frame_cfa) is rsp+8 so
+    // they resolve to the incoming ABI slots.  Pick the concrete whose ranges
+    // contain that PC; fall back to ABI reconstruction when none exists.
     if (!dp->lookup_function_symbol_pc(fullname, pc)) {
       return 0;
     }
-    pc_recovered_from_symbol = true;
+    if (dp->select_concrete_instance(dwarf_dieoffset(&func_abstract), pc,
+                                     concrete)) {
+      use_concrete = true;
+    } else {
+      pc_recovered_from_symbol = true;
+    }
   }
   auto arr = dp->probes[fullname];
   if (pc_recovered_from_symbol) {
@@ -1000,8 +1097,14 @@ static int handle_function(Dwarf_Die *die, void *data) {
     string varname = arr[i][0];
     Dwarf_Die vardie, typedie;
     VarLocation varloc;
-    bool ok = dp->translate_param_location(die, varname, pc, vardie, varloc);
+    bool ok = use_concrete
+                  ? dp->find_concrete_param_location(&concrete, varname, pc,
+                                                     vardie, varloc)
+                  : dp->translate_param_location(die, varname, pc, vardie,
+                                                 varloc);
     if (!ok) {
+      // The concrete location list (or the abstract's own location) may have no
+      // entry at the entry PC; reconstruct the incoming ABI slot in that case.
       Dwarf_Die retry_vardie;
       if (dp->find_param(die, varname, retry_vardie)) {
         vardie = retry_vardie;
@@ -1235,6 +1338,9 @@ static int handle_module(Dwfl_Module *dwflmod, void **userdata,
   Dwarf_Off next_offset;
   size_t header_size;
   Dwarf_Die cu_die;
+
+  dp->abstract_to_concrete.clear();
+  dp->index_concrete_instances(dwarf);
 
   while (dwarf_nextcu(dwarf, offset, &next_offset, &header_size, nullptr,
                       nullptr, nullptr) == 0) {

--- a/src/dwarf_parser.cc
+++ b/src/dwarf_parser.cc
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <cstring>
 #include <ctime>
+#include <cxxabi.h>
 #include <iostream>
 #include <map>
 #include <set>
@@ -24,6 +25,8 @@ extern "C" {
 #include <elfutils/libdw.h>
 #include <elfutils/libdwfl.h>
 #include <fcntl.h>
+#include <gelf.h>
+#include <libelf.h>
 #include <unistd.h>
 #include <stdlib.h>
 }
@@ -34,6 +37,234 @@ extern "C" {
 #include "version_utils.h"
 
 using namespace std;
+
+static const int x86_64_dwarf_rsp = 7;
+static const int x86_64_integer_arg_regs[] = {5, 4, 1, 2, 8, 9};
+
+enum x86_64_abi_class {
+  X86_64_ABI_INTEGER,
+  X86_64_ABI_MEMORY,
+};
+
+struct x86_64_abi_param {
+  enum x86_64_abi_class cls;
+  int stack_size;
+};
+
+static int align_up(int value, int align) {
+  return (value + align - 1) & ~(align - 1);
+}
+
+static bool die_type(Dwarf_Die *die, Dwarf_Die &typedie) {
+  Dwarf_Attribute attr_mem;
+  Dwarf_Attribute *attr = dwarf_attr_integrate(die, DW_AT_type, &attr_mem);
+  return attr != NULL && dwarf_formref_die(attr, &typedie) != NULL;
+}
+
+static bool strip_type_modifiers(Dwarf_Die &die) {
+  while (true) {
+    switch (dwarf_tag(&die)) {
+      case DW_TAG_typedef:
+      case DW_TAG_const_type:
+      case DW_TAG_volatile_type:
+      case DW_TAG_restrict_type: {
+        Dwarf_Die referent;
+        if (!die_type(&die, referent)) return false;
+        die = referent;
+        break;
+      }
+      default:
+        return true;
+    }
+  }
+}
+
+static bool param_type(Dwarf_Die *param, Dwarf_Die &type,
+                       const char *want_name, bool &name_matched) {
+  if (!die_type(param, type)) return false;
+  name_matched = false;
+
+  while (true) {
+    const char *name = dwarf_diename(&type);
+    if (name != NULL && strcmp(name, want_name) == 0)
+      name_matched = true;
+
+    switch (dwarf_tag(&type)) {
+      case DW_TAG_typedef:
+      case DW_TAG_const_type:
+      case DW_TAG_volatile_type:
+      case DW_TAG_restrict_type: {
+        Dwarf_Die referent;
+        if (!die_type(&type, referent)) return false;
+        type = referent;
+        break;
+      }
+      default:
+        return true;
+    }
+  }
+}
+
+static bool data_member_offset(Dwarf_Die *member_die, int &offset) {
+  Dwarf_Attribute attr;
+  if (dwarf_attr_integrate(member_die, DW_AT_data_member_location, &attr) ==
+      NULL)
+    return false;
+
+  Dwarf_Word udata;
+  if (dwarf_formudata(&attr, &udata) == 0) {
+    offset = (int)udata;
+    return true;
+  }
+
+  Dwarf_Sword sdata;
+  if (dwarf_formsdata(&attr, &sdata) == 0) {
+    offset = (int)sdata;
+    return true;
+  }
+
+  return false;
+}
+
+static bool find_direct_member(Dwarf_Die *type, const char *want_name,
+                               Dwarf_Die &member_die, int &offset) {
+  Dwarf_Die child;
+  if (dwarf_child(type, &child) != 0) return false;
+
+  do {
+    if (dwarf_tag(&child) != DW_TAG_member)
+      continue;
+
+    const char *name = dwarf_diename(&child);
+    if (name == NULL || strcmp(name, want_name) != 0)
+      continue;
+
+    if (!data_member_offset(&child, offset))
+      return false;
+
+    member_die = child;
+    return true;
+  } while (dwarf_siblingof(&child, &child) == 0);
+
+  return false;
+}
+
+static bool osd_reqid_type_layout_ok(Dwarf_Die *type) {
+  int64_t bytes = dwarf_bytesize(type);
+  if (bytes != 32) return false;
+
+  Dwarf_Die name_member, tid_member;
+  int name_offset, tid_offset;
+  if (!find_direct_member(type, "name", name_member, name_offset) ||
+      name_offset != 0)
+    return false;
+  if (!find_direct_member(type, "tid", tid_member, tid_offset) ||
+      tid_offset != 16)
+    return false;
+
+  Dwarf_Die name_type;
+  if (!die_type(&name_member, name_type)) return false;
+  if (!strip_type_modifiers(name_type)) return false;
+
+  Dwarf_Die num_member;
+  int num_offset;
+  return find_direct_member(&name_type, "_num", num_member, num_offset) &&
+         num_offset == 8;
+}
+
+static bool classify_x86_64_abi_param(Dwarf_Die *param,
+                                      struct x86_64_abi_param &abi_param) {
+  Dwarf_Die type;
+  bool is_osd_reqid = false;
+  if (!param_type(param, type, "osd_reqid_t", is_osd_reqid)) return false;
+
+  switch (dwarf_tag(&type)) {
+    case DW_TAG_pointer_type:
+    case DW_TAG_reference_type:
+    case DW_TAG_rvalue_reference_type:
+      abi_param.cls = X86_64_ABI_INTEGER;
+      abi_param.stack_size = 8;
+      return true;
+
+    case DW_TAG_base_type:
+    case DW_TAG_enumeration_type: {
+      int64_t bytes = dwarf_bytesize(&type);
+      if (bytes <= 0 || bytes > 8) return false;
+      abi_param.cls = X86_64_ABI_INTEGER;
+      abi_param.stack_size = 8;
+      return true;
+    }
+
+    case DW_TAG_structure_type:
+    case DW_TAG_union_type:
+    case DW_TAG_class_type: {
+      int64_t bytes = dwarf_bytesize(&type);
+      if (bytes <= 0) return false;
+
+      // VarLocation can represent one base register or stack address only.
+      // Only recover Ceph's request id aggregate after proving the exact
+      // DWARF type and member layout used by osdtrace's JSON fields.
+      if (!is_osd_reqid || !osd_reqid_type_layout_ok(&type)) return false;
+
+      abi_param.cls = X86_64_ABI_MEMORY;
+      abi_param.stack_size = align_up((int)bytes, 8);
+      return true;
+    }
+
+    default:
+      return false;
+  }
+}
+
+static bool function_return_may_use_x86_64_memory_pointer(Dwarf_Die *func) {
+  Dwarf_Die type;
+  if (!die_type(func, type)) return false;
+  if (!strip_type_modifiers(type)) return true;
+
+  switch (dwarf_tag(&type)) {
+    case DW_TAG_pointer_type:
+    case DW_TAG_reference_type:
+    case DW_TAG_rvalue_reference_type:
+    case DW_TAG_base_type:
+    case DW_TAG_enumeration_type:
+      return false;
+
+    case DW_TAG_structure_type:
+    case DW_TAG_union_type:
+    case DW_TAG_class_type:
+      // Non-trivial C++ aggregate returns may be implemented with a hidden
+      // sret pointer.  DWARF type size alone is not enough to prove they do
+      // not shift the visible argument registers, so do not recover here.
+      return true;
+
+    default:
+      return true;
+  }
+}
+
+static string demangle_symbol(const char *name) {
+  int status = 0;
+  char *demangled = abi::__cxa_demangle(name, NULL, NULL, &status);
+  if (status == 0 && demangled != NULL) {
+    string result(demangled);
+    free(demangled);
+    return result;
+  }
+  free(demangled);
+  return name ?: "";
+}
+
+static string demangled_function_base(string name) {
+  const string thunk_prefix = "non-virtual thunk to ";
+  if (name.rfind(thunk_prefix, 0) == 0) return "";
+
+  size_t clone = name.find(" [clone ");
+  if (clone != string::npos) return "";
+
+  size_t paren = name.find('(');
+  if (paren != string::npos) name.resize(paren);
+  return name;
+}
 
 bool DwarfParser::die_has_loclist(Dwarf_Die *begin_die) {
   Dwarf_Die die;
@@ -205,7 +436,174 @@ bool DwarfParser::find_param(Dwarf_Die *func, string symbol,
   // dwarf_getscopevar: returns a non-negative scope index on success, -1 on
   // error or -2 when no matching variable exists.  On failure it leaves
   // vardie untouched, so the caller must not use it.
-  return dwarf_getscopevar(func, 1, symbol.c_str(), 0, NULL, 0, 0, &vardie) >= 0;
+  if (dwarf_getscopevar(func, 1, symbol.c_str(), 0, NULL, 0, 0, &vardie) >= 0)
+    return true;
+
+  // Some C++ debug info represents the implicit object parameter through
+  // DW_AT_object_pointer instead of a normal name lookup for "this".
+  if (symbol == "this") {
+    Dwarf_Attribute attr_mem;
+    Dwarf_Attribute *attr = dwarf_attr_integrate(func, DW_AT_object_pointer,
+                                                 &attr_mem);
+    if (attr != NULL && dwarf_formref_die(attr, &vardie) != NULL)
+      return true;
+  }
+
+  return false;
+}
+
+bool DwarfParser::current_module_is_x86_64() {
+  if (cur_mod == NULL) return false;
+
+  GElf_Addr bias = 0;
+  Elf *elf = dwfl_module_getelf(cur_mod, &bias);
+  if (elf == NULL) return false;
+
+  GElf_Ehdr ehdr;
+  if (gelf_getehdr(elf, &ehdr) == NULL) return false;
+
+  return ehdr.e_machine == EM_X86_64;
+}
+
+bool DwarfParser::lookup_function_symbol_pc(string fullname, Dwarf_Addr &pc) {
+  if (cur_mod == NULL) return false;
+
+  GElf_Addr bias = 0;
+  Elf *elf = dwfl_module_getelf(cur_mod, &bias);
+  if (elf == NULL) return false;
+
+  bool found = false;
+  Dwarf_Addr found_pc = 0;
+  Elf_Scn *scn = NULL;
+  while ((scn = elf_nextscn(elf, scn)) != NULL) {
+    GElf_Shdr shdr;
+    if (gelf_getshdr(scn, &shdr) == NULL) continue;
+    if (shdr.sh_type != SHT_SYMTAB && shdr.sh_type != SHT_DYNSYM)
+      continue;
+    if (shdr.sh_entsize == 0) continue;
+
+    Elf_Data *data = NULL;
+    while ((data = elf_getdata(scn, data)) != NULL) {
+      size_t symbols = data->d_size / shdr.sh_entsize;
+      for (size_t i = 0; i < symbols; ++i) {
+        GElf_Sym sym;
+        if (gelf_getsym(data, i, &sym) == NULL) continue;
+        if (GELF_ST_TYPE(sym.st_info) != STT_FUNC || sym.st_value == 0)
+          continue;
+
+        const char *raw_name = elf_strptr(elf, shdr.sh_link, sym.st_name);
+        if (raw_name == NULL) continue;
+
+        string demangled = demangle_symbol(raw_name);
+        string base = demangled_function_base(demangled);
+        if (raw_name != fullname && base != fullname) continue;
+
+        Dwarf_Addr sym_pc = sym.st_value + bias;
+        if (found && found_pc != sym_pc) {
+          cerr << "Ambiguous ELF symbols for function " << fullname << endl;
+          return false;
+        }
+
+        found = true;
+        found_pc = sym_pc;
+      }
+    }
+  }
+
+  if (!found) return false;
+
+  pc = found_pc;
+  cerr << "Recovered entry PC for " << fullname
+       << " from ELF symbol table: " << pc << endl;
+  return true;
+}
+
+bool DwarfParser::recover_param_location_from_abi(Dwarf_Die *func,
+                                                  string symbol,
+                                                  Dwarf_Addr pc,
+                                                  Dwarf_Die &vardie,
+                                                  VarLocation &varloc) {
+  if (!current_module_is_x86_64()) {
+    return false;
+  }
+
+  Dwarf_Addr entrypc;
+  if (func_entrypc(func, &entrypc) && pc != entrypc) {
+    cerr << "Cannot recover parameter " << symbol
+         << " from entry ABI because probe PC is not function entry" << endl;
+    return false;
+  }
+
+  if (function_return_may_use_x86_64_memory_pointer(func)) {
+    cerr << "Cannot recover parameter " << symbol
+         << " from ABI because function may use a hidden return pointer"
+         << endl;
+    return false;
+  }
+
+  Dwarf_Off target_off = dwarf_dieoffset(&vardie);
+  int gpr_idx = 0;
+  int stack_offset = 8;  // entry %rsp points at the return address.
+
+  Dwarf_Die child;
+  if (dwarf_child(func, &child) != 0) return false;
+
+  do {
+    if (dwarf_tag(&child) != DW_TAG_formal_parameter)
+      continue;
+
+    struct x86_64_abi_param abi_param;
+    if (!classify_x86_64_abi_param(&child, abi_param)) {
+      const char *name = dwarf_diename(&child);
+      cerr << "Cannot classify x86_64 ABI location for parameter "
+           << (name ?: "<anonymous>") << endl;
+      return false;
+    }
+
+    VarLocation candidate;
+    if (abi_param.cls == X86_64_ABI_INTEGER) {
+      if (gpr_idx < (int)(sizeof(x86_64_integer_arg_regs) /
+                         sizeof(x86_64_integer_arg_regs[0]))) {
+        candidate.reg = x86_64_integer_arg_regs[gpr_idx];
+        candidate.offset = 0;
+        candidate.stack = false;
+      } else {
+        candidate.reg = x86_64_dwarf_rsp;
+        candidate.offset = stack_offset;
+        candidate.stack = true;
+      }
+    } else {
+      stack_offset = align_up(stack_offset, 8);
+      candidate.reg = x86_64_dwarf_rsp;
+      candidate.offset = stack_offset;
+      candidate.stack = true;
+    }
+
+    const char *name = dwarf_diename(&child);
+    bool is_target = dwarf_dieoffset(&child) == target_off ||
+                     (name != NULL && symbol == name);
+    if (is_target) {
+      varloc = candidate;
+      cerr << "Recovered location for parameter " << symbol
+           << " from x86_64 SysV entry ABI: register " << varloc.reg
+           << " offset " << varloc.offset << " stack " << varloc.stack
+           << endl;
+      return true;
+    }
+
+    if (abi_param.cls == X86_64_ABI_INTEGER) {
+      if (gpr_idx < (int)(sizeof(x86_64_integer_arg_regs) /
+                         sizeof(x86_64_integer_arg_regs[0]))) {
+        ++gpr_idx;
+      } else {
+        stack_offset += 8;
+      }
+    } else {
+      stack_offset += abi_param.stack_size;
+    }
+  } while (dwarf_siblingof(&child, &child) == 0);
+
+  return false;
 }
 
 Dwarf_Attribute *DwarfParser::find_func_frame_base(
@@ -366,6 +764,33 @@ bool DwarfParser::find_class_member(Dwarf_Die *vardie, Dwarf_Die *typedie,
   return false;
 }
 
+bool DwarfParser::translate_data_member_location(Dwarf_Attribute *attr,
+                                                 Dwarf_Addr pc,
+                                                 int &offset) {
+  Dwarf_Word udata;
+  if (dwarf_formudata(attr, &udata) == 0) {
+    offset = (int)udata;
+    return true;
+  }
+
+  Dwarf_Sword sdata;
+  if (dwarf_formsdata(attr, &sdata) == 0) {
+    offset = (int)sdata;
+    return true;
+  }
+
+  Dwarf_Op *expr;
+  size_t len;
+  if (dwarf_getlocation_addr(attr, pc, &expr, &len, 1) != 1 || len == 0) {
+    return false;
+  }
+
+  VarLocation varloc;
+  if (!translate_expr(NULL, expr, pc, varloc)) return false;
+  offset = varloc.offset;
+  return true;
+}
+
 bool DwarfParser::translate_fields(Dwarf_Die *vardie, Dwarf_Die *typedie,
                                    Dwarf_Addr pc, vector<string> fields,
                                    vector<Field> &res) {
@@ -419,18 +844,12 @@ bool DwarfParser::translate_fields(Dwarf_Die *vardie, Dwarf_Die *typedie,
           clog << "failed to find member location for " << fields[i] << endl;
           return false;
         }
-        Dwarf_Op *expr;
-        size_t len;
-        if (dwarf_getlocation_addr(&attr, pc, &expr, &len, 1) != 1 || len == 0) {
+        int member_offset = 0;
+        if (!translate_data_member_location(&attr, pc, member_offset)) {
           clog << "failed to get location of attr for " << fields[i] << endl;
           return false;
         }
-        VarLocation varloc;
-        if (!translate_expr(NULL, expr, pc, varloc)) {
-          clog << "failed to translate location of " << fields[i] << endl;
-          return false;
-        }
-        res[i].offset = varloc.offset;
+        res[i].offset = member_offset;
 
         dwarf_die_type(vardie, typedie);
         ++i;
@@ -541,16 +960,35 @@ static int handle_function(Dwarf_Die *die, void *data) {
 
   // TODO need to check if the class name matches
   Dwarf_Addr pc;
+  bool pc_recovered_from_symbol = false;
   if (!dp->find_prologue(die, pc)) {
-    // LTO optimization will not generate the low_pc/high_pc/rangs for the abstract function
-    return 0;
+    // LTO optimization will not generate the low_pc/high_pc/ranges for the
+    // abstract function.  If the concrete function still exists in the ELF
+    // symbol table, the symbol value is the exact uprobe entry PC.
+    if (!dp->lookup_function_symbol_pc(fullname, pc)) {
+      return 0;
+    }
+    pc_recovered_from_symbol = true;
+  }
+  auto arr = dp->probes[fullname];
+  if (pc_recovered_from_symbol) {
+    for (int i = 0; i < (int)arr.size(); ++i) {
+      if (arr[i].empty()) continue;
+
+      Dwarf_Die vardie;
+      if (!dp->find_param(die, arr[i][0], vardie)) {
+        cerr << "Skipping " << fullname
+             << " after ELF symbol PC recovery because parameter "
+             << arr[i][0] << " is not available in this DIE" << endl;
+        return 0;
+      }
+    }
   }
   auto &func2pc = dp->mod_func2pc[dp->cur_mod_name];
   func2pc[fullname] = pc;
 
   auto &func2vf = dp->mod_func2vf[dp->cur_mod_name];
   auto &vf = func2vf[fullname];
-  auto arr = dp->probes[fullname];
   vf.resize(arr.size());
 
   for (int i = 0; i < (int)arr.size(); ++i) {
@@ -558,6 +996,14 @@ static int handle_function(Dwarf_Die *die, void *data) {
     Dwarf_Die vardie, typedie;
     VarLocation varloc;
     bool ok = dp->translate_param_location(die, varname, pc, vardie, varloc);
+    if (!ok) {
+      Dwarf_Die retry_vardie;
+      if (dp->find_param(die, varname, retry_vardie)) {
+        vardie = retry_vardie;
+        ok = dp->recover_param_location_from_abi(die, varname, pc, vardie,
+                                                 varloc);
+      }
+    }
     assert(ok);
     //printf("var %s location : register %d, offset %d, stack %d\n",
      //varname.c_str(), varloc.reg, varloc.offset, varloc.stack);

--- a/src/dwarf_parser.cc
+++ b/src/dwarf_parser.cc
@@ -48,7 +48,8 @@ enum x86_64_abi_class {
 
 struct x86_64_abi_param {
   enum x86_64_abi_class cls;
-  int stack_size;
+  int int_regs;    // INTEGER class: number of GPRs the argument consumes (1 or 2).
+  int stack_size;  // bytes the argument consumes when it lands on the stack.
 };
 
 static int align_up(int value, int align) {
@@ -79,110 +80,98 @@ static bool strip_type_modifiers(Dwarf_Die &die) {
   }
 }
 
-static bool param_type(Dwarf_Die *param, Dwarf_Die &type,
-                       const char *want_name, bool &name_matched) {
-  if (!die_type(param, type)) return false;
-  name_matched = false;
-
-  while (true) {
-    const char *name = dwarf_diename(&type);
-    if (name != NULL && strcmp(name, want_name) == 0)
-      name_matched = true;
-
-    switch (dwarf_tag(&type)) {
-      case DW_TAG_typedef:
-      case DW_TAG_const_type:
-      case DW_TAG_volatile_type:
-      case DW_TAG_restrict_type: {
-        Dwarf_Die referent;
-        if (!die_type(&type, referent)) return false;
-        type = referent;
-        break;
-      }
-      default:
-        return true;
-    }
-  }
+static bool param_type(Dwarf_Die *param, Dwarf_Die &type) {
+  return die_type(param, type) && strip_type_modifiers(type);
 }
 
-static bool data_member_offset(Dwarf_Die *member_die, int &offset) {
-  Dwarf_Attribute attr;
-  if (dwarf_attr_integrate(member_die, DW_AT_data_member_location, &attr) ==
-      NULL)
-    return false;
-
-  Dwarf_Word udata;
-  if (dwarf_formudata(&attr, &udata) == 0) {
-    offset = (int)udata;
-    return true;
-  }
-
-  Dwarf_Sword sdata;
-  if (dwarf_formsdata(&attr, &sdata) == 0) {
-    offset = (int)sdata;
-    return true;
-  }
-
+// Non-trivially-copyable Standard Library types and Ceph smart pointers,
+// matched by their unqualified DW_AT_name prefix.
+static bool type_name_is_nontrivial(const char *name) {
+  static const char *const prefixes[] = {
+      "basic_string", "vector<", "map<", "multimap<", "set<", "multiset<",
+      "list<", "deque<", "unordered_map<", "unordered_multimap<",
+      "unordered_set<", "unordered_multiset<", "unique_ptr<", "shared_ptr<",
+      "weak_ptr<", "intrusive_ptr<"};
+  for (const char *p : prefixes)
+    if (strncmp(name, p, strlen(p)) == 0) return true;
   return false;
 }
 
-static bool find_direct_member(Dwarf_Die *type, const char *want_name,
-                               Dwarf_Die &member_die, int &offset) {
+// A class is passed by invisible reference (one hidden pointer in a single INTEGER
+// register) when it is not trivially copyable for the purpose of calls.  This build
+// omits DW_AT_calling_convention, so detect it structurally: the type itself is a
+// non-trivial Standard Library type, or it transitively holds a member that is.
+static bool type_passed_by_invisible_reference(Dwarf_Die *type, int depth) {
+  if (depth > 8) return false;
+
+  const char *name = dwarf_diename(type);
+  if (name != NULL && type_name_is_nontrivial(name)) return true;
+
+  int tag = dwarf_tag(type);
+  if (tag != DW_TAG_structure_type && tag != DW_TAG_class_type &&
+      tag != DW_TAG_union_type)
+    return false;
+
   Dwarf_Die child;
   if (dwarf_child(type, &child) != 0) return false;
-
   do {
-    if (dwarf_tag(&child) != DW_TAG_member)
-      continue;
-
-    const char *name = dwarf_diename(&child);
-    if (name == NULL || strcmp(name, want_name) != 0)
-      continue;
-
-    if (!data_member_offset(&child, offset))
-      return false;
-
-    member_die = child;
-    return true;
+    if (dwarf_tag(&child) != DW_TAG_member) continue;
+    Dwarf_Die mt;
+    if (!die_type(&child, mt) || !strip_type_modifiers(mt)) continue;
+    if (type_passed_by_invisible_reference(&mt, depth + 1)) return true;
   } while (dwarf_siblingof(&child, &child) == 0);
-
   return false;
 }
 
-static bool osd_reqid_type_layout_ok(Dwarf_Die *type) {
-  int64_t bytes = dwarf_bytesize(type);
-  if (bytes != 32) return false;
+// A by-value aggregate of at most two eightbytes is passed in INTEGER registers
+// only when every scalar leaf is an integer-class member.  A floating-point leaf
+// would use the SSE class (XMM registers), which we do not model, so return false
+// and let the caller drop the function rather than misclassify.
+static bool aggregate_is_all_integer(Dwarf_Die *type, int depth) {
+  if (depth > 8) return false;
 
-  Dwarf_Die name_member, tid_member;
-  int name_offset, tid_offset;
-  if (!find_direct_member(type, "name", name_member, name_offset) ||
-      name_offset != 0)
-    return false;
-  if (!find_direct_member(type, "tid", tid_member, tid_offset) ||
-      tid_offset != 16)
-    return false;
-
-  Dwarf_Die name_type;
-  if (!die_type(&name_member, name_type)) return false;
-  if (!strip_type_modifiers(name_type)) return false;
-
-  Dwarf_Die num_member;
-  int num_offset;
-  return find_direct_member(&name_type, "_num", num_member, num_offset) &&
-         num_offset == 8;
+  Dwarf_Die child;
+  if (dwarf_child(type, &child) != 0) return true;
+  do {
+    if (dwarf_tag(&child) != DW_TAG_member) continue;
+    Dwarf_Die mt;
+    if (!die_type(&child, mt) || !strip_type_modifiers(mt)) return false;
+    switch (dwarf_tag(&mt)) {
+      case DW_TAG_base_type: {
+        Dwarf_Attribute enc_mem;
+        Dwarf_Attribute *enc = dwarf_attr_integrate(&mt, DW_AT_encoding, &enc_mem);
+        Dwarf_Word encoding;
+        if (enc == NULL || dwarf_formudata(enc, &encoding) != 0) return false;
+        if (encoding == DW_ATE_float || encoding == DW_ATE_complex_float)
+          return false;
+        break;
+      }
+      case DW_TAG_pointer_type:
+      case DW_TAG_enumeration_type:
+        break;
+      case DW_TAG_structure_type:
+      case DW_TAG_class_type:
+      case DW_TAG_union_type:
+        if (!aggregate_is_all_integer(&mt, depth + 1)) return false;
+        break;
+      default:
+        return false;
+    }
+  } while (dwarf_siblingof(&child, &child) == 0);
+  return true;
 }
 
 static bool classify_x86_64_abi_param(Dwarf_Die *param,
                                       struct x86_64_abi_param &abi_param) {
   Dwarf_Die type;
-  bool is_osd_reqid = false;
-  if (!param_type(param, type, "osd_reqid_t", is_osd_reqid)) return false;
+  if (!param_type(param, type)) return false;
 
   switch (dwarf_tag(&type)) {
     case DW_TAG_pointer_type:
     case DW_TAG_reference_type:
     case DW_TAG_rvalue_reference_type:
       abi_param.cls = X86_64_ABI_INTEGER;
+      abi_param.int_regs = 1;
       abi_param.stack_size = 8;
       return true;
 
@@ -191,6 +180,7 @@ static bool classify_x86_64_abi_param(Dwarf_Die *param,
       int64_t bytes = dwarf_bytesize(&type);
       if (bytes <= 0 || bytes > 8) return false;
       abi_param.cls = X86_64_ABI_INTEGER;
+      abi_param.int_regs = 1;
       abi_param.stack_size = 8;
       return true;
     }
@@ -201,13 +191,29 @@ static bool classify_x86_64_abi_param(Dwarf_Die *param,
       int64_t bytes = dwarf_bytesize(&type);
       if (bytes <= 0) return false;
 
-      // VarLocation can represent one base register or stack address only.
-      // Only recover Ceph's request id aggregate after proving the exact
-      // DWARF type and member layout used by osdtrace's JSON fields.
-      if (!is_osd_reqid || !osd_reqid_type_layout_ok(&type)) return false;
+      // Non-trivially-copyable types are passed as a hidden pointer (one register).
+      if (type_passed_by_invisible_reference(&type, 0)) {
+        abi_param.cls = X86_64_ABI_INTEGER;
+        abi_param.int_regs = 1;
+        abi_param.stack_size = 8;
+        return true;
+      }
 
-      abi_param.cls = X86_64_ABI_MEMORY;
-      abi_param.stack_size = align_up((int)bytes, 8);
+      // Trivially-copyable aggregate, passed by value.  More than two eightbytes
+      // goes to memory on the stack (spg_t is 24 bytes, osd_reqid_t 32).
+      if (bytes > 16) {
+        abi_param.cls = X86_64_ABI_MEMORY;
+        abi_param.int_regs = 0;
+        abi_param.stack_size = align_up((int)bytes, 8);
+        return true;
+      }
+
+      // One or two eightbytes: passed in INTEGER registers when every leaf is an
+      // integer-class member (eversion_t is 16 bytes, pg_shard_t 8).
+      if (!aggregate_is_all_integer(&type, 0)) return false;
+      abi_param.cls = X86_64_ABI_INTEGER;
+      abi_param.int_regs = (bytes > 8) ? 2 : 1;
+      abi_param.stack_size = abi_param.int_regs * 8;
       return true;
     }
 
@@ -498,7 +504,9 @@ bool DwarfParser::lookup_function_symbol_pc(string fullname, Dwarf_Addr &pc) {
         string base = demangled_function_base(demangled);
         if (raw_name != fullname && base != fullname) continue;
 
-        Dwarf_Addr sym_pc = sym.st_value + bias;
+        // func2pc stores DWARF addresses (dwarf_entrypc space, no load bias);
+        // the symbol table is in the same address space, so use st_value as-is.
+        Dwarf_Addr sym_pc = sym.st_value;
         if (found && found_pc != sym_pc) {
           cerr << "Ambiguous ELF symbols for function " << fullname << endl;
           return false;
@@ -560,23 +568,26 @@ bool DwarfParser::recover_param_location_from_abi(Dwarf_Die *func,
       return false;
     }
 
+    const int ngpr = (int)(sizeof(x86_64_integer_arg_regs) /
+                           sizeof(x86_64_integer_arg_regs[0]));
     VarLocation candidate;
-    if (abi_param.cls == X86_64_ABI_INTEGER) {
-      if (gpr_idx < (int)(sizeof(x86_64_integer_arg_regs) /
-                         sizeof(x86_64_integer_arg_regs[0]))) {
-        candidate.reg = x86_64_integer_arg_regs[gpr_idx];
-        candidate.offset = 0;
-        candidate.stack = false;
-      } else {
-        candidate.reg = x86_64_dwarf_rsp;
-        candidate.offset = stack_offset;
-        candidate.stack = true;
-      }
+    bool on_stack;
+    if (abi_param.cls == X86_64_ABI_INTEGER &&
+        gpr_idx + abi_param.int_regs <= ngpr) {
+      candidate.reg = x86_64_integer_arg_regs[gpr_idx];
+      candidate.offset = 0;
+      candidate.stack = false;
+      on_stack = false;
     } else {
+      // MEMORY, or an INTEGER argument whose eightbytes do not all fit in the
+      // remaining registers: the whole argument is passed on the stack, and no
+      // later argument backfills the skipped registers.
+      if (abi_param.cls == X86_64_ABI_INTEGER) gpr_idx = ngpr;
       stack_offset = align_up(stack_offset, 8);
       candidate.reg = x86_64_dwarf_rsp;
       candidate.offset = stack_offset;
       candidate.stack = true;
+      on_stack = true;
     }
 
     const char *name = dwarf_diename(&child);
@@ -591,16 +602,10 @@ bool DwarfParser::recover_param_location_from_abi(Dwarf_Die *func,
       return true;
     }
 
-    if (abi_param.cls == X86_64_ABI_INTEGER) {
-      if (gpr_idx < (int)(sizeof(x86_64_integer_arg_regs) /
-                         sizeof(x86_64_integer_arg_regs[0]))) {
-        ++gpr_idx;
-      } else {
-        stack_offset += 8;
-      }
-    } else {
+    if (on_stack)
       stack_offset += abi_param.stack_size;
-    }
+    else
+      gpr_idx += abi_param.int_regs;
   } while (dwarf_siblingof(&child, &child) == 0);
 
   return false;
@@ -1004,7 +1009,13 @@ static int handle_function(Dwarf_Die *die, void *data) {
                                                  varloc);
       }
     }
-    assert(ok);
+    if (!ok) {
+      cerr << "Dropping " << fullname << " because parameter " << varname
+           << " location could not be resolved" << endl;
+      func2pc.erase(fullname);
+      func2vf.erase(fullname);
+      return 0;
+    }
     //printf("var %s location : register %d, offset %d, stack %d\n",
      //varname.c_str(), varloc.reg, varloc.offset, varloc.stack);
     vf[i].varloc = varloc;
@@ -1013,7 +1024,13 @@ static int handle_function(Dwarf_Die *die, void *data) {
     dp->dwarf_die_type(&vardie, &typedie);
     vf[i].fields.resize(arr[i].size());
     ok = dp->translate_fields(&vardie, &typedie, pc, arr[i], vf[i].fields);
-    assert(ok);
+    if (!ok) {
+      cerr << "Dropping " << fullname << " because fields of parameter "
+           << varname << " could not be resolved" << endl;
+      func2pc.erase(fullname);
+      func2vf.erase(fullname);
+      return 0;
+    }
     for (int j = 1; j < (int)vf[i].fields.size(); ++j) {
        //printf("Field %s is at offset %d, defref %d\n", arr[i][j].c_str(),
        //vf[i].fields[j].offset, vf[i].fields[j].pointer);

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -39,6 +39,11 @@ class DwarfParser {
   typedef std::map<std::string, std::vector<std::vector<std::string>>> probes_t;
   mod_func2vf_t mod_func2vf;
   mod_func2pc_t mod_func2pc;
+  // LTO emits an address-less abstract subprogram plus one or more out-of-line
+  // concrete instances (with ranges and parameter location lists) linked by
+  // DW_AT_abstract_origin.  Maps the abstract DIE offset to its concrete DIEs so
+  // handle_function can read the real locations instead of reconstructing them.
+  std::map<Dwarf_Off, std::vector<Dwarf_Die>> abstract_to_concrete;
   // basename → full path on disk for every add_module() call.  Lets
   // export_to_json() read each module's ELF build-id without the caller
   // needing to re-derive the path.
@@ -74,6 +79,10 @@ class DwarfParser {
   Dwarf_Attribute *find_func_frame_base(Dwarf_Die *, Dwarf_Attribute *);
   bool translate_param_location(Dwarf_Die *, std::string, Dwarf_Addr,
                                 Dwarf_Die &, VarLocation &);
+  bool find_concrete_param_location(Dwarf_Die *, std::string, Dwarf_Addr,
+                                    Dwarf_Die &, VarLocation &);
+  void index_concrete_instances(Dwarf *);
+  bool select_concrete_instance(Dwarf_Off, Dwarf_Addr, Dwarf_Die &);
   bool recover_param_location_from_abi(Dwarf_Die *, std::string, Dwarf_Addr,
                                        Dwarf_Die &, VarLocation &);
   bool translate_data_member_location(Dwarf_Attribute *, Dwarf_Addr, int &);

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -74,6 +74,11 @@ class DwarfParser {
   Dwarf_Attribute *find_func_frame_base(Dwarf_Die *, Dwarf_Attribute *);
   bool translate_param_location(Dwarf_Die *, std::string, Dwarf_Addr,
                                 Dwarf_Die &, VarLocation &);
+  bool recover_param_location_from_abi(Dwarf_Die *, std::string, Dwarf_Addr,
+                                       Dwarf_Die &, VarLocation &);
+  bool translate_data_member_location(Dwarf_Attribute *, Dwarf_Addr, int &);
+  bool current_module_is_x86_64();
+  bool lookup_function_symbol_pc(std::string, Dwarf_Addr &);
   bool func_entrypc(Dwarf_Die *, Dwarf_Addr *);
   bool find_prologue(Dwarf_Die *func, Dwarf_Addr &pc);
   void dwarf_die_type(Dwarf_Die *, Dwarf_Die *);

--- a/tests/dwarf-compare.sh
+++ b/tests/dwarf-compare.sh
@@ -102,29 +102,55 @@ fi
 # Get the ceph version for reference file lookup
 matching_ref_version=$(dpkg -l | awk '$2=="ceph-common" {print $3}')
 
-# Reference filenames may carry an optional architecture suffix
-# (e.g. osd-19.2.3-0ubuntu0.24.04.3_arm64_dwarf.json) when the same
-# package version is checked in for more than one arch.  Glob and pick
-# the first match instead of hard-coding the filename.
+# Stable key of every per-module build-id in a dwarf JSON (sorted,
+# comma-joined; empty when the JSON carries no build-id).
+dwarf_build_id_key() {
+    ./tests/dwarf_build_id.py "$1"
+}
+
+# Pick the reference whose per-module build-ids match the generated JSON.
+# A version can ship as several binaries (arch, the 26.04 amd64v3 variant,
+# a rebuild), each with its own addresses, so the build-id -- not the
+# filename -- selects the right one.
 find_ref() {
-    local dir="$1" prefix="$2"
-    ls "${dir}/${prefix}${matching_ref_version}"*_dwarf.json 2>/dev/null | head -1
+    local dir="$1" prefix="$2" generated="$3" want cand
+    want=$(dwarf_build_id_key "$generated")
+    [ -n "$want" ] || return 0
+    for cand in "${dir}/${prefix}${matching_ref_version}"*_dwarf.json; do
+        [ -e "$cand" ] || continue
+        if [ "$(dwarf_build_id_key "$cand")" = "$want" ]; then
+            echo "$cand"
+            return 0
+        fi
+    done
+}
+
+# Compare a freshly generated JSON against its build-id-matched reference.
+compare_by_build_id() {
+    local label="$1" dir="$2" prefix="$3" generated="$4" ref
+    ref=$(find_ref "$dir" "$prefix" "$generated")
+    if [ -n "$ref" ]; then
+        echo "Comparing $label against reference $ref"
+        ./tests/compare_dwarf_json.py "$ref" "$generated"
+        echo "$label dwarf json comparison passed!"
+    else
+        echo "ERROR: no checked-in $label reference matches build-id" \
+             "$(dwarf_build_id_key "$generated") of the installed binary;" \
+             "generated JSON left at $generated" >&2
+        exit 1
+    fi
 }
 
 # Test osdtrace dwarf json generation
 echo "Testing osdtrace dwarf json generation..."
 osd_new_dwarf="generated-osd-dwarf.json"
 ./osdtrace -j $osd_new_dwarf
-osd_ref_file=$(find_ref ./files/ubuntu/osdtrace osd-)
-./tests/compare_dwarf_json.py $osd_ref_file $osd_new_dwarf
-echo "osdtrace dwarf json comparison passed!"
+compare_by_build_id osdtrace ./files/ubuntu/osdtrace osd- "$osd_new_dwarf"
 
 # Test radostrace dwarf json generation
 echo "Testing radostrace dwarf json generation..."
 rados_new_dwarf="generated-rados-dwarf.json"
 ./radostrace -j $rados_new_dwarf
-rados_ref_file=$(find_ref ./files/ubuntu/radostrace "")
-./tests/compare_dwarf_json.py $rados_ref_file $rados_new_dwarf
-echo "radostrace dwarf json comparison passed!"
+compare_by_build_id radostrace ./files/ubuntu/radostrace "" "$rados_new_dwarf"
 
 echo "All dwarf json comparisons passed successfully!"

--- a/tests/dwarf_build_id.py
+++ b/tests/dwarf_build_id.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+Print the build-id key of a cephtrace dwarf JSON.
+
+The key is every per-module build-id, sorted and comma-joined (empty when
+the JSON carries no build-id).  dwarf-compare.sh uses it to match a freshly
+generated JSON to the checked-in reference for the same binary.
+"""
+
+import json
+import sys
+
+
+def build_id_key(file_path: str) -> str:
+    """Return the sorted, comma-joined per-module build-id of a dwarf JSON."""
+    with open(file_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    return ",".join(sorted(
+        v["build_id"] for v in data.values()
+        if isinstance(v, dict) and "build_id" in v
+    ))
+
+
+def main():
+    """Main entry point"""
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <dwarf.json>", file=sys.stderr)
+        sys.exit(2)
+    print(build_id_key(sys.argv[1]))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Builds on pponnuvel's 26.04 support.

- Run dwarf-compare against both 26.04 ceph-osd variants (amd64 baseline and amd64v3), selecting the reference by build-id.
- Recover parameter locations when debuginfo is degraded. LTO splits some functions into an address-less abstract DIE plus an out-of-line concrete instance; read the real location lists from the concrete instance, falling back to x86_64 SysV ABI reconstruction when a location list has no entry-point slot.