### PR TITLE
ci: only run push builds on main

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -2,6 +2,8 @@ name: Build on Pull Request
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
prevent running the same ci every time