### PR TITLE
refactor(osdtrace): decompose main() into single-purpose helpers

### DIFF
--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -12,6 +12,7 @@
 #include <ctime>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -1025,172 +1026,181 @@ int attach_probes(struct osdtrace_bpf *skel,
   return 0;
 }
 
-// Convenient alias for non-return uprobes
-inline int attach_uprobes(struct osdtrace_bpf *skel,
-                          DwarfParser &dp,
-                          std::string path,
-                          const std::set<int> &process_ids,
-                          std::string funcname,
-                          int v = 0) {
-  return attach_probes(skel, dp, path, process_ids, funcname, false, v);
+
+// ---------------------------------------------------------------------------
+// main() building blocks.  Each helper owns one job and returns a process
+// exit code (or 0 on success) so main() reads as a straight-line story:
+// parse -> subcommands -> resolve targets -> load DWARF -> attach & run.
+// ---------------------------------------------------------------------------
+
+// The tracing target: which PIDs to attach to (empty = trace the host binary
+// system-wide) and the ceph-osd binary path the probes resolve against.
+struct TraceTarget {
+  std::set<int> pids;
+  std::string osd_path;
+};
+
+static int run_list_embedded() {
+  DwarfParser::list_embedded_versions("osdtrace");
+  return 0;
 }
 
-int main(int argc, char **argv) {
-  signal(SIGINT, signal_handler);
-
-  if (parse_args(argc, argv) < 0) return 0;
-
-  if (list_embedded) {
-    DwarfParser::list_embedded_versions("osdtrace");
+static int run_list() {
+  if (geteuid() != 0) {
+    std::cout << "Warning: Running without root privileges. Containerized status of OSDs owned by other users may not be accurately detected." << std::endl << std::endl;
+  }
+  auto processes = discover_ceph_osd_processes();
+  if (processes.empty()) {
+    std::cout << "No active ceph-osd processes detected on the host." << std::endl;
     return 0;
   }
+  annotate_traceability(processes);
+  std::cout << "Detected " << processes.size() << " active ceph-osd process(es) on the host:" << std::endl;
+  print_discovered_osds(processes, /*show_traceable=*/true);
 
-  if (list_only) {
-    if (geteuid() != 0) {
-      std::cout << "Warning: Running without root privileges. Containerized status of OSDs owned by other users may not be accurately detected." << std::endl << std::endl;
+  // If any OSD isn't directly traceable, tell the user how to proceed.
+  bool any_no = false, any_unknown = false;
+  for (const auto& proc : processes) {
+    if (proc.traceable == "no") any_no = true;
+    else if (proc.traceable == "unknown") any_unknown = true;
+  }
+  if (any_no || any_unknown) {
+    std::cout << std::endl
+              << "Traceable: 'yes' means this osdtrace already has matching DWARF data built in." << std::endl;
+    if (any_no) {
+      std::cout << "  'no':      no embedded DWARF matches this binary's build-id. Export a DWARF JSON" << std::endl;
+      std::cout << "             on a host that has the matching ceph-osd (osdtrace -j <file>), then trace" << std::endl;
+      std::cout << "             with: osdtrace -p <pid> -i <file> --skip-version-check" << std::endl;
     }
-    auto processes = discover_ceph_osd_processes();
-    if (processes.empty()) {
-      std::cout << "No active ceph-osd processes detected on the host." << std::endl;
-    } else {
-      annotate_traceability(processes);
-      std::cout << "Detected " << processes.size() << " active ceph-osd process(es) on the host:" << std::endl;
-      print_discovered_osds(processes, /*show_traceable=*/true);
+    if (any_unknown) {
+      std::cout << "  'unknown': could not read the OSD binary's build-id; re-run as root" << std::endl;
+      std::cout << "             (required for containerized OSDs)." << std::endl;
+    }
+    std::cout << std::endl
+              << "Ceph Version: authoritative when Traceable='yes' (the matched embedded entry)." << std::endl;
+    std::cout << "             For Traceable='no' it is a best-effort host package lookup, shown only" << std::endl;
+    std::cout << "             for native OSDs whose on-disk binary still matches the running process;" << std::endl;
+    std::cout << "             'unknown' for containerized OSDs or binaries upgraded since launch." << std::endl;
+  }
+  return 0;
+}
 
-      // If any OSD isn't directly traceable, tell the user how to proceed.
-      bool any_no = false, any_unknown = false;
-      for (const auto& proc : processes) {
-        if (proc.traceable == "no") any_no = true;
-        else if (proc.traceable == "unknown") any_unknown = true;
-      }
-      if (any_no || any_unknown) {
-        std::cout << std::endl
-                  << "Traceable: 'yes' means this osdtrace already has matching DWARF data built in." << std::endl;
-        if (any_no) {
-          std::cout << "  'no':      no embedded DWARF matches this binary's build-id. Export a DWARF JSON" << std::endl;
-          std::cout << "             on a host that has the matching ceph-osd (osdtrace -j <file>), then trace" << std::endl;
-          std::cout << "             with: osdtrace -p <pid> -i <file> --skip-version-check" << std::endl;
-        }
-        if (any_unknown) {
-          std::cout << "  'unknown': could not read the OSD binary's build-id; re-run as root" << std::endl;
-          std::cout << "             (required for containerized OSDs)." << std::endl;
-        }
-        std::cout << std::endl
-                  << "Ceph Version: authoritative when Traceable='yes' (the matched embedded entry)." << std::endl;
-        std::cout << "             For Traceable='no' it is a best-effort host package lookup, shown only" << std::endl;
-        std::cout << "             for native OSDs whose on-disk binary still matches the running process;" << std::endl;
-        std::cout << "             'unknown' for containerized OSDs or binaries upgraded since launch." << std::endl;
-      }
-    }
-    return 0;
+// -a / --all: trace every traceable ceph-osd process on the host (native and
+// containerized).  Discover all OSDs, keep the ones this binary has matching
+// embedded DWARF for, and feed their PIDs into the normal multi-PID flow.
+//
+// The BPF probe offsets are version-specific (one hprobes map, one set of
+// function addresses per run), so -a assumes every traceable OSD shares a
+// single build.  If the traceable OSDs span more than one build-id we can't
+// trace them correctly in one run, so give up and ask the user to select a
+// single-build subset with -p/--id.
+static int select_all_traceable_osds() {
+  if (!process_ids.empty() || !requested_osd_ids.empty()) {
+    std::cerr << "Error: -a/--all cannot be combined with -p or --id" << std::endl;
+    return 1;
+  }
+  if (export_json || import_json) {
+    std::cerr << "Error: -a/--all cannot be combined with -j or -i" << std::endl;
+    return 1;
+  }
+  if (geteuid() != 0) {
+    std::cerr << "Warning: not running as root; containerized OSDs (and OSDs"
+              << " owned by other users) may be missed or show as untraceable." << std::endl;
   }
 
-  // -a / --all: trace every traceable ceph-osd process on the host (native and
-  // containerized).  Discover all OSDs, keep the ones this binary has matching
-  // embedded DWARF for, and feed their PIDs into the normal multi-PID flow.
-  //
-  // The BPF probe offsets are version-specific (one hprobes map, one set of
-  // function addresses per run), so -a assumes every traceable OSD shares a
-  // single build.  If the traceable OSDs span more than one build-id we can't
-  // trace them correctly in one run, so give up and ask the user to select a
-  // single-build subset with -p/--id.
-  if (trace_all) {
-    if (!process_ids.empty() || !requested_osd_ids.empty()) {
-      std::cerr << "Error: -a/--all cannot be combined with -p or --id" << std::endl;
-      return 1;
-    }
-    if (export_json || import_json) {
-      std::cerr << "Error: -a/--all cannot be combined with -j or -i" << std::endl;
-      return 1;
-    }
-    if (geteuid() != 0) {
-      std::cerr << "Warning: not running as root; containerized OSDs (and OSDs"
-                << " owned by other users) may be missed or show as untraceable." << std::endl;
-    }
+  auto processes = discover_ceph_osd_processes();
+  if (processes.empty()) {
+    std::cerr << "No active ceph-osd processes detected on the host." << std::endl;
+    return 1;
+  }
+  annotate_traceability(processes);
 
-    auto processes = discover_ceph_osd_processes();
-    if (processes.empty()) {
-      std::cerr << "No active ceph-osd processes detected on the host." << std::endl;
-      return 1;
-    }
-    annotate_traceability(processes);
+  std::vector<OsdProcessInfo> traceable, not_traceable;
+  for (const auto& p : processes) {
+    if (p.traceable == "yes" && !p.build_id.empty())
+      traceable.push_back(p);
+    else
+      not_traceable.push_back(p);
+  }
 
-    std::vector<OsdProcessInfo> traceable, not_traceable;
-    for (const auto& p : processes) {
-      if (p.traceable == "yes" && !p.build_id.empty())
-        traceable.push_back(p);
-      else
-        not_traceable.push_back(p);
-    }
+  if (traceable.empty()) {
+    std::cerr << "Error: none of the " << processes.size()
+              << " ceph-osd process(es) are traceable with this osdtrace's"
+              << " embedded DWARF data." << std::endl;
+    print_discovered_osds(processes, /*show_traceable=*/true);
+    std::cerr << std::endl
+              << "Export a DWARF JSON on a host with the matching ceph-osd"
+              << " (osdtrace -j <file>), then trace with -p <pid> -i <file>"
+              << " --skip-version-check." << std::endl;
+    return 1;
+  }
 
-    if (traceable.empty()) {
-      std::cerr << "Error: none of the " << processes.size()
-                << " ceph-osd process(es) are traceable with this osdtrace's"
-                << " embedded DWARF data." << std::endl;
-      print_discovered_osds(processes, /*show_traceable=*/true);
+  // -a assumes a single build across all traceable OSDs; bail out otherwise.
+  const std::string& build_id = traceable.front().build_id;
+  for (const auto& p : traceable) {
+    if (p.build_id != build_id) {
+      std::cerr << "Error: traceable ceph-osd processes span more than one"
+                << " build; -a cannot trace multiple builds in one run."
+                << std::endl;
+      print_discovered_osds(traceable, /*show_traceable=*/true);
       std::cerr << std::endl
-                << "Export a DWARF JSON on a host with the matching ceph-osd"
-                << " (osdtrace -j <file>), then trace with -p <pid> -i <file>"
-                << " --skip-version-check." << std::endl;
+                << "Trace a single-build subset explicitly with -p <pid,...>"
+                << " or --id <osd-id,...>." << std::endl;
       return 1;
     }
-
-    // -a assumes a single build across all traceable OSDs; bail out otherwise.
-    const std::string& build_id = traceable.front().build_id;
-    for (const auto& p : traceable) {
-      if (p.build_id != build_id) {
-        std::cerr << "Error: traceable ceph-osd processes span more than one"
-                  << " build; -a cannot trace multiple builds in one run."
-                  << std::endl;
-        print_discovered_osds(traceable, /*show_traceable=*/true);
-        std::cerr << std::endl
-                  << "Trace a single-build subset explicitly with -p <pid,...>"
-                  << " or --id <osd-id,...>." << std::endl;
-        return 1;
-      }
-    }
-
-    for (const auto& p : traceable) process_ids.insert(p.pid);
-
-    std::cout << "Tracing " << process_ids.size()
-              << " ceph-osd process(es) selected by -a:" << std::endl;
-    print_discovered_osds(traceable, /*show_traceable=*/true);
-    if (!not_traceable.empty()) {
-      std::cout << std::endl << "Skipping " << not_traceable.size()
-                << " non-traceable ceph-osd process(es):" << std::endl;
-      print_discovered_osds(not_traceable, /*show_traceable=*/true);
-    }
-    std::cout << std::endl;
   }
 
-  // Resolve --id <osd-id,...> to PIDs via discovery and feed into process_ids.
-  if (!requested_osd_ids.empty()) {
-    if (!process_ids.empty()) {
-      std::cerr << "Error: --id and -p are mutually exclusive" << std::endl;
+  for (const auto& p : traceable) process_ids.insert(p.pid);
+
+  std::cout << "Tracing " << process_ids.size()
+            << " ceph-osd process(es) selected by -a:" << std::endl;
+  print_discovered_osds(traceable, /*show_traceable=*/true);
+  if (!not_traceable.empty()) {
+    std::cout << std::endl << "Skipping " << not_traceable.size()
+              << " non-traceable ceph-osd process(es):" << std::endl;
+    print_discovered_osds(not_traceable, /*show_traceable=*/true);
+  }
+  std::cout << std::endl;
+  return 0;
+}
+
+// Resolve --id <osd-id,...> to PIDs via discovery and feed into process_ids.
+static int resolve_requested_osd_ids() {
+  if (!process_ids.empty()) {
+    std::cerr << "Error: --id and -p are mutually exclusive" << std::endl;
+    return 1;
+  }
+  auto processes = discover_ceph_osd_processes();
+  for (int want : requested_osd_ids) {
+    std::vector<int> matches;
+    for (const auto& p : processes) {
+      if (p.osd_id == want) matches.push_back(p.pid);
+    }
+    if (matches.empty()) {
+      std::cerr << "Error: no running ceph-osd process found with OSD ID "
+                << want << " (try --list)" << std::endl;
       return 1;
     }
-    auto processes = discover_ceph_osd_processes();
-    for (int want : requested_osd_ids) {
-      std::vector<int> matches;
-      for (const auto& p : processes) {
-        if (p.osd_id == want) matches.push_back(p.pid);
-      }
-      if (matches.empty()) {
-        std::cerr << "Error: no running ceph-osd process found with OSD ID "
-                  << want << " (try --list)" << std::endl;
-        return 1;
-      }
-      if (matches.size() > 1) {
-        std::cerr << "Error: OSD ID " << want << " matched multiple PIDs (";
-        for (size_t i = 0; i < matches.size(); ++i)
-          std::cerr << (i ? "," : "") << matches[i];
-        std::cerr << "); use -p <pid> explicitly" << std::endl;
-        return 1;
-      }
-      process_ids.insert(matches[0]);
-      clog << "--id " << want << " resolved to PID " << matches[0] << endl;
+    if (matches.size() > 1) {
+      std::cerr << "Error: OSD ID " << want << " matched multiple PIDs (";
+      for (size_t i = 0; i < matches.size(); ++i)
+        std::cerr << (i ? "," : "") << matches[i];
+      std::cerr << "); use -p <pid> explicitly" << std::endl;
+      return 1;
     }
+    process_ids.insert(matches[0]);
+    clog << "--id " << want << " resolved to PID " << matches[0] << endl;
   }
+  return 0;
+}
+
+// Turn the user's selection (-a, --id, -p, or nothing) into a validated
+// TraceTarget: the set of PIDs to attach to and the ceph-osd path the
+// probes resolve against.
+static int resolve_trace_targets(TraceTarget &target) {
+  if (trace_all && select_all_traceable_osds() != 0) return 1;
+
+  if (!requested_osd_ids.empty() && resolve_requested_osd_ids() != 0) return 1;
 
   // Validate all process_ids if specified
   for (int pid : process_ids) {
@@ -1201,27 +1211,21 @@ int main(int argc, char **argv) {
     }
   }
 
-  struct osdtrace_bpf *skel;
-  int ret = 0;
-  struct ring_buffer *rb;
-
-  std::string osd_path;
-
   if (!process_ids.empty()) {
     // PIDs specified - read executable path from /proc/<first_pid>/exe
     // All PIDs should be running the same ceph-osd binary
     int first_pid = *process_ids.begin();
-    osd_path = get_exe_path_for_pid(first_pid);
-    if (osd_path.empty()) {
+    target.osd_path = get_exe_path_for_pid(first_pid);
+    if (target.osd_path.empty()) {
       std::cerr << "Error: Could not read /proc/" << first_pid << "/exe" << std::endl;
       return 1;
     }
-    clog << "Reading executable from process " << first_pid << ": " << osd_path << endl;
+    clog << "Reading executable from process " << first_pid << ": " << target.osd_path << endl;
 
     // Validate that the process is actually running ceph-osd
-    if (osd_path.find("ceph-osd") == std::string::npos) {
+    if (target.osd_path.find("ceph-osd") == std::string::npos) {
       std::cerr << "Error: Process ID " << first_pid << " is not running ceph-osd" << std::endl;
-      std::cerr << "Process is running: " << osd_path << std::endl;
+      std::cerr << "Process is running: " << target.osd_path << std::endl;
       return 1;
     }
 
@@ -1233,9 +1237,9 @@ int main(int argc, char **argv) {
         std::cerr << "Error: Could not read /proc/" << pid << "/exe" << std::endl;
         return 1;
       }
-      if (pid_exe != osd_path) {
+      if (pid_exe != target.osd_path) {
         std::cerr << "Error: Process ID " << pid << " is running a different executable" << std::endl;
-        std::cerr << "Expected: " << osd_path << std::endl;
+        std::cerr << "Expected: " << target.osd_path << std::endl;
         std::cerr << "Got: " << pid_exe << std::endl;
         return 1;
       }
@@ -1244,10 +1248,10 @@ int main(int argc, char **argv) {
     // No PID specified - look for a host-side ceph-osd binary, and separately
     // discover running ceph-osd processes.  Discovery scans /proc, so it sees
     // containerized OSDs too, even though their binary is not on the host FS.
-    osd_path = find_executable_path("ceph-osd");
+    target.osd_path = find_executable_path("ceph-osd");
     auto processes = discover_ceph_osd_processes();
 
-    if (osd_path.empty()) {
+    if (target.osd_path.empty()) {
       // No ceph-osd on the host filesystem.  This is the normal case when OSDs
       // run inside containers: the binary lives in the container image, so
       // there is nothing for us to read on the host without attaching to a
@@ -1290,8 +1294,14 @@ int main(int argc, char **argv) {
     }
   }
 
-  std::cout << "Tracing ceph-osd at: " << osd_path << std::endl;
+  target.pids = process_ids;
+  std::cout << "Tracing ceph-osd at: " << target.osd_path << std::endl;
+  return 0;
+}
 
+// Populate the DwarfParser from JSON import, embedded DWARF, or a live parse
+// of the target binary.
+static int load_dwarf_data(DwarfParser &dwarfparser, const TraceTarget &target) {
   // Check if any ceph-osd processes are running with old/deleted executables.
   // Only enforced for live tracing; for JSON export we deliberately want to
   // read the *on-disk* (possibly newly-upgraded) binary so the exported
@@ -1304,8 +1314,6 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  DwarfParser dwarfparser(osd_probes, probe_units);
-  
   if (import_json) {
     // Import dwarf data from JSON file
     std::string version = "";
@@ -1314,7 +1322,7 @@ int main(int argc, char **argv) {
       clog << "Skipping version check as requested" << endl;
     } else {
       // Get version information for comparison
-      version = get_package_version(osd_path);
+      version = get_package_version(target.osd_path);
       if (version != "unknown") {
         clog << "Current package version: " << version << endl;
       } else {
@@ -1328,48 +1336,84 @@ int main(int argc, char **argv) {
       return 1;
     }
     clog << "Successfully imported dwarf data from " << json_input_file << endl;
-  } else {
-    // When -j is used to export JSON, force live parsing so the output reflects
-    // the installed binary (not a re-dump of the embedded data the header came
-    // from). Otherwise try embedded DWARF data first, keyed by the on-disk
-    // ELF build-id (arch-safe, snap-safe, custom-rebuild-safe).
-    //
-    // osd_path is the in-process view ("/usr/bin/ceph-osd"), which for a
-    // containerized OSD doesn't exist on the host.  Reach into the target's
-    // mount namespace via /proc/<pid>/root/ so the build-id read sees the
-    // same binary the kernel uprobe will attach to.
-    std::string osd_buildid_path = osd_path;
-    if (!process_ids.empty()) {
-      osd_buildid_path = "/proc/" + std::to_string(*process_ids.begin())
-                         + "/root" + osd_path;
-    }
-    std::string osd_buildid = get_elf_build_id(osd_buildid_path);
-    if (!export_json && !osd_buildid.empty() &&
-        dwarfparser.import_from_embedded(
-            {{get_basename(osd_path), osd_buildid}}, "osdtrace")) {
-      // Detailed match info already logged inside import_from_embedded.
-    } else {
-      clog << "Start to parse dwarf info" << endl;
-      dwarfparser.add_module(osd_path);
-      dwarfparser.parse();
-    }
-  }
-
-  // Export dwarf parsing results to JSON if requested
-  if (export_json) {
-    // Get version information from the ceph-osd binary
-    std::string version = get_package_version(osd_path);
-    if (version != "unknown") {
-      clog << "Detected package version: " << version << endl;
-    } else {
-      clog << "Could not determine package version for ceph-osd, using 'unknown'" << endl;
-    }
-    
-    dwarfparser.export_to_json(json_output_file, version);
-    clog << "Dwarf parsing data exported to " << json_output_file << endl;
     return 0;
   }
 
+  // When -j is used to export JSON, force live parsing so the output reflects
+  // the installed binary (not a re-dump of the embedded data the header came
+  // from). Otherwise try embedded DWARF data first, keyed by the on-disk
+  // ELF build-id (arch-safe, snap-safe, custom-rebuild-safe).
+  //
+  // osd_path is the in-process view ("/usr/bin/ceph-osd"), which for a
+  // containerized OSD doesn't exist on the host.  Reach into the target's
+  // mount namespace via /proc/<pid>/root/ so the build-id read sees the
+  // same binary the kernel uprobe will attach to.
+  std::string osd_buildid_path = target.osd_path;
+  if (!target.pids.empty()) {
+    osd_buildid_path = "/proc/" + std::to_string(*target.pids.begin())
+                       + "/root" + target.osd_path;
+  }
+  std::string osd_buildid = get_elf_build_id(osd_buildid_path);
+  if (!export_json && !osd_buildid.empty() &&
+      dwarfparser.import_from_embedded(
+          {{get_basename(target.osd_path), osd_buildid}}, "osdtrace")) {
+    // Detailed match info already logged inside import_from_embedded.
+  } else {
+    clog << "Start to parse dwarf info" << endl;
+    dwarfparser.add_module(target.osd_path);
+    dwarfparser.parse();
+  }
+  return 0;
+}
+
+// Export dwarf parsing results to JSON (-j) and exit.
+static int do_export_json(DwarfParser &dwarfparser, const TraceTarget &target) {
+  // Get version information from the ceph-osd binary
+  std::string version = get_package_version(target.osd_path);
+  if (version != "unknown") {
+    clog << "Detected package version: " << version << endl;
+  } else {
+    clog << "Could not determine package version for ceph-osd, using 'unknown'" << endl;
+  }
+
+  dwarfparser.export_to_json(json_output_file, version);
+  clog << "Dwarf parsing data exported to " << json_output_file << endl;
+  return 0;
+}
+
+// Every probe osdtrace can attach, with the probe_mode that enables it.
+// `exact` preserves the historical gating: the single-op probe
+// (log_op_stats_v2) is only attached when -s is the *only* mode requested.
+// Attach order matches the historical call order.
+struct AttachEntry {
+  const char *func;
+  int mode;
+  bool exact;
+  int v;
+};
+
+static const AttachEntry ATTACH_LIST[] = {
+    {"PrimaryLogPG::log_op_stats", OP_SINGLE_PROBE, /*exact=*/true, 2},
+    {"OSD::dequeue_op", OP_FULL_PROBE, false, 0},
+    {"PrimaryLogPG::execute_ctx", OP_FULL_PROBE, false, 0},
+    {"ECBackend::submit_transaction", OP_FULL_PROBE, false, 0},
+    {"OpRequest::mark_flag_point_string", OP_FULL_PROBE, false, 0},
+    {"OpRequest::mark_flag_point", OP_FULL_PROBE, false, 0},
+    {"ReplicatedBackend::generate_subop", OP_FULL_PROBE, false, 0},
+    {"ReplicatedBackend::do_repop_reply", OP_FULL_PROBE, false, 0},
+    {"BlueStore::queue_transactions", OP_FULL_PROBE, false, 0},
+    {"BlueStore::_txc_calc_cost", OP_FULL_PROBE, false, 0},
+    {"BlueStore::_txc_state_proc", OP_FULL_PROBE, false, 0},
+    {"PrimaryLogPG::log_op_stats", OP_FULL_PROBE, false, 0},
+    {"ReplicatedBackend::repop_commit", OP_FULL_PROBE, false, 0},
+    {"OSD::enqueue_op", OP_FULL_PROBE, false, 0},
+    {"BlueStore::log_latency", BLUESTORE_PROBE, false, 0},
+    {"BlueStore::log_latency_fn", BLUESTORE_PROBE, false, 0},
+};
+
+// Load the BPF skeleton, attach the probes selected by probe_mode, and poll
+// the ring buffer until timeout or error.
+static int run_tracer(DwarfParser &dwarfparser, const TraceTarget &target) {
   libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 
   /* Set up libbpf errors and debug info callback */
@@ -1378,95 +1422,82 @@ int main(int argc, char **argv) {
   /* Load and verify BPF application */
   clog << "Start to load uprobe" << endl;
 
-  skel = osdtrace_bpf__open_and_load();
+  std::unique_ptr<osdtrace_bpf, decltype(&osdtrace_bpf__destroy)> skel(
+      osdtrace_bpf__open_and_load(), osdtrace_bpf__destroy);
   if (!skel) {
     cerr << "Failed to open and load BPF skeleton" << endl;
     return 1;
   }
 
-  // map_fd = bpf_object__find_map_fd_by_name(skel->obj, "hprobes");
-
-  fill_map_hprobes(osd_path, dwarfparser, skel->maps.hprobes);
+  fill_map_hprobes(target.osd_path, dwarfparser, skel->maps.hprobes);
 
   clog << "BPF prog loaded" << endl;
 
-  //Start to load the probes
-  if (probe_mode == OP_SINGLE_PROBE) {
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "PrimaryLogPG::log_op_stats", 2);
+  int attached = 0;
+  for (const auto &e : ATTACH_LIST) {
+    bool enabled = e.exact ? (probe_mode == e.mode) : (probe_mode & e.mode);
+    if (!enabled) continue;
+    if (attach_probes(skel.get(), dwarfparser, target.osd_path, target.pids,
+                      e.func, /*is_retprobe=*/false, e.v) == 0)
+      ++attached;
   }
-
-  if (probe_mode & OP_FULL_PROBE) {
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "OSD::dequeue_op");
-
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "PrimaryLogPG::execute_ctx");
-
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "ECBackend::submit_transaction");
-
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "OpRequest::mark_flag_point_string");
-
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "OpRequest::mark_flag_point");
-
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "ReplicatedBackend::generate_subop");
-
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "ReplicatedBackend::do_repop_reply");
-
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "BlueStore::queue_transactions");
-
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "BlueStore::_txc_calc_cost");
-
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "BlueStore::_txc_state_proc");
-
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "PrimaryLogPG::log_op_stats");
-
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "ReplicatedBackend::repop_commit");
-
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "OSD::enqueue_op");
-  }
-
-  if (probe_mode & BLUESTORE_PROBE) {
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "BlueStore::log_latency");
-    attach_uprobes(skel, dwarfparser, osd_path, process_ids, "BlueStore::log_latency_fn");
+  if (attached == 0) {
+    cerr << "Error: no probes could be attached to " << target.osd_path << endl;
+    return 1;
   }
 
   bootstamp = get_bootstamp();
   clog << "New a ring buffer" << endl;
 
-  rb = ring_buffer__new(bpf_map__fd(skel->maps.rb), handle_event, NULL, NULL);
+  std::unique_ptr<ring_buffer, decltype(&ring_buffer__free)> rb(
+      ring_buffer__new(bpf_map__fd(skel->maps.rb), handle_event, NULL, NULL),
+      ring_buffer__free);
   if (!rb) {
     cerr << "failed to setup ring_buffer" << endl;
-    goto cleanup;
+    clog << "Clean up the eBPF program" << endl;
+    return -errno;
   }
 
   /* Set up timeout if provided - start counting after initialization is complete */
   if (timeout > 0) {
-      signal(SIGALRM, timeout_handler);
-      alarm(timeout);
-      std::cout << "Execution timeout set to " << timeout << " seconds.\n";
+    signal(SIGALRM, timeout_handler);
+    alarm(timeout);
+    std::cout << "Execution timeout set to " << timeout << " seconds.\n";
   } else {
-      std::cout << "No execution timeout set (unlimited).\n";
+    std::cout << "No execution timeout set (unlimited).\n";
   }
 
   clog << "Started to poll from ring buffer" << endl;
 
-  while ((!timeout_occurred || timeout == -1) && (ret = ring_buffer__poll(rb, 1000)) >= 0) {
-      // Continue polling while timeout hasn't occurred or if unlimited execution time
+  int ret = 0;
+  while ((!timeout_occurred || timeout == -1) && (ret = ring_buffer__poll(rb.get(), 1000)) >= 0) {
+    // Continue polling while timeout hasn't occurred or if unlimited execution time
   }
 
-  if (timeout_occurred) {
-      cerr << "Timeout occurred. Exiting." << endl;
-  }
+  if (timeout_occurred)
+    cerr << "Timeout occurred. Exiting." << endl;
+  else
+    cerr << "Ring buffer poll failed: " << ret << endl;
 
-  /* we can also attach uprobe/uretprobe to any existing or future
-   * processes that use the same binary executable; to do that we need
-   * to specify -1 as PID, as we do here
-   */
-  /* Let libbpf perform auto-attach for uprobe_sub/uretprobe_sub
-   * NOTICE: we provide path and symbol info in SEC for BPF programs
-   */
-  clog << "Unexpected line hit" << endl;
-cleanup:
   clog << "Clean up the eBPF program" << endl;
-  ring_buffer__free(rb);
-  osdtrace_bpf__destroy(skel);
   return timeout_occurred ? -1 : -errno;
+}
+
+int main(int argc, char **argv) {
+  signal(SIGINT, signal_handler);
+
+  if (parse_args(argc, argv) < 0) return 0;
+
+  if (list_embedded) return run_list_embedded();
+  if (list_only) return run_list();
+
+  TraceTarget target;
+  if (resolve_trace_targets(target) != 0) return 1;
+
+  DwarfParser dwarfparser(osd_probes, probe_units);
+  if (load_dwarf_data(dwarfparser, target) != 0) return 1;
+
+  if (export_json) return do_export_json(dwarfparser, target);
+
+  return run_tracer(dwarfparser, target);
 }


### PR DESCRIPTION
## Summary
`main()` was ~430 lines interleaving five jobs. This PR splits it into helpers that each own one job, so `main()` (now 18 lines) reads as the actual flow:

```
parse -> subcommands -> resolve targets -> load DWARF -> attach & run
```

- **`run_list_embedded()` / `run_list()`** — the `--list-embedded` and `--list` subcommands, moved verbatim.
- **`resolve_trace_targets()`** — `-a` selection (`select_all_traceable_osds()`), `--id` resolution (`resolve_requested_osd_ids()`), PID validation, and osd_path resolution into a `TraceTarget` struct.
- **`load_dwarf_data()`** — deleted-exe guard + the import-JSON / embedded / live-parse trichotomy.
- **`do_export_json()`** — the `-j` export path.
- **`run_tracer()`** — skeleton load, hprobes fill, probe attach, ring-buffer poll, cleanup.

## Two deliberate improvements (not pure moves)
1. The 16 hand-written attach calls are replaced by a data-driven `ATTACH_LIST` table looped in `run_tracer()`. Attach results are now **counted**: if zero probes attach, osdtrace exits with an error instead of silently polling an empty ring buffer. Historical mode gating is preserved exactly (`log_op_stats_v2` still requires `probe_mode == OP_SINGLE_PROBE`).
2. The skeleton and ring buffer are held in `unique_ptr`s with libbpf destructors, removing the `goto cleanup` label and the unreachable "Unexpected line hit" log (a real poll error is now reported with its return code).

The `attach_uprobes` alias from #163 is dropped — the table loop was its only caller.

## Testing (p14s, 11 containerized OSDs across 4 ceph builds)
- Clean build, no new warnings (Ubuntu 24.04, clang)
- `--list`: all 11 OSDs listed with correct build/traceability — **run_list()**
- `-a`: correctly refuses with "span more than one build" — **select_all_traceable_osds()**
- `--id 0`: correctly refuses ambiguous id (3 PIDs) — **resolve_requested_osd_ids()**
- `--id 3,4` (single-build pair): embedded DWARF matched by build-id, 13 probes attached per PID, **live op_r events captured**, clean 25s-timeout exit — **resolve → load → run_tracer** end to end
- `-p 999999` → "does not exist"; `-p 1` → "not running ceph-osd"; `--list-embedded`, `-h`, `-V`, bad flag: all preserved
- Exit code after timeout unchanged (255)
