### PR TITLE
fix(tests): prefer distro podman over runner-image podman 5.8.4 in cephadm CI

### DIFF
--- a/tests/functional-test-cephadm-rgw.sh
+++ b/tests/functional-test-cephadm-rgw.sh
@@ -93,6 +93,56 @@ trap cleanup EXIT
 info "=== Step 1: install host deps (podman, s3cmd, lvm2) ==="
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -q
+
+# GitHub's ubuntu-22.04/24.04 runner images (>= 20260810, runner-images
+# #14412) untar the mgoltzsche/podman-static 5.8.4 bundle into /usr/local
+# (podman, crun, runc, conmon, netavark, aardvark-dns, pasta,
+# fuse-overlayfs, systemd units) and drop its config into /etc/containers
+# (containers.conf, storage.conf, seccomp.json, plus containers.conf.d
+# drop-ins pinning crun to /usr/local/bin/crun).  Ubuntu 26.04 gets podman
+# from apt and is unaffected.
+#
+# That bundle breaks this test two ways.  With /usr/local/bin/podman
+# first on PATH, cephadm resolves the engine to the 5.8.4 static binary
+# and the mon container fails to start during bootstrap.  Even with the
+# distro podman installed below and first on PATH, podman's built-in
+# conmon search order prefers /usr/local/lib/podman/conmon -- built
+# without journald -- so every `podman run` dies with exit 126
+# "[conmon:e]: Include journald in compilation path to log to systemd
+# journal", and the drop-ins still route it to the bundle's crun.
+#
+# Strip the bundle, its config and any container-storage state its podman
+# initialised (the image build ran `podman network reload` as root, which
+# creates a 5.x sqlite libpod DB under /var/lib/containers) so the host
+# looks like a stock Ubuntu box, then install the distro podman this test
+# has always run against.  Keyed on the bundle's own layout
+# (/usr/local/lib/podman/conmon) rather than just /usr/local/bin/podman so
+# a hand-installed podman on a developer machine is left alone.
+if [ -x /usr/local/bin/podman ] && [ -x /usr/local/lib/podman/conmon ]; then
+    info "removing runner-image static podman bundle ($(/usr/local/bin/podman --version 2>/dev/null | head -1))"
+    systemctl disable --now podman.socket podman.service podman-restart.service 2>/dev/null || true
+    rm -f /usr/local/bin/podman /usr/local/bin/crun /usr/local/bin/runc \
+          /usr/local/bin/pasta /usr/local/bin/pasta.avx2 \
+          /usr/local/bin/fuse-overlayfs /usr/local/bin/fusermount3
+    rm -rf /usr/local/lib/podman /usr/local/libexec/podman
+    rm -f /usr/local/lib/systemd/system/podman.socket \
+          /usr/local/lib/systemd/system/podman.service \
+          /usr/local/lib/systemd/system/podman-restart.service \
+          /usr/local/lib/systemd/user/podman.socket \
+          /usr/local/lib/systemd/user/podman.service \
+          /usr/local/lib/systemd/user/podman-restart.service \
+          /usr/local/lib/systemd/system-generators/podman-system-generator \
+          /usr/local/lib/systemd/user-generators/podman-user-generator
+    rm -f /etc/containers/containers.conf /etc/containers/storage.conf \
+          /etc/containers/seccomp.json \
+          /etc/containers/containers.conf.d/00-fix-runtime.conf \
+          /etc/containers/containers.conf.d/99-fix-firewall.conf
+    rm -rf /var/lib/containers/storage /var/lib/containers/cache \
+           /run/containers/storage /run/libpod
+    systemctl daemon-reload 2>/dev/null || true
+    hash -r 2>/dev/null || true
+fi
+
 apt-get install -y -q podman s3cmd python3 curl lvm2 gdisk parted
 
 # Quincy's bundled cephadm (v17.2.x) has a buggy `_fetch_apparmor` that

--- a/tests/lib/cephadm-setup.sh
+++ b/tests/lib/cephadm-setup.sh
@@ -325,10 +325,16 @@ wait_cephadm_healthy() {
     while [[ $(date +%s) -lt $deadline ]]; do
         local s
         s=$(_ceph "$fsid" ceph -s --format=json 2>/dev/null) || true
-        if [[ -n "$s" ]] && python3 -c "
+        # Feed the JSON through stdin rather than splicing it into the
+        # python source: embedded in a string literal, JSON escapes such
+        # as the \n inside progress_events[].message (present for as long
+        # as any progress bar is showing -- quincy keeps a "Global Recovery
+        # Event" up for many minutes) turn into real control characters and
+        # json.loads() fails, so the loop never sees the cluster as ready.
+        if [[ -n "$s" ]] && printf '%s' "$s" | python3 -c "
 import json, sys
 try:
-    d = json.loads('''$s''')
+    d = json.load(sys.stdin)
 except Exception:
     sys.exit(2)
 mon  = len(d.get('quorum_names', []))

--- a/tests/lib/cephadm-setup.sh
+++ b/tests/lib/cephadm-setup.sh
@@ -183,7 +183,8 @@ _purge_partial_clusters() {
 # cephadm_bootstrap_single_host).
 _orch_backend_ready() {
     local fsid="$1"
-    cephadm shell --fsid "$fsid" -- ceph orch status >/dev/null 2>&1
+    local cephadm_bin="${2:-/tmp/cephadm}"
+    timeout 15 "$cephadm_bin" shell --fsid "$fsid" -- ceph --connect-timeout 5 orch status >/dev/null 2>&1
 }
 
 
@@ -277,7 +278,7 @@ cephadm_bootstrap_single_host() {
             >&2 || rc=$?
 
         fsid=$(ls /var/lib/ceph/ 2>/dev/null | grep -E '^[0-9a-f]{8}-[0-9a-f-]+$' | head -1)
-        if [[ -n "$fsid" ]] && _orch_backend_ready "$fsid"; then
+        if [[ -n "$fsid" ]] && _orch_backend_ready "$fsid" "$cephadm_bin"; then
             # Cluster is up with a working orchestrator backend; a non-zero
             # rc here is the benign service-apply mismatch described above.
             # info() goes to stdout, which this function's caller captures as

--- a/tests/lib/microceph-setup.sh
+++ b/tests/lib/microceph-setup.sh
@@ -60,10 +60,13 @@ microceph_setup_single_node() {
     while [ "$elapsed" -lt "$health_timeout" ]; do
         local status_json
         status_json=$(microceph.ceph status --format=json 2>/dev/null) || true
-        if [ -n "$status_json" ] && python3 -c "
+        # JSON via stdin, not spliced into the python source: escapes such as
+        # the \n in progress_events[].message would become real control
+        # characters inside the string literal and break json.loads().
+        if [ -n "$status_json" ] && printf '%s' "$status_json" | python3 -c "
 import json, sys
 try:
-    d = json.loads('''$status_json''')
+    d = json.load(sys.stdin)
 except Exception:
     sys.exit(2)
 health = d.get('health', {}).get('status', '')


### PR DESCRIPTION
## Summary

`build-ubuntu-cephadm (ubuntu-22.04|24.04, *)` has been red on `main` since ~Aug 13 (last green run: 30200848101, Jul 26). Every failure is the same: cephadm bootstrap dies at `Creating mon...` with

```
Non-zero exit code 1 from systemctl start ceph-<fsid>@mon.<host>
```

on all 3 attempts, before any osdtrace/radostrace code runs.

## Root cause

GitHub's runner images `20260810.260` (22.04) / `20260810.271` (24.04) no longer install podman from apt. Per [actions/runner-images#14412](https://github.com/actions/runner-images/pull/14412) (`images/ubuntu/scripts/build/install-container-tools.sh`) they untar the **mgoltzsche/podman-static 5.8.4 bundle** into `/usr/local` — `podman`, `crun`, `runc`, `pasta`, `fuse-overlayfs`, `fusermount3` in `/usr/local/bin`; `conmon`, `netavark`, `aardvark-dns`, `catatonit`, `rootlessport` in `/usr/local/lib/podman`; systemd units — and drop its config into `/etc/containers` (`containers.conf`, `storage.conf`, `seccomp.json`) plus two `containers.conf.d` drop-ins (`00-fix-runtime.conf` pinning crun to `/usr/local/bin/crun`, `99-fix-firewall.conf`). Ubuntu 26.04 still gets podman from apt and is unaffected.

The test still `apt-get install`s the distro podman (3.4.4 on jammy, 4.9.3 on noble), but that bundle breaks it two ways:

1. `/usr/local/bin` precedes `/usr/bin` on `PATH`, and cephadm resolves the engine purely via `PATH` (`cephadmlib/exe_utils.py::find_executable`) — so it uses the 5.8.4 static binary (`podman (/usr/local/bin/podman) version 5.8.4 is present` in the logs) and the mon unit fails to start.
2. Even with the distro podman winning on `PATH` (first revision of this PR), podman's built-in conmon search order prefers `/usr/local/lib/podman/conmon` over `/usr/bin/conmon`. The bundle's conmon is built without journald, so every `podman run` exits 126:
   ```
   [conmon:e]: Include journald in compilation path to log to systemd journal
   ```
   and the drop-ins still route the runtime to the bundle's crun.

| runner image | engine cephadm sees | result |
|---|---|---|
| `20260720.247` (green) | `/usr/bin/podman` 4.9.3 | ✅ |
| `20260810.*` (red) | `/usr/local/bin/podman` 5.8.4 (+ bundle conmon/crun/config) | ❌ |

## Fix

- `tests/functional-test-cephadm-rgw.sh`: before `apt-get install podman`, remove the bundle (binaries, `/usr/local/lib/podman`, systemd units), its `/etc/containers` config and drop-ins, and the container-storage state its podman initialised during image build (`podman network reload` as root → 5.x sqlite libpod DB), so the host is a stock Ubuntu box running the distro podman the test has always used. Keyed on the bundle's own layout (`/usr/local/lib/podman/conmon`), so a hand-installed podman on a developer machine is left alone. This script is the single entry point for both `pr-build.yaml` and the DWARF-refresh `verify` job.
- `tests/lib/cephadm-setup.sh` + `tests/lib/microceph-setup.sh`: the cluster-readiness loops spliced the `ceph -s --format=json` text into the python source as a `'''...'''` literal, so a `\n` escape inside `progress_events[].message` became a real newline and `json.loads` failed → never "ready". Quincy keeps a *Global Recovery Event* progress bar up for many minutes, which is why the first run of this PR had `build-ubuntu-cephadm (ubuntu-22.04, quincy)` time out at 900s while its final `ceph -s` showed 3 OSDs up for 14 min and HEALTH_OK. JSON now goes in via stdin (`json.load(sys.stdin)`).
- `tests/lib/cephadm-setup.sh`: `_orch_backend_ready` gets a 15s `timeout` and an explicit cephadm binary path (hardening carried over from the #177 investigation).

## Test plan

- [x] Run 32080878130 (`4dfd226`, bundle removal only): 11/12 `build-ubuntu-cephadm` jobs green — every 22.04/24.04 job that had been red since Aug 13 now bootstraps and traces; the one failure (22.04/quincy) was the readiness-check bug above, fixed in `ed67a9c`
- [x] Full `build-ubuntu-cephadm` matrix green on `ed67a9c` (run 32083122776: 25/25 checks, incl. all 12 cephadm jobs)
- [x] Step 1 log shows `removing runner-image static podman bundle (podman version 5.8.4)` on 22.04/24.04 and cephadm reports `podman (/usr/bin/podman) version 3.4.4|4.9.3 is present`
- [x] `bash -n` on both scripts

Note: #177 / #180 (and any other open PR) will keep failing these jobs until this lands on `main`.
