### PR TITLE
osdtrace: add allocator tracing mode (-A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ __pycache__/
 
 # auto-generated
 src/embedded_dwarf_data.h
+src/ceph_btf_local.h
 

--- a/doc/man/8/osdtrace.rst
+++ b/doc/man/8/osdtrace.rst
@@ -14,7 +14,7 @@ probe and trace OSD(s) on given nodes
 SYNOPSIS
 ========
 
-| **osdtrace** [-s] [-b] [-l <milliseconds>] [-t <seconds>] [-j <filename>] [-i <filename>] [-a] [-p <pid1,pid2,...>] [--id <osd-id1,osd-id2,...>] [--skip-version-check] [--list] [--list-embedded] [-V] [-h]
+| **osdtrace** [-s] [-b] [-A] [-l <milliseconds>] [-t <seconds>] [-j <filename>] [-i <filename>] [-a] [-p <pid1,pid2,...>] [--id <osd-id1,osd-id2,...>] [--skip-version-check] [--list] [--list-embedded] [-V] [-h]
 
 
 DESCRIPTION
@@ -43,6 +43,15 @@ OPTIONS
    operation label the OSD itself passes to the function (e.g.
    _txc_committed_kv, kv_commit, _do_read, _remove), so the labels stay
    correct across Ceph versions.
+
+-A
+
+   Allocator probe mode: trace every call into the BlueStore/BlueFS
+   free-space allocator. Each line reports the allocator instance
+   (block, bluefs-wal/db/slow), the requested size, alignment unit and
+   hint, the bytes actually allocated, the returned physical extents
+   (a split request is a direct fragmentation signal), the call
+   latency, and the calling thread. Can be combined with -b.
 
 -l <milliseconds>
 

--- a/doc/osdtrace.md
+++ b/doc/osdtrace.md
@@ -98,6 +98,8 @@ sudo ./osdtrace
                            / log_latency_fn call as "bluestore <name> lat <us>",
                            where <name> is the operation label the OSD passes
                            (e.g. _txc_committed_kv, kv_commit, _do_read, _remove)
+-A                         Allocator probe mode: trace every BlueStore/BlueFS
+                           allocator call (size, latency, returned extents)
 -l <milliseconds>          Only capture operations slower than this threshold
 -i <filename>              Import DWARF info from JSON file
 -j <filename>              Export DWARF info to JSON file and exit
@@ -115,6 +117,37 @@ By default osdtrace runs in **full tracing mode**, printing the complete latency
 breakdown (messenger, OSD, peers, BlueStore sub-latencies) for every operation.
 The former `-x` flag is gone - its output is now the default; the `-d` and `-m`
 aggregation options were removed at the same time.
+
+## Allocator Probe Mode (-A)
+
+`osdtrace -A` traces every call into the BlueStore free-space allocator —
+the `allocate()` overrides of whichever allocator implementation the OSD
+runs (`hybrid` by default; bitmap/avl/btree/btree2/stupid are covered too).
+This includes BlueFS's allocators, so RocksDB file growth is visible next
+to object-data allocations. One line per call:
+
+```
+osd 0 alloc block      want 0x10000 unit 0x1000 -> 0x10000 exts 1 [0x8e2000~0x10000] lat 13us comm tp_osd_tp
+osd 0 alloc bluefs-wal want 0x1200000 unit 0x100000 hint 0x16300000 -> 0x1200000 exts 1 [0x16300000~0x1200000] lat 9us comm bstore_kv_sync
+```
+
+| Field | Meaning |
+|-------|---------|
+| **alloc** | Allocator instance name: `block` (BlueStore data) or `bluefs-wal/db/slow` (BlueFS/RocksDB) |
+| **want / unit / hint** | Requested bytes, allocation-unit alignment, preferred offset (omitted when unset) |
+| **->** | Bytes actually allocated; `SHORT` when less than requested, `ENOSPC` on failure |
+| **exts N [off~len ...]** | The returned physical extents (first 6 shown). N > 1 means the request was split — a direct fragmentation signal |
+| **(nested dN)** | Call made from inside another allocator (e.g. hybrid falling back to its internal bitmap) |
+| **lat** | allocate() entry → return, µs: lock wait + free-space search time |
+
+Rising latency together with rising extent counts is fragmentation biting
+the write path — the per-call complement to
+`ceph daemon osd.N bluestore allocator score block`. `-l <ms>` filters on
+latency; `-A -b` combines with the BlueStore latency probes.
+
+Note: `-A` needs DWARF data that includes the allocator probes; direct
+binary parsing and freshly exported JSONs work, older DWARF JSONs and
+embedded data skip these probes with a warning.
 
 ### Examples
 

--- a/files/centos-stream/osdtrace/osd-2:17.2.6-0.el8_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:17.2.6-0.el8_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "461e6598014802fdd3c01be5ed4df872294224cf",
     "func2pc": {
+      "Allocator::get_name": 13912464,
+      "AvlAllocator::allocate": 14279120,
+      "BitmapAllocator::allocate": 14247872,
       "BlueStore::_do_write": 13158816,
       "BlueStore::_txc_add_transaction": 13170096,
       "BlueStore::_txc_apply_kv": 13018720,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 13486544,
       "BlueStore::log_latency_fn": 13487216,
       "BlueStore::queue_transactions": 13241968,
+      "BtreeAllocator::allocate": 14303056,
       "ECBackend::submit_transaction": 11527472,
+      "HybridAllocator::allocate": 14335616,
       "OSD::dequeue_op": 6923680,
       "OSD::enqueue_op": 6974704,
       "OpRequest::mark_flag_point": 17924608,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 11221568,
       "ReplicatedBackend::generate_subop": 11197488,
       "ReplicatedBackend::repop_commit": 11233664,
-      "ReplicatedBackend::submit_transaction": 11215760
+      "ReplicatedBackend::submit_transaction": 11215760,
+      "StupidAllocator::allocate": 14226592
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:17.2.7-0.el8_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:17.2.7-0.el8_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "84048f0efecab952762b84088552902855690551",
     "func2pc": {
+      "Allocator::get_name": 13954560,
+      "AvlAllocator::allocate": 14322752,
+      "BitmapAllocator::allocate": 14290112,
       "BlueStore::_do_write": 13199456,
       "BlueStore::_txc_add_transaction": 13210720,
       "BlueStore::_txc_apply_kv": 13059808,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 13528576,
       "BlueStore::log_latency_fn": 13529248,
       "BlueStore::queue_transactions": 13282592,
+      "BtreeAllocator::allocate": 14346816,
       "ECBackend::submit_transaction": 11568496,
+      "HybridAllocator::allocate": 14380528,
       "OSD::dequeue_op": 6932864,
       "OSD::enqueue_op": 6982384,
       "OpRequest::mark_flag_point": 17978880,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 11259888,
       "ReplicatedBackend::generate_subop": 11235760,
       "ReplicatedBackend::repop_commit": 11271984,
-      "ReplicatedBackend::submit_transaction": 11254080
+      "ReplicatedBackend::submit_transaction": 11254080,
+      "StupidAllocator::allocate": 14269712
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:17.2.7-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:17.2.7-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "05de81b6650328a5ec36323b1fb74a1d1bd50e4f",
     "func2pc": {
+      "Allocator::get_name": 10413152,
+      "AvlAllocator::allocate": 10804448,
+      "BitmapAllocator::allocate": 10734096,
       "BlueStore::_do_write": 10006128,
       "BlueStore::_txc_add_transaction": 10023584,
       "BlueStore::_txc_apply_kv": 9905424,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 14682016,
       "BlueStore::log_latency_fn": 10046816,
       "BlueStore::queue_transactions": 9922624,
+      "BtreeAllocator::allocate": 10808928,
       "ECBackend::submit_transaction": 8769744,
+      "HybridAllocator::allocate": 10824512,
       "OSD::dequeue_op": 5576480,
       "OSD::enqueue_op": 5554944,
       "OpRequest::mark_flag_point": 13245024,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 8509504,
       "ReplicatedBackend::generate_subop": 8539248,
       "ReplicatedBackend::repop_commit": 8537392,
-      "ReplicatedBackend::submit_transaction": 8525072
+      "ReplicatedBackend::submit_transaction": 8525072,
+      "StupidAllocator::allocate": 10754064
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:17.2.8-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:17.2.8-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "35125af39c8129e981e32543745079b7d0a72f94",
     "func2pc": {
+      "Allocator::get_name": 10092688,
+      "AvlAllocator::allocate": 10479568,
+      "BitmapAllocator::allocate": 10448848,
       "BlueStore::_do_write": 9692416,
       "BlueStore::_txc_add_transaction": 9709760,
       "BlueStore::_txc_apply_kv": 9569296,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 16980000,
       "BlueStore::log_latency_fn": 9769888,
       "BlueStore::queue_transactions": 9717888,
+      "BtreeAllocator::allocate": 10533664,
       "ECBackend::submit_transaction": 8432976,
+      "HybridAllocator::allocate": 10535216,
       "OSD::dequeue_op": 5143504,
       "OSD::enqueue_op": 5142288,
       "OpRequest::mark_flag_point": 13069328,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 8177152,
       "ReplicatedBackend::generate_subop": 8197392,
       "ReplicatedBackend::repop_commit": 8239888,
-      "ReplicatedBackend::submit_transaction": 8203888
+      "ReplicatedBackend::submit_transaction": 8203888,
+      "StupidAllocator::allocate": 10475392
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:17.2.9-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:17.2.9-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "316ac6a34b0493ba15893b9e09acc1981fc4c318",
     "func2pc": {
+      "Allocator::get_name": 10092576,
+      "AvlAllocator::allocate": 10479392,
+      "BitmapAllocator::allocate": 10448656,
       "BlueStore::_do_write": 9692304,
       "BlueStore::_txc_add_transaction": 9709648,
       "BlueStore::_txc_apply_kv": 9569184,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 16979952,
       "BlueStore::log_latency_fn": 9769776,
       "BlueStore::queue_transactions": 9717776,
+      "BtreeAllocator::allocate": 10533488,
       "ECBackend::submit_transaction": 8432992,
+      "HybridAllocator::allocate": 10535040,
       "OSD::dequeue_op": 5143504,
       "OSD::enqueue_op": 5142288,
       "OpRequest::mark_flag_point": 13069232,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 8177168,
       "ReplicatedBackend::generate_subop": 8197408,
       "ReplicatedBackend::repop_commit": 8239904,
-      "ReplicatedBackend::submit_transaction": 8203904
+      "ReplicatedBackend::submit_transaction": 8203904,
+      "StupidAllocator::allocate": 10475216
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:18.2.0-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:18.2.0-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "4b7cd2971be43eb0cd1c5c1ac4d58ce2f3b5dc5f",
     "func2pc": {
+      "Allocator::get_name": 10571056,
+      "AvlAllocator::allocate": 10874464,
+      "BitmapAllocator::allocate": 10856208,
       "BlueStore::_do_write": 10313216,
       "BlueStore::_txc_add_transaction": 10253504,
       "BlueStore::_txc_apply_kv": 10214592,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 15026672,
       "BlueStore::log_latency_fn": 10361600,
       "BlueStore::queue_transactions": 10261104,
+      "BtreeAllocator::allocate": 10917184,
       "ECBackend::submit_transaction": 9392896,
+      "HybridAllocator::allocate": 10935280,
       "OSD::dequeue_op": 6136816,
       "OSD::enqueue_op": 6125760,
       "OpRequest::mark_flag_point": 13440608,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 9139168,
       "ReplicatedBackend::generate_subop": 9168304,
       "ReplicatedBackend::repop_commit": 9166448,
-      "ReplicatedBackend::submit_transaction": 9149056
+      "ReplicatedBackend::submit_transaction": 9149056,
+      "StupidAllocator::allocate": 10869568
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:18.2.1-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:18.2.1-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "69b2dce8c84328cdb71d9ce87fdd87ea5ab8ace0",
     "func2pc": {
+      "Allocator::get_name": 10575488,
+      "AvlAllocator::allocate": 10878640,
+      "BitmapAllocator::allocate": 10860560,
       "BlueStore::_do_write": 10317456,
       "BlueStore::_txc_add_transaction": 10257744,
       "BlueStore::_txc_apply_kv": 10218832,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 15035424,
       "BlueStore::log_latency_fn": 10365840,
       "BlueStore::queue_transactions": 10265344,
+      "BtreeAllocator::allocate": 10922464,
       "ECBackend::submit_transaction": 9397120,
+      "HybridAllocator::allocate": 10940560,
       "OSD::dequeue_op": 6140336,
       "OSD::enqueue_op": 6129280,
       "OpRequest::mark_flag_point": 13447888,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 9142848,
       "ReplicatedBackend::generate_subop": 9171984,
       "ReplicatedBackend::repop_commit": 9170128,
-      "ReplicatedBackend::submit_transaction": 9152736
+      "ReplicatedBackend::submit_transaction": 9152736,
+      "StupidAllocator::allocate": 10873744
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:18.2.2-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:18.2.2-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "eed1b48d637dd119aac8217ac07257ed647716e4",
     "func2pc": {
+      "Allocator::get_name": 10553808,
+      "AvlAllocator::allocate": 10905584,
+      "BitmapAllocator::allocate": 10844240,
       "BlueStore::_do_write": 10311296,
       "BlueStore::_txc_add_transaction": 10325328,
       "BlueStore::_txc_apply_kv": 10211200,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 15031456,
       "BlueStore::log_latency_fn": 10340048,
       "BlueStore::queue_transactions": 10228368,
+      "BtreeAllocator::allocate": 10910048,
       "ECBackend::submit_transaction": 9352960,
+      "HybridAllocator::allocate": 10923856,
       "OSD::dequeue_op": 6138304,
       "OSD::enqueue_op": 6136528,
       "OpRequest::mark_flag_point": 13443968,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 9136912,
       "ReplicatedBackend::generate_subop": 9172928,
       "ReplicatedBackend::repop_commit": 9144016,
-      "ReplicatedBackend::submit_transaction": 9177952
+      "ReplicatedBackend::submit_transaction": 9177952,
+      "StupidAllocator::allocate": 10856480
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:18.2.4-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:18.2.4-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "b5c05fcb978b9dde949fbfb04175f83e68cc4387",
     "func2pc": {
+      "Allocator::get_name": 10211328,
+      "AvlAllocator::allocate": 10589488,
+      "BitmapAllocator::allocate": 10436336,
       "BlueStore::_do_write": 9974928,
       "BlueStore::_txc_add_transaction": 9999920,
       "BlueStore::_txc_apply_kv": 9870112,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 18148464,
       "BlueStore::log_latency_fn": 10051216,
       "BlueStore::queue_transactions": 10007440,
+      "BtreeAllocator::allocate": 10595760,
       "ECBackend::submit_transaction": 9050096,
+      "HybridAllocator::allocate": 10591280,
       "OSD::dequeue_op": 5637280,
       "OSD::enqueue_op": 5635504,
       "OpRequest::mark_flag_point": 13164320,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 8763344,
       "ReplicatedBackend::generate_subop": 8807488,
       "ReplicatedBackend::repop_commit": 8770464,
-      "ReplicatedBackend::submit_transaction": 8813936
+      "ReplicatedBackend::submit_transaction": 8813936,
+      "StupidAllocator::allocate": 10508496
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:18.2.5-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:18.2.5-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "eefec294a75485e36c3cf08475504281039e4b45",
     "func2pc": {
+      "Allocator::get_name": 10251552,
+      "AvlAllocator::allocate": 10636400,
+      "BitmapAllocator::allocate": 10482864,
       "BlueStore::_do_write": 10012464,
       "BlueStore::_txc_add_transaction": 10037312,
       "BlueStore::_txc_apply_kv": 9907440,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 18232080,
       "BlueStore::log_latency_fn": 10068640,
       "BlueStore::queue_transactions": 10045200,
+      "BtreeAllocator::allocate": 10642912,
       "ECBackend::submit_transaction": 9080656,
+      "HybridAllocator::allocate": 10638272,
       "OSD::dequeue_op": 5658752,
       "OSD::enqueue_op": 5656960,
       "OpRequest::mark_flag_point": 13233552,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 8793568,
       "ReplicatedBackend::generate_subop": 8837632,
       "ReplicatedBackend::repop_commit": 8800560,
-      "ReplicatedBackend::submit_transaction": 8844080
+      "ReplicatedBackend::submit_transaction": 8844080,
+      "StupidAllocator::allocate": 10574352
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:18.2.6-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:18.2.6-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "0413033996ae70837e848d75ecaa9645e16c1927",
     "func2pc": {
+      "Allocator::get_name": 10252496,
+      "AvlAllocator::allocate": 10637344,
+      "BitmapAllocator::allocate": 10483808,
       "BlueStore::_do_write": 10013280,
       "BlueStore::_txc_add_transaction": 10038128,
       "BlueStore::_txc_apply_kv": 9908256,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 18234624,
       "BlueStore::log_latency_fn": 10069456,
       "BlueStore::queue_transactions": 10046016,
+      "BtreeAllocator::allocate": 10643856,
       "ECBackend::submit_transaction": 9081472,
+      "HybridAllocator::allocate": 10639216,
       "OSD::dequeue_op": 5659248,
       "OSD::enqueue_op": 5657456,
       "OpRequest::mark_flag_point": 13234976,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 8794400,
       "ReplicatedBackend::generate_subop": 8838464,
       "ReplicatedBackend::repop_commit": 8801392,
-      "ReplicatedBackend::submit_transaction": 8844912
+      "ReplicatedBackend::submit_transaction": 8844912,
+      "StupidAllocator::allocate": 10575296
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:18.2.7-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:18.2.7-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "55d2fa99b99cb563a50089732bf2f92e681d64c1",
     "func2pc": {
+      "Allocator::get_name": 10252848,
+      "AvlAllocator::allocate": 10637408,
+      "BitmapAllocator::allocate": 10483872,
       "BlueStore::_do_write": 10013648,
       "BlueStore::_txc_add_transaction": 10038496,
       "BlueStore::_txc_apply_kv": 9908624,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 18234128,
       "BlueStore::log_latency_fn": 10069824,
       "BlueStore::queue_transactions": 10046384,
+      "BtreeAllocator::allocate": 10643920,
       "ECBackend::submit_transaction": 9081840,
+      "HybridAllocator::allocate": 10639280,
       "OSD::dequeue_op": 5659360,
       "OSD::enqueue_op": 5657568,
       "OpRequest::mark_flag_point": 13235328,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 8794768,
       "ReplicatedBackend::generate_subop": 8838832,
       "ReplicatedBackend::repop_commit": 8801760,
-      "ReplicatedBackend::submit_transaction": 8845280
+      "ReplicatedBackend::submit_transaction": 8845280,
+      "StupidAllocator::allocate": 10575360
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:18.2.8-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:18.2.8-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "03872f5228642b1108d9d5f4054ab92f0893c087",
     "func2pc": {
+      "Allocator::get_name": 10309824,
+      "AvlAllocator::allocate": 10699248,
+      "BitmapAllocator::allocate": 10541056,
       "BlueStore::_do_write": 10064720,
       "BlueStore::_txc_add_transaction": 10093744,
       "BlueStore::_txc_apply_kv": 9960192,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 18328176,
       "BlueStore::log_latency_fn": 10124240,
       "BlueStore::queue_transactions": 10101632,
+      "Btree2Allocator::allocate": 10725312,
+      "BtreeAllocator::allocate": 10701728,
       "ECBackend::submit_transaction": 9055904,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 10728592,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 10726112,
+      "HybridBtree2Allocator::allocate": 10727408,
       "OSD::dequeue_op": 5695952,
       "OSD::enqueue_op": 5694160,
       "OpRequest::mark_flag_point": 13331424,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 8860880,
       "ReplicatedBackend::generate_subop": 8864160,
       "ReplicatedBackend::repop_commit": 8862304,
-      "ReplicatedBackend::submit_transaction": 8870608
+      "ReplicatedBackend::submit_transaction": 8870608,
+      "StupidAllocator::allocate": 10635104
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:19.2.0-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:19.2.0-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "4048ea46052c162365edc550699743cd6fef997b",
     "func2pc": {
+      "Allocator::get_name": 10634544,
+      "AvlAllocator::allocate": 10936240,
+      "BitmapAllocator::allocate": 10900368,
       "BlueStore::_do_write": 10372080,
       "BlueStore::_txc_add_transaction": 10293024,
       "BlueStore::_txc_apply_kv": 10248816,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 18646448,
       "BlueStore::log_latency_fn": 10365280,
       "BlueStore::queue_transactions": 10301008,
+      "BtreeAllocator::allocate": 10992768,
       "ECBackend::submit_transaction": 9437232,
+      "HybridAllocator::allocate": 10994320,
       "OSD::dequeue_op": 5846272,
       "OSD::enqueue_op": 5844496,
       "OpRequest::mark_flag_point": 13604512,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 9222352,
       "ReplicatedBackend::generate_subop": 9238832,
       "ReplicatedBackend::repop_commit": 9281168,
-      "ReplicatedBackend::submit_transaction": 9245360
+      "ReplicatedBackend::submit_transaction": 9245360,
+      "StupidAllocator::allocate": 10927312
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:19.2.1-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:19.2.1-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "f933b10ee3a93412336bd7358b3a1aaeb2eafb01",
     "func2pc": {
+      "Allocator::get_name": 10633392,
+      "AvlAllocator::allocate": 11024000,
+      "BitmapAllocator::allocate": 10874128,
       "BlueStore::_do_write": 10392416,
       "BlueStore::_txc_add_transaction": 10423104,
       "BlueStore::_txc_apply_kv": 10284400,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 18699312,
       "BlueStore::log_latency_fn": 10450656,
       "BlueStore::queue_transactions": 10302464,
+      "BtreeAllocator::allocate": 11026608,
       "ECBackend::submit_transaction": 9455760,
+      "HybridAllocator::allocate": 10974000,
       "OSD::dequeue_op": 5863408,
       "OSD::enqueue_op": 5861616,
       "OpRequest::mark_flag_point": 13652976,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 9240768,
       "ReplicatedBackend::generate_subop": 9257184,
       "ReplicatedBackend::repop_commit": 9302416,
-      "ReplicatedBackend::submit_transaction": 9263712
+      "ReplicatedBackend::submit_transaction": 9263712,
+      "StupidAllocator::allocate": 10953312
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:19.2.2-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:19.2.2-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "702d13c48678e61ff8128a9f70c452669f494eb5",
     "func2pc": {
+      "Allocator::get_name": 10633392,
+      "AvlAllocator::allocate": 11024000,
+      "BitmapAllocator::allocate": 10874128,
       "BlueStore::_do_write": 10392416,
       "BlueStore::_txc_add_transaction": 10423104,
       "BlueStore::_txc_apply_kv": 10284400,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 18699312,
       "BlueStore::log_latency_fn": 10450656,
       "BlueStore::queue_transactions": 10302464,
+      "BtreeAllocator::allocate": 11026608,
       "ECBackend::submit_transaction": 9455760,
+      "HybridAllocator::allocate": 10974000,
       "OSD::dequeue_op": 5863408,
       "OSD::enqueue_op": 5861616,
       "OpRequest::mark_flag_point": 13652976,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 9240768,
       "ReplicatedBackend::generate_subop": 9257184,
       "ReplicatedBackend::repop_commit": 9302416,
-      "ReplicatedBackend::submit_transaction": 9263712
+      "ReplicatedBackend::submit_transaction": 9263712,
+      "StupidAllocator::allocate": 10953312
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:19.2.3-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:19.2.3-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "39ec76a70203385f8c9fbf812b95f32821290c8b",
     "func2pc": {
+      "Allocator::get_name": 10733536,
+      "AvlAllocator::allocate": 11093152,
+      "BitmapAllocator::allocate": 10958624,
       "BlueStore::_do_write": 10466544,
       "BlueStore::_txc_add_transaction": 10387296,
       "BlueStore::_txc_apply_kv": 10347168,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 18831504,
       "BlueStore::log_latency_fn": 10459520,
       "BlueStore::queue_transactions": 10395184,
+      "Btree2Allocator::allocate": 11119712,
+      "BtreeAllocator::allocate": 11095632,
       "ECBackend::submit_transaction": 9495280,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 11122992,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 11120512,
+      "HybridBtree2Allocator::allocate": 11121808,
       "OSD::dequeue_op": 5900416,
       "OSD::enqueue_op": 5898624,
       "OpRequest::mark_flag_point": 13772448,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 9261760,
       "ReplicatedBackend::generate_subop": 9305360,
       "ReplicatedBackend::repop_commit": 9268576,
-      "ReplicatedBackend::submit_transaction": 9311888
+      "ReplicatedBackend::submit_transaction": 9311888,
+      "StupidAllocator::allocate": 11025840
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:19.2.4-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:19.2.4-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "9a5242e28de10f5715ce97504009711051f46921",
     "func2pc": {
+      "Allocator::get_name": 10751200,
+      "AvlAllocator::allocate": 11108304,
+      "BitmapAllocator::allocate": 10973776,
       "BlueStore::_do_write": 10484080,
       "BlueStore::_txc_add_transaction": 10404784,
       "BlueStore::_txc_apply_kv": 10364656,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 18859792,
       "BlueStore::log_latency_fn": 10477056,
       "BlueStore::queue_transactions": 10412672,
+      "Btree2Allocator::allocate": 11134832,
+      "BtreeAllocator::allocate": 11110784,
       "ECBackend::submit_transaction": 9510848,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 11138112,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 11135632,
+      "HybridBtree2Allocator::allocate": 11136928,
       "OSD::dequeue_op": 5898448,
       "OSD::enqueue_op": 5777088,
       "OpRequest::mark_flag_point": 13800656,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 9277088,
       "ReplicatedBackend::generate_subop": 9320688,
       "ReplicatedBackend::repop_commit": 9283904,
-      "ReplicatedBackend::submit_transaction": 9327216
+      "ReplicatedBackend::submit_transaction": 9327216,
+      "StupidAllocator::allocate": 11041008
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:19.2.5-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:19.2.5-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "6465fa22329962eaa80e8c3dcdae947fac9c8845",
     "func2pc": {
+      "Allocator::get_name": 10756416,
+      "AvlAllocator::allocate": 11113632,
+      "BitmapAllocator::allocate": 10978928,
       "BlueStore::_do_write": 10489296,
       "BlueStore::_txc_add_transaction": 10410000,
       "BlueStore::_txc_apply_kv": 10369872,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 18871168,
       "BlueStore::log_latency_fn": 10482272,
       "BlueStore::queue_transactions": 10417888,
+      "Btree2Allocator::allocate": 11140192,
+      "BtreeAllocator::allocate": 11116144,
       "ECBackend::submit_transaction": 9515424,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 11143472,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 11140992,
+      "HybridBtree2Allocator::allocate": 11142288,
       "OSD::dequeue_op": 5903280,
       "OSD::enqueue_op": 5781904,
       "OpRequest::mark_flag_point": 13807776,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 9281664,
       "ReplicatedBackend::generate_subop": 9325264,
       "ReplicatedBackend::repop_commit": 9288480,
-      "ReplicatedBackend::submit_transaction": 9331792
+      "ReplicatedBackend::submit_transaction": 9331792,
+      "StupidAllocator::allocate": 11046304
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:20.2.0-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:20.2.0-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "dd676e9d69e0c9f93d8c85b3d80f2430fa28999b",
     "func2pc": {
+      "AllocatorBase::get_name": 11896288,
+      "AvlAllocator::allocate": 12300992,
+      "BitmapAllocator::allocate": 12196896,
       "BlueStore::_do_write": 11557792,
       "BlueStore::_txc_add_transaction": 11579312,
       "BlueStore::_txc_apply_kv": 11431952,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 19864864,
       "BlueStore::log_latency_fn": 11611728,
       "BlueStore::queue_transactions": 11586304,
+      "Btree2Allocator::allocate": 12326400,
+      "BtreeAllocator::allocate": 12303888,
       "ECBackend::submit_transaction": 10166640,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 12329760,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 12327216,
+      "HybridBtree2Allocator::allocate": 12328528,
       "OSD::dequeue_op": 6647488,
       "OSD::enqueue_op": 6643232,
       "OpRequest::mark_flag_point": 15102736,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 8137536,
       "ReplicatedBackend::generate_subop": 8177744,
       "ReplicatedBackend::repop_commit": 8138752,
-      "ReplicatedBackend::submit_transaction": 8182144
+      "ReplicatedBackend::submit_transaction": 8182144,
+      "StupidAllocator::allocate": 12235248
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "AllocatorBase::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:20.2.1-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:20.2.1-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "e0b1f5dbe570436650a38c3e73883f5dc5034da4",
     "func2pc": {
+      "AllocatorBase::get_name": 11906160,
+      "AvlAllocator::allocate": 12312032,
+      "BitmapAllocator::allocate": 12286992,
       "BlueStore::_do_write": 11573968,
       "BlueStore::_txc_add_transaction": 11585136,
       "BlueStore::_txc_apply_kv": 11433728,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 19902544,
       "BlueStore::log_latency_fn": 11615760,
       "BlueStore::queue_transactions": 11592128,
+      "Btree2Allocator::allocate": 12340704,
+      "BtreeAllocator::allocate": 12314992,
       "ECBackend::submit_transaction": 10184096,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 12344064,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 12341520,
+      "HybridBtree2Allocator::allocate": 12342832,
       "OSD::dequeue_op": 6632304,
       "OSD::enqueue_op": 6628048,
       "OpRequest::mark_flag_point": 15140272,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 8154048,
       "ReplicatedBackend::generate_subop": 8194256,
       "ReplicatedBackend::repop_commit": 8155264,
-      "ReplicatedBackend::submit_transaction": 8198656
+      "ReplicatedBackend::submit_transaction": 8198656,
+      "StupidAllocator::allocate": 12235872
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "AllocatorBase::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:20.2.2-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:20.2.2-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "21c7468038c4f11a99e186d00947ef8c9a3021b3",
     "func2pc": {
+      "AllocatorBase::get_name": 11932800,
+      "AvlAllocator::allocate": 12338560,
+      "BitmapAllocator::allocate": 12313520,
       "BlueStore::_do_write": 11600400,
       "BlueStore::_txc_add_transaction": 11611568,
       "BlueStore::_txc_apply_kv": 11460176,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 19943360,
       "BlueStore::log_latency_fn": 11641456,
       "BlueStore::queue_transactions": 11618560,
+      "Btree2Allocator::allocate": 12367232,
+      "BtreeAllocator::allocate": 12341520,
       "ECBackend::submit_transaction": 10202000,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 12370592,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 12368048,
+      "HybridBtree2Allocator::allocate": 12369360,
       "OSD::dequeue_op": 6665232,
       "OSD::enqueue_op": 6660976,
       "OpRequest::mark_flag_point": 15170976,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 8173008,
       "ReplicatedBackend::generate_subop": 8216240,
       "ReplicatedBackend::repop_commit": 8174224,
-      "ReplicatedBackend::submit_transaction": 8220640
+      "ReplicatedBackend::submit_transaction": 8220640,
+      "StupidAllocator::allocate": 12262400
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "AllocatorBase::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/centos-stream/osdtrace/osd-2:20.2.3-0.el9_dwarf.json
+++ b/files/centos-stream/osdtrace/osd-2:20.2.3-0.el9_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "48ede7820d5cb5ba0e7bc9854ef0e6e3c748882a",
     "func2pc": {
+      "AllocatorBase::get_name": 11935344,
+      "AvlAllocator::allocate": 12341488,
+      "BitmapAllocator::allocate": 12316448,
       "BlueStore::_do_write": 11602816,
       "BlueStore::_txc_add_transaction": 11613984,
       "BlueStore::_txc_apply_kv": 11462560,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 19952688,
       "BlueStore::log_latency_fn": 11643872,
       "BlueStore::queue_transactions": 11620976,
+      "Btree2Allocator::allocate": 12370160,
+      "BtreeAllocator::allocate": 12344448,
       "ECBackend::submit_transaction": 10212240,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 12373520,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 12370976,
+      "HybridBtree2Allocator::allocate": 12372288,
       "OSD::dequeue_op": 6647072,
       "OSD::enqueue_op": 6642816,
       "OpRequest::mark_flag_point": 15179392,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 8174384,
       "ReplicatedBackend::generate_subop": 8217616,
       "ReplicatedBackend::repop_commit": 8175600,
-      "ReplicatedBackend::submit_transaction": 8222016
+      "ReplicatedBackend::submit_transaction": 8222016,
+      "StupidAllocator::allocate": 12265328
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "AllocatorBase::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/debian/osdtrace/osd-18.2.7+ds-1_dwarf.json
+++ b/files/debian/osdtrace/osd-18.2.7+ds-1_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "18.2.7+ds-1",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "43240de334d28cf53de108f7d44110a81bd6ee79",
-        "func2pc": {
-            "BlueStore::_do_write": 13671680,
-            "BlueStore::_txc_add_transaction": 13796512,
-            "BlueStore::_txc_apply_kv": 13302208,
-            "BlueStore::_txc_calc_cost": 13659168,
-            "BlueStore::_txc_state_proc": 13806704,
-            "BlueStore::_wctx_finish": 13475648,
-            "BlueStore::log_latency": 14014432,
-            "BlueStore::log_latency_fn": 14023440,
-            "BlueStore::queue_transactions": 13820336,
-            "ECBackend::submit_transaction": 12559888,
-            "OSD::dequeue_op": 7934016,
-            "OSD::enqueue_op": 8004576,
-            "OpRequest::mark_flag_point": 18391440,
-            "OpRequest::mark_flag_point_string": 18391584,
-            "PrimaryLogPG::execute_ctx": 9576272,
-            "PrimaryLogPG::log_op_stats": 9159264,
-            "ReplicatedBackend::do_repop_reply": 12203392,
-            "ReplicatedBackend::generate_subop": 12181840,
-            "ReplicatedBackend::repop_commit": 12215968,
-            "ReplicatedBackend::submit_transaction": 12198400
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "18.2.7+ds-1",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "43240de334d28cf53de108f7d44110a81bd6ee79",
+    "func2pc": {
+      "BlueStore::_do_write": 13671680,
+      "BlueStore::_txc_add_transaction": 13796512,
+      "BlueStore::_txc_apply_kv": 13302208,
+      "BlueStore::_txc_calc_cost": 13659168,
+      "BlueStore::_txc_state_proc": 13806704,
+      "BlueStore::_wctx_finish": 13475648,
+      "BlueStore::log_latency": 14014432,
+      "BlueStore::log_latency_fn": 14023440,
+      "BlueStore::queue_transactions": 13820336,
+      "ECBackend::submit_transaction": 12559888,
+      "OSD::dequeue_op": 7934016,
+      "OSD::enqueue_op": 8004576,
+      "OpRequest::mark_flag_point": 18391440,
+      "OpRequest::mark_flag_point_string": 18391584,
+      "PrimaryLogPG::execute_ctx": 9576272,
+      "PrimaryLogPG::log_op_stats": 9159264,
+      "ReplicatedBackend::do_repop_reply": 12203392,
+      "ReplicatedBackend::generate_subop": 12181840,
+      "ReplicatedBackend::repop_commit": 12215968,
+      "ReplicatedBackend::submit_transaction": 12198400
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 728,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 728,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 728,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 728,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 160,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/debian/osdtrace/osd-18.2.7+ds-1_dwarf.json
+++ b/files/debian/osdtrace/osd-18.2.7+ds-1_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "43240de334d28cf53de108f7d44110a81bd6ee79",
     "func2pc": {
+      "Allocator::get_name": 14144832,
+      "AvlAllocator::allocate": 14514816,
+      "BitmapAllocator::allocate": 14488288,
       "BlueStore::_do_write": 13671680,
       "BlueStore::_txc_add_transaction": 13796512,
       "BlueStore::_txc_apply_kv": 13302208,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 14014432,
       "BlueStore::log_latency_fn": 14023440,
       "BlueStore::queue_transactions": 13820336,
+      "BtreeAllocator::allocate": 14538816,
       "ECBackend::submit_transaction": 12559888,
+      "HybridAllocator::allocate": 14568064,
       "OSD::dequeue_op": 7934016,
       "OSD::enqueue_op": 8004576,
       "OpRequest::mark_flag_point": 18391440,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 12203392,
       "ReplicatedBackend::generate_subop": 12181840,
       "ReplicatedBackend::repop_commit": 12215968,
-      "ReplicatedBackend::submit_transaction": 12198400
+      "ReplicatedBackend::submit_transaction": 12198400,
+      "StupidAllocator::allocate": 14465536
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/debian/radostrace/18.2.7+ds-1_dwarf.json
+++ b/files/debian/radostrace/18.2.7+ds-1_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "18.2.7+ds-1",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "3d5071d7aa3ba5906909b5af9c17916d49f463d9",
-        "func2pc": {
-            "Objecter::_finish_op": 8731584,
-            "Objecter::_send_op": 8675392
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "18.2.7+ds-1",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "3d5071d7aa3ba5906909b5af9c17916d49f463d9",
+    "func2pc": {
+      "Objecter::_finish_op": 8731584,
+      "Objecter::_send_op": 8675392
     },
-    "librados.so.2": {
-        "build_id": "db58d5e5bd1ed353110ae4b19ba270c188a27e8b",
-        "func2pc": {
-            "Objecter::_finish_op": 1005696,
-            "Objecter::_send_op": 949504
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "e5806305275cda8edc4e898b9b3cf9c1170a34c0",
-        "func2pc": {
-            "Objecter::_finish_op": 7208192,
-            "Objecter::_send_op": 7152000
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "db58d5e5bd1ed353110ae4b19ba270c188a27e8b",
+    "func2pc": {
+      "Objecter::_finish_op": 1005696,
+      "Objecter::_send_op": 949504
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "e5806305275cda8edc4e898b9b3cf9c1170a34c0",
+    "func2pc": {
+      "Objecter::_finish_op": 7208192,
+      "Objecter::_send_op": 7152000
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-15.2.17-0ubuntu0.20.04.6_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-15.2.17-0ubuntu0.20.04.6_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "254fd8aa10290a29f04468e831951223a0a32ef1",
     "func2pc": {
+      "Allocator::get_name": 12591296,
+      "AvlAllocator::allocate": 13001200,
+      "BitmapAllocator::allocate": 12974688,
       "BlueStore::_do_write": 11905456,
       "BlueStore::_txc_add_transaction": 11987712,
       "BlueStore::_txc_apply_kv": 11671824,
@@ -14,6 +17,7 @@
       "BlueStore::log_latency_fn": 12192784,
       "BlueStore::queue_transactions": 11999168,
       "ECBackend::submit_transaction": 10213376,
+      "HybridAllocator::allocate": 13015248,
       "OSD::dequeue_op": 6194528,
       "OSD::enqueue_op": 6301920,
       "OpRequest::mark_flag_point": 16414256,
@@ -23,7 +27,8 @@
       "ReplicatedBackend::do_repop_reply": 9913376,
       "ReplicatedBackend::generate_subop": 9893024,
       "ReplicatedBackend::repop_commit": 9928784,
-      "ReplicatedBackend::submit_transaction": 9908896
+      "ReplicatedBackend::submit_transaction": 9908896,
+      "StupidAllocator::allocate": 12938704
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +39,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -432,6 +562,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1801,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-15.2.17-0ubuntu0.20.04.6_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-15.2.17-0ubuntu0.20.04.6_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "15.2.17-0ubuntu0.20.04.6",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "254fd8aa10290a29f04468e831951223a0a32ef1",
-        "func2pc": {
-            "BlueStore::_do_write": 11905456,
-            "BlueStore::_txc_add_transaction": 11987712,
-            "BlueStore::_txc_apply_kv": 11671824,
-            "BlueStore::_txc_calc_cost": 11568000,
-            "BlueStore::_txc_state_proc": 11716496,
-            "BlueStore::_wctx_finish": 11765424,
-            "BlueStore::log_latency": 12192144,
-            "BlueStore::log_latency_fn": 12192784,
-            "BlueStore::queue_transactions": 11999168,
-            "ECBackend::submit_transaction": 10213376,
-            "OSD::dequeue_op": 6194528,
-            "OSD::enqueue_op": 6301920,
-            "OpRequest::mark_flag_point": 16414256,
-            "OpRequest::mark_flag_point_string": 16414400,
-            "PrimaryLogPG::execute_ctx": 7844432,
-            "PrimaryLogPG::log_op_stats": 7419280,
-            "ReplicatedBackend::do_repop_reply": 9913376,
-            "ReplicatedBackend::generate_subop": 9893024,
-            "ReplicatedBackend::repop_commit": 9928784,
-            "ReplicatedBackend::submit_transaction": 9908896
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "15.2.17-0ubuntu0.20.04.6",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "254fd8aa10290a29f04468e831951223a0a32ef1",
+    "func2pc": {
+      "BlueStore::_do_write": 11905456,
+      "BlueStore::_txc_add_transaction": 11987712,
+      "BlueStore::_txc_apply_kv": 11671824,
+      "BlueStore::_txc_calc_cost": 11568000,
+      "BlueStore::_txc_state_proc": 11716496,
+      "BlueStore::_wctx_finish": 11765424,
+      "BlueStore::log_latency": 12192144,
+      "BlueStore::log_latency_fn": 12192784,
+      "BlueStore::queue_transactions": 11999168,
+      "ECBackend::submit_transaction": 10213376,
+      "OSD::dequeue_op": 6194528,
+      "OSD::enqueue_op": 6301920,
+      "OpRequest::mark_flag_point": 16414256,
+      "OpRequest::mark_flag_point_string": 16414400,
+      "PrimaryLogPG::execute_ctx": 7844432,
+      "PrimaryLogPG::log_op_stats": 7419280,
+      "ReplicatedBackend::do_repop_reply": 9913376,
+      "ReplicatedBackend::generate_subop": 9893024,
+      "ReplicatedBackend::repop_commit": 9928784,
+      "ReplicatedBackend::submit_transaction": 9908896
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 288,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 704,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 288,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 704,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 512,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 288,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 704,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 288,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 704,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 288,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 704,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 512,
+                "pointer": true
+              },
+              {
+                "offset": 160,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 288,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 704,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-17.2.6-0ubuntu0.22.04.3_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.6-0ubuntu0.22.04.3_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "82b1bd65d889f7b6eb4223a95d81da84b1d2855a",
     "func2pc": {
+      "Allocator::get_name": 13341904,
+      "AvlAllocator::allocate": 13684128,
+      "BitmapAllocator::allocate": 13659280,
       "BlueStore::_do_write": 12618640,
       "BlueStore::_txc_add_transaction": 12703136,
       "BlueStore::_txc_apply_kv": 12638624,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 12952464,
       "BlueStore::log_latency_fn": 12953104,
       "BlueStore::queue_transactions": 12712016,
+      "BtreeAllocator::allocate": 13707280,
       "ECBackend::submit_transaction": 11108160,
+      "HybridAllocator::allocate": 13732624,
       "OSD::dequeue_op": 6922480,
       "OSD::enqueue_op": 6987232,
       "OpRequest::mark_flag_point": 17223184,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 10793200,
       "ReplicatedBackend::generate_subop": 10777520,
       "ReplicatedBackend::repop_commit": 10804864,
-      "ReplicatedBackend::submit_transaction": 10783616
+      "ReplicatedBackend::submit_transaction": 10783616,
+      "StupidAllocator::allocate": 13635360
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-17.2.6-0ubuntu0.22.04.3_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.6-0ubuntu0.22.04.3_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "17.2.6-0ubuntu0.22.04.3",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "82b1bd65d889f7b6eb4223a95d81da84b1d2855a",
-        "func2pc": {
-            "BlueStore::_do_write": 12618640,
-            "BlueStore::_txc_add_transaction": 12703136,
-            "BlueStore::_txc_apply_kv": 12638624,
-            "BlueStore::_txc_calc_cost": 12517216,
-            "BlueStore::_txc_state_proc": 12639840,
-            "BlueStore::_wctx_finish": 12591264,
-            "BlueStore::log_latency": 12952464,
-            "BlueStore::log_latency_fn": 12953104,
-            "BlueStore::queue_transactions": 12712016,
-            "ECBackend::submit_transaction": 11108160,
-            "OSD::dequeue_op": 6922480,
-            "OSD::enqueue_op": 6987232,
-            "OpRequest::mark_flag_point": 17223184,
-            "OpRequest::mark_flag_point_string": 17223328,
-            "PrimaryLogPG::execute_ctx": 8489376,
-            "PrimaryLogPG::log_op_stats": 8086096,
-            "ReplicatedBackend::do_repop_reply": 10793200,
-            "ReplicatedBackend::generate_subop": 10777520,
-            "ReplicatedBackend::repop_commit": 10804864,
-            "ReplicatedBackend::submit_transaction": 10783616
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "17.2.6-0ubuntu0.22.04.3",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "82b1bd65d889f7b6eb4223a95d81da84b1d2855a",
+    "func2pc": {
+      "BlueStore::_do_write": 12618640,
+      "BlueStore::_txc_add_transaction": 12703136,
+      "BlueStore::_txc_apply_kv": 12638624,
+      "BlueStore::_txc_calc_cost": 12517216,
+      "BlueStore::_txc_state_proc": 12639840,
+      "BlueStore::_wctx_finish": 12591264,
+      "BlueStore::log_latency": 12952464,
+      "BlueStore::log_latency_fn": 12953104,
+      "BlueStore::queue_transactions": 12712016,
+      "ECBackend::submit_transaction": 11108160,
+      "OSD::dequeue_op": 6922480,
+      "OSD::enqueue_op": 6987232,
+      "OpRequest::mark_flag_point": 17223184,
+      "OpRequest::mark_flag_point_string": 17223328,
+      "PrimaryLogPG::execute_ctx": 8489376,
+      "PrimaryLogPG::log_op_stats": 8086096,
+      "ReplicatedBackend::do_repop_reply": 10793200,
+      "ReplicatedBackend::generate_subop": 10777520,
+      "ReplicatedBackend::repop_commit": 10804864,
+      "ReplicatedBackend::submit_transaction": 10783616
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 752,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 752,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 184,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 752,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 752,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 184,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-17.2.7-0ubuntu0.22.04.1_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.7-0ubuntu0.22.04.1_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "cda98ccdb608a670dd7e01f5c5f41bddee9ec2c7",
     "func2pc": {
+      "Allocator::get_name": 13392992,
+      "AvlAllocator::allocate": 13736768,
+      "BitmapAllocator::allocate": 13710576,
       "BlueStore::_do_write": 12672656,
       "BlueStore::_txc_add_transaction": 12791200,
       "BlueStore::_txc_apply_kv": 12692640,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 13003520,
       "BlueStore::log_latency_fn": 13004160,
       "BlueStore::queue_transactions": 12800080,
+      "BtreeAllocator::allocate": 13759984,
       "ECBackend::submit_transaction": 11157024,
+      "HybridAllocator::allocate": 13786352,
       "OSD::dequeue_op": 6936832,
       "OSD::enqueue_op": 7002304,
       "OpRequest::mark_flag_point": 17283808,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 10839408,
       "ReplicatedBackend::generate_subop": 10823680,
       "ReplicatedBackend::repop_commit": 10851072,
-      "ReplicatedBackend::submit_transaction": 10829824
+      "ReplicatedBackend::submit_transaction": 10829824,
+      "StupidAllocator::allocate": 13687520
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-17.2.7-0ubuntu0.22.04.1_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.7-0ubuntu0.22.04.1_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "17.2.7-0ubuntu0.22.04.1",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "cda98ccdb608a670dd7e01f5c5f41bddee9ec2c7",
-        "func2pc": {
-            "BlueStore::_do_write": 12672656,
-            "BlueStore::_txc_add_transaction": 12791200,
-            "BlueStore::_txc_apply_kv": 12692640,
-            "BlueStore::_txc_calc_cost": 12563584,
-            "BlueStore::_txc_state_proc": 12693856,
-            "BlueStore::_wctx_finish": 12645376,
-            "BlueStore::log_latency": 13003520,
-            "BlueStore::log_latency_fn": 13004160,
-            "BlueStore::queue_transactions": 12800080,
-            "ECBackend::submit_transaction": 11157024,
-            "OSD::dequeue_op": 6936832,
-            "OSD::enqueue_op": 7002304,
-            "OpRequest::mark_flag_point": 17283808,
-            "OpRequest::mark_flag_point_string": 17283952,
-            "PrimaryLogPG::execute_ctx": 8504768,
-            "PrimaryLogPG::log_op_stats": 8102016,
-            "ReplicatedBackend::do_repop_reply": 10839408,
-            "ReplicatedBackend::generate_subop": 10823680,
-            "ReplicatedBackend::repop_commit": 10851072,
-            "ReplicatedBackend::submit_transaction": 10829824
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "17.2.7-0ubuntu0.22.04.1",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "cda98ccdb608a670dd7e01f5c5f41bddee9ec2c7",
+    "func2pc": {
+      "BlueStore::_do_write": 12672656,
+      "BlueStore::_txc_add_transaction": 12791200,
+      "BlueStore::_txc_apply_kv": 12692640,
+      "BlueStore::_txc_calc_cost": 12563584,
+      "BlueStore::_txc_state_proc": 12693856,
+      "BlueStore::_wctx_finish": 12645376,
+      "BlueStore::log_latency": 13003520,
+      "BlueStore::log_latency_fn": 13004160,
+      "BlueStore::queue_transactions": 12800080,
+      "ECBackend::submit_transaction": 11157024,
+      "OSD::dequeue_op": 6936832,
+      "OSD::enqueue_op": 7002304,
+      "OpRequest::mark_flag_point": 17283808,
+      "OpRequest::mark_flag_point_string": 17283952,
+      "PrimaryLogPG::execute_ctx": 8504768,
+      "PrimaryLogPG::log_op_stats": 8102016,
+      "ReplicatedBackend::do_repop_reply": 10839408,
+      "ReplicatedBackend::generate_subop": 10823680,
+      "ReplicatedBackend::repop_commit": 10851072,
+      "ReplicatedBackend::submit_transaction": 10829824
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 752,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 752,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 184,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 752,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 752,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 184,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-17.2.7-0ubuntu0.22.04.1~cloud0_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.7-0ubuntu0.22.04.1~cloud0_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "17.2.7-0ubuntu0.22.04.1~cloud0",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "e427742f98a87fcfe343d5aaba10d9b07ce4c32f",
-        "func2pc": {
-            "BlueStore::_do_write": 13642848,
-            "BlueStore::_txc_add_transaction": 13655168,
-            "BlueStore::_txc_apply_kv": 13396272,
-            "BlueStore::_txc_calc_cost": 13249248,
-            "BlueStore::_txc_state_proc": 13598976,
-            "BlueStore::_wctx_finish": 13620336,
-            "BlueStore::log_latency": 13962064,
-            "BlueStore::log_latency_fn": 13962704,
-            "BlueStore::queue_transactions": 13666848,
-            "ECBackend::submit_transaction": 11869840,
-            "OSD::dequeue_op": 7329824,
-            "OSD::enqueue_op": 7441168,
-            "OpRequest::mark_flag_point": 18455824,
-            "OpRequest::mark_flag_point_string": 18455968,
-            "PrimaryLogPG::execute_ctx": 9011168,
-            "PrimaryLogPG::log_op_stats": 8541328,
-            "ReplicatedBackend::do_repop_reply": 11561504,
-            "ReplicatedBackend::generate_subop": 11539104,
-            "ReplicatedBackend::repop_commit": 11576960,
-            "ReplicatedBackend::submit_transaction": 11557008
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "17.2.7-0ubuntu0.22.04.1~cloud0",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "e427742f98a87fcfe343d5aaba10d9b07ce4c32f",
+    "func2pc": {
+      "BlueStore::_do_write": 13642848,
+      "BlueStore::_txc_add_transaction": 13655168,
+      "BlueStore::_txc_apply_kv": 13396272,
+      "BlueStore::_txc_calc_cost": 13249248,
+      "BlueStore::_txc_state_proc": 13598976,
+      "BlueStore::_wctx_finish": 13620336,
+      "BlueStore::log_latency": 13962064,
+      "BlueStore::log_latency_fn": 13962704,
+      "BlueStore::queue_transactions": 13666848,
+      "ECBackend::submit_transaction": 11869840,
+      "OSD::dequeue_op": 7329824,
+      "OSD::enqueue_op": 7441168,
+      "OpRequest::mark_flag_point": 18455824,
+      "OpRequest::mark_flag_point_string": 18455968,
+      "PrimaryLogPG::execute_ctx": 9011168,
+      "PrimaryLogPG::log_op_stats": 8541328,
+      "ReplicatedBackend::do_repop_reply": 11561504,
+      "ReplicatedBackend::generate_subop": 11539104,
+      "ReplicatedBackend::repop_commit": 11576960,
+      "ReplicatedBackend::submit_transaction": 11557008
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 752,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 752,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 184,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 752,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 752,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 184,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-17.2.7-0ubuntu0.22.04.1~cloud0_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.7-0ubuntu0.22.04.1~cloud0_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "e427742f98a87fcfe343d5aaba10d9b07ce4c32f",
     "func2pc": {
+      "Allocator::get_name": 14379008,
+      "AvlAllocator::allocate": 14781440,
+      "BitmapAllocator::allocate": 14753552,
       "BlueStore::_do_write": 13642848,
       "BlueStore::_txc_add_transaction": 13655168,
       "BlueStore::_txc_apply_kv": 13396272,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 13962064,
       "BlueStore::log_latency_fn": 13962704,
       "BlueStore::queue_transactions": 13666848,
+      "BtreeAllocator::allocate": 14803184,
       "ECBackend::submit_transaction": 11869840,
+      "HybridAllocator::allocate": 14833904,
       "OSD::dequeue_op": 7329824,
       "OSD::enqueue_op": 7441168,
       "OpRequest::mark_flag_point": 18455824,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 11561504,
       "ReplicatedBackend::generate_subop": 11539104,
       "ReplicatedBackend::repop_commit": 11576960,
-      "ReplicatedBackend::submit_transaction": 11557008
+      "ReplicatedBackend::submit_transaction": 11557008,
+      "StupidAllocator::allocate": 14718704
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-17.2.7-0ubuntu0.22.04.2_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.7-0ubuntu0.22.04.2_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "0d21298ec69fb32a3c78996a1ffcaf9e70ca8ba7",
     "func2pc": {
+      "Allocator::get_name": 13392992,
+      "AvlAllocator::allocate": 13736768,
+      "BitmapAllocator::allocate": 13710576,
       "BlueStore::_do_write": 12672656,
       "BlueStore::_txc_add_transaction": 12791200,
       "BlueStore::_txc_apply_kv": 12692640,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 13003520,
       "BlueStore::log_latency_fn": 13004160,
       "BlueStore::queue_transactions": 12800080,
+      "BtreeAllocator::allocate": 13759984,
       "ECBackend::submit_transaction": 11157024,
+      "HybridAllocator::allocate": 13786352,
       "OSD::dequeue_op": 6936832,
       "OSD::enqueue_op": 7002304,
       "OpRequest::mark_flag_point": 17283808,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 10839408,
       "ReplicatedBackend::generate_subop": 10823680,
       "ReplicatedBackend::repop_commit": 10851072,
-      "ReplicatedBackend::submit_transaction": 10829824
+      "ReplicatedBackend::submit_transaction": 10829824,
+      "StupidAllocator::allocate": 13687520
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-17.2.7-0ubuntu0.22.04.2_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.7-0ubuntu0.22.04.2_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "17.2.7-0ubuntu0.22.04.2",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "0d21298ec69fb32a3c78996a1ffcaf9e70ca8ba7",
-        "func2pc": {
-            "BlueStore::_do_write": 12672656,
-            "BlueStore::_txc_add_transaction": 12791200,
-            "BlueStore::_txc_apply_kv": 12692640,
-            "BlueStore::_txc_calc_cost": 12563584,
-            "BlueStore::_txc_state_proc": 12693856,
-            "BlueStore::_wctx_finish": 12645376,
-            "BlueStore::log_latency": 13003520,
-            "BlueStore::log_latency_fn": 13004160,
-            "BlueStore::queue_transactions": 12800080,
-            "ECBackend::submit_transaction": 11157024,
-            "OSD::dequeue_op": 6936832,
-            "OSD::enqueue_op": 7002304,
-            "OpRequest::mark_flag_point": 17283808,
-            "OpRequest::mark_flag_point_string": 17283952,
-            "PrimaryLogPG::execute_ctx": 8504768,
-            "PrimaryLogPG::log_op_stats": 8102016,
-            "ReplicatedBackend::do_repop_reply": 10839408,
-            "ReplicatedBackend::generate_subop": 10823680,
-            "ReplicatedBackend::repop_commit": 10851072,
-            "ReplicatedBackend::submit_transaction": 10829824
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "17.2.7-0ubuntu0.22.04.2",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "0d21298ec69fb32a3c78996a1ffcaf9e70ca8ba7",
+    "func2pc": {
+      "BlueStore::_do_write": 12672656,
+      "BlueStore::_txc_add_transaction": 12791200,
+      "BlueStore::_txc_apply_kv": 12692640,
+      "BlueStore::_txc_calc_cost": 12563584,
+      "BlueStore::_txc_state_proc": 12693856,
+      "BlueStore::_wctx_finish": 12645376,
+      "BlueStore::log_latency": 13003520,
+      "BlueStore::log_latency_fn": 13004160,
+      "BlueStore::queue_transactions": 12800080,
+      "ECBackend::submit_transaction": 11157024,
+      "OSD::dequeue_op": 6936832,
+      "OSD::enqueue_op": 7002304,
+      "OpRequest::mark_flag_point": 17283808,
+      "OpRequest::mark_flag_point_string": 17283952,
+      "PrimaryLogPG::execute_ctx": 8504768,
+      "PrimaryLogPG::log_op_stats": 8102016,
+      "ReplicatedBackend::do_repop_reply": 10839408,
+      "ReplicatedBackend::generate_subop": 10823680,
+      "ReplicatedBackend::repop_commit": 10851072,
+      "ReplicatedBackend::submit_transaction": 10829824
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 752,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 752,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 184,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 752,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 752,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 184,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 232,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 232,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.1_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.1_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "17.2.9-0ubuntu0.22.04.1",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "a688608a8d0f7c30e67c81eaf6a476de7567fa71",
-        "func2pc": {
-            "BlueStore::_do_write": 12700304,
-            "BlueStore::_txc_add_transaction": 12818704,
-            "BlueStore::_txc_apply_kv": 12720160,
-            "BlueStore::_txc_calc_cost": 12604672,
-            "BlueStore::_txc_state_proc": 12721376,
-            "BlueStore::_wctx_finish": 12673024,
-            "BlueStore::log_latency": 13034880,
-            "BlueStore::log_latency_fn": 13038816,
-            "BlueStore::queue_transactions": 12827248,
-            "ECBackend::submit_transaction": 11184320,
-            "OSD::dequeue_op": 6948672,
-            "OSD::enqueue_op": 7015120,
-            "OpRequest::mark_flag_point": 17337312,
-            "OpRequest::mark_flag_point_string": 17337456,
-            "PrimaryLogPG::execute_ctx": 8532800,
-            "PrimaryLogPG::log_op_stats": 8129632,
-            "ReplicatedBackend::do_repop_reply": 10866960,
-            "ReplicatedBackend::generate_subop": 10851232,
-            "ReplicatedBackend::repop_commit": 10878624,
-            "ReplicatedBackend::submit_transaction": 10857376
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "17.2.9-0ubuntu0.22.04.1",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "a688608a8d0f7c30e67c81eaf6a476de7567fa71",
+    "func2pc": {
+      "BlueStore::_do_write": 12700304,
+      "BlueStore::_txc_add_transaction": 12818704,
+      "BlueStore::_txc_apply_kv": 12720160,
+      "BlueStore::_txc_calc_cost": 12604672,
+      "BlueStore::_txc_state_proc": 12721376,
+      "BlueStore::_wctx_finish": 12673024,
+      "BlueStore::log_latency": 13034880,
+      "BlueStore::log_latency_fn": 13038816,
+      "BlueStore::queue_transactions": 12827248,
+      "ECBackend::submit_transaction": 11184320,
+      "OSD::dequeue_op": 6948672,
+      "OSD::enqueue_op": 7015120,
+      "OpRequest::mark_flag_point": 17337312,
+      "OpRequest::mark_flag_point_string": 17337456,
+      "PrimaryLogPG::execute_ctx": 8532800,
+      "PrimaryLogPG::log_op_stats": 8129632,
+      "ReplicatedBackend::do_repop_reply": 10866960,
+      "ReplicatedBackend::generate_subop": 10851232,
+      "ReplicatedBackend::repop_commit": 10878624,
+      "ReplicatedBackend::submit_transaction": 10857376
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 752,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 752,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 184,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 752,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 752,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 184,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.1_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.1_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "a688608a8d0f7c30e67c81eaf6a476de7567fa71",
     "func2pc": {
+      "Allocator::get_name": 13420048,
+      "AvlAllocator::allocate": 13766976,
+      "BitmapAllocator::allocate": 13740896,
       "BlueStore::_do_write": 12700304,
       "BlueStore::_txc_add_transaction": 12818704,
       "BlueStore::_txc_apply_kv": 12720160,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 13034880,
       "BlueStore::log_latency_fn": 13038816,
       "BlueStore::queue_transactions": 12827248,
+      "BtreeAllocator::allocate": 13790160,
       "ECBackend::submit_transaction": 11184320,
+      "HybridAllocator::allocate": 13816528,
       "OSD::dequeue_op": 6948672,
       "OSD::enqueue_op": 7015120,
       "OpRequest::mark_flag_point": 17337312,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 10866960,
       "ReplicatedBackend::generate_subop": 10851232,
       "ReplicatedBackend::repop_commit": 10878624,
-      "ReplicatedBackend::submit_transaction": 10857376
+      "ReplicatedBackend::submit_transaction": 10857376,
+      "StupidAllocator::allocate": 13717840
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.1~cloud0_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.1~cloud0_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "a5ca92639c1e4333d03a37d192659655a3de3748",
     "func2pc": {
+      "Allocator::get_name": 14419888,
+      "AvlAllocator::allocate": 14824496,
+      "BitmapAllocator::allocate": 14796704,
       "BlueStore::_do_write": 13608560,
       "BlueStore::_txc_add_transaction": 13742176,
       "BlueStore::_txc_apply_kv": 13449600,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 14006384,
       "BlueStore::log_latency_fn": 14007040,
       "BlueStore::queue_transactions": 13775744,
+      "BtreeAllocator::allocate": 14846160,
       "ECBackend::submit_transaction": 11904352,
+      "HybridAllocator::allocate": 14876880,
       "OSD::dequeue_op": 7353168,
       "OSD::enqueue_op": 7464224,
       "OpRequest::mark_flag_point": 18519424,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 11595328,
       "ReplicatedBackend::generate_subop": 11572928,
       "ReplicatedBackend::repop_commit": 11610784,
-      "ReplicatedBackend::submit_transaction": 11590832
+      "ReplicatedBackend::submit_transaction": 11590832,
+      "StupidAllocator::allocate": 14761856
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.1~cloud0_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.1~cloud0_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "17.2.9-0ubuntu0.22.04.1~cloud0",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "a5ca92639c1e4333d03a37d192659655a3de3748",
-        "func2pc": {
-            "BlueStore::_do_write": 13608560,
-            "BlueStore::_txc_add_transaction": 13742176,
-            "BlueStore::_txc_apply_kv": 13449600,
-            "BlueStore::_txc_calc_cost": 13293584,
-            "BlueStore::_txc_state_proc": 13758912,
-            "BlueStore::_wctx_finish": 13434320,
-            "BlueStore::log_latency": 14006384,
-            "BlueStore::log_latency_fn": 14007040,
-            "BlueStore::queue_transactions": 13775744,
-            "ECBackend::submit_transaction": 11904352,
-            "OSD::dequeue_op": 7353168,
-            "OSD::enqueue_op": 7464224,
-            "OpRequest::mark_flag_point": 18519424,
-            "OpRequest::mark_flag_point_string": 18519568,
-            "PrimaryLogPG::execute_ctx": 9061456,
-            "PrimaryLogPG::log_op_stats": 8577008,
-            "ReplicatedBackend::do_repop_reply": 11595328,
-            "ReplicatedBackend::generate_subop": 11572928,
-            "ReplicatedBackend::repop_commit": 11610784,
-            "ReplicatedBackend::submit_transaction": 11590832
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "17.2.9-0ubuntu0.22.04.1~cloud0",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "a5ca92639c1e4333d03a37d192659655a3de3748",
+    "func2pc": {
+      "BlueStore::_do_write": 13608560,
+      "BlueStore::_txc_add_transaction": 13742176,
+      "BlueStore::_txc_apply_kv": 13449600,
+      "BlueStore::_txc_calc_cost": 13293584,
+      "BlueStore::_txc_state_proc": 13758912,
+      "BlueStore::_wctx_finish": 13434320,
+      "BlueStore::log_latency": 14006384,
+      "BlueStore::log_latency_fn": 14007040,
+      "BlueStore::queue_transactions": 13775744,
+      "ECBackend::submit_transaction": 11904352,
+      "OSD::dequeue_op": 7353168,
+      "OSD::enqueue_op": 7464224,
+      "OpRequest::mark_flag_point": 18519424,
+      "OpRequest::mark_flag_point_string": 18519568,
+      "PrimaryLogPG::execute_ctx": 9061456,
+      "PrimaryLogPG::log_op_stats": 8577008,
+      "ReplicatedBackend::do_repop_reply": 11595328,
+      "ReplicatedBackend::generate_subop": 11572928,
+      "ReplicatedBackend::repop_commit": 11610784,
+      "ReplicatedBackend::submit_transaction": 11590832
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 752,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 752,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 184,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 752,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 752,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 184,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.2_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.2_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "ddb878ac38ac981163fff4679ba5df948a274267",
     "func2pc": {
+      "Allocator::get_name": 13420048,
+      "AvlAllocator::allocate": 13766976,
+      "BitmapAllocator::allocate": 13740896,
       "BlueStore::_do_write": 12700304,
       "BlueStore::_txc_add_transaction": 12818704,
       "BlueStore::_txc_apply_kv": 12720160,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 13034880,
       "BlueStore::log_latency_fn": 13038816,
       "BlueStore::queue_transactions": 12827248,
+      "BtreeAllocator::allocate": 13790160,
       "ECBackend::submit_transaction": 11184320,
+      "HybridAllocator::allocate": 13816528,
       "OSD::dequeue_op": 6948672,
       "OSD::enqueue_op": 7015120,
       "OpRequest::mark_flag_point": 17337312,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 10866960,
       "ReplicatedBackend::generate_subop": 10851232,
       "ReplicatedBackend::repop_commit": 10878624,
-      "ReplicatedBackend::submit_transaction": 10857376
+      "ReplicatedBackend::submit_transaction": 10857376,
+      "StupidAllocator::allocate": 13717840
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.2_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.2_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "17.2.9-0ubuntu0.22.04.2",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "ddb878ac38ac981163fff4679ba5df948a274267",
-        "func2pc": {
-            "BlueStore::_do_write": 12700304,
-            "BlueStore::_txc_add_transaction": 12818704,
-            "BlueStore::_txc_apply_kv": 12720160,
-            "BlueStore::_txc_calc_cost": 12604672,
-            "BlueStore::_txc_state_proc": 12721376,
-            "BlueStore::_wctx_finish": 12673024,
-            "BlueStore::log_latency": 13034880,
-            "BlueStore::log_latency_fn": 13038816,
-            "BlueStore::queue_transactions": 12827248,
-            "ECBackend::submit_transaction": 11184320,
-            "OSD::dequeue_op": 6948672,
-            "OSD::enqueue_op": 7015120,
-            "OpRequest::mark_flag_point": 17337312,
-            "OpRequest::mark_flag_point_string": 17337456,
-            "PrimaryLogPG::execute_ctx": 8532800,
-            "PrimaryLogPG::log_op_stats": 8129632,
-            "ReplicatedBackend::do_repop_reply": 10866960,
-            "ReplicatedBackend::generate_subop": 10851232,
-            "ReplicatedBackend::repop_commit": 10878624,
-            "ReplicatedBackend::submit_transaction": 10857376
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "17.2.9-0ubuntu0.22.04.2",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "ddb878ac38ac981163fff4679ba5df948a274267",
+    "func2pc": {
+      "BlueStore::_do_write": 12700304,
+      "BlueStore::_txc_add_transaction": 12818704,
+      "BlueStore::_txc_apply_kv": 12720160,
+      "BlueStore::_txc_calc_cost": 12604672,
+      "BlueStore::_txc_state_proc": 12721376,
+      "BlueStore::_wctx_finish": 12673024,
+      "BlueStore::log_latency": 13034880,
+      "BlueStore::log_latency_fn": 13038816,
+      "BlueStore::queue_transactions": 12827248,
+      "ECBackend::submit_transaction": 11184320,
+      "OSD::dequeue_op": 6948672,
+      "OSD::enqueue_op": 7015120,
+      "OpRequest::mark_flag_point": 17337312,
+      "OpRequest::mark_flag_point_string": 17337456,
+      "PrimaryLogPG::execute_ctx": 8532800,
+      "PrimaryLogPG::log_op_stats": 8129632,
+      "ReplicatedBackend::do_repop_reply": 10866960,
+      "ReplicatedBackend::generate_subop": 10851232,
+      "ReplicatedBackend::repop_commit": 10878624,
+      "ReplicatedBackend::submit_transaction": 10857376
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 752,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 752,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 184,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 752,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 720,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 752,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 184,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 720,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 264,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 264,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.3_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-17.2.9-0ubuntu0.22.04.3_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "28f0efa8527232967ff9b211f89f289e96ac9769",
     "func2pc": {
+      "Allocator::get_name": 13420048,
+      "AvlAllocator::allocate": 13766976,
+      "BitmapAllocator::allocate": 13740896,
       "BlueStore::_do_write": 12700304,
       "BlueStore::_txc_add_transaction": 12818704,
       "BlueStore::_txc_apply_kv": 12720160,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 13034880,
       "BlueStore::log_latency_fn": 13038816,
       "BlueStore::queue_transactions": 12827248,
+      "BtreeAllocator::allocate": 13790160,
       "ECBackend::submit_transaction": 11184320,
+      "HybridAllocator::allocate": 13816528,
       "OSD::dequeue_op": 6948672,
       "OSD::enqueue_op": 7015120,
       "OpRequest::mark_flag_point": 17337312,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 10866960,
       "ReplicatedBackend::generate_subop": 10851232,
       "ReplicatedBackend::repop_commit": 10878624,
-      "ReplicatedBackend::submit_transaction": 10857376
+      "ReplicatedBackend::submit_transaction": 10857376,
+      "StupidAllocator::allocate": 13717840
     },
     "type_sizes": {
       "OSDOp": 152
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-19.2.0-0ubuntu0.24.04.2_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.0-0ubuntu0.24.04.2_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "6cac51923118fae61dd97b077cea3a0db3508da3",
     "func2pc": {
+      "Allocator::get_name": 14271264,
+      "AvlAllocator::allocate": 14643328,
+      "BitmapAllocator::allocate": 14612272,
       "BlueStore::_do_write": 13814432,
       "BlueStore::_txc_add_transaction": 13910560,
       "BlueStore::_txc_apply_kv": 13528256,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 14162704,
       "BlueStore::log_latency_fn": 14163408,
       "BlueStore::queue_transactions": 13936944,
+      "BtreeAllocator::allocate": 14665664,
       "ECBackend::submit_transaction": 12571360,
+      "HybridAllocator::allocate": 14692080,
       "OSD::dequeue_op": 7833952,
       "OSD::enqueue_op": 7926304,
       "OpRequest::mark_flag_point": 18521296,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 12328816,
       "ReplicatedBackend::generate_subop": 12302048,
       "ReplicatedBackend::repop_commit": 12340256,
-      "ReplicatedBackend::submit_transaction": 12320208
+      "ReplicatedBackend::submit_transaction": 12320208,
+      "StupidAllocator::allocate": 14590576
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-19.2.0-0ubuntu0.24.04.2_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.0-0ubuntu0.24.04.2_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "19.2.0-0ubuntu0.24.04.2",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "6cac51923118fae61dd97b077cea3a0db3508da3",
-        "func2pc": {
-            "BlueStore::_do_write": 13814432,
-            "BlueStore::_txc_add_transaction": 13910560,
-            "BlueStore::_txc_apply_kv": 13528256,
-            "BlueStore::_txc_calc_cost": 13481520,
-            "BlueStore::_txc_state_proc": 13924704,
-            "BlueStore::_wctx_finish": 13632336,
-            "BlueStore::log_latency": 14162704,
-            "BlueStore::log_latency_fn": 14163408,
-            "BlueStore::queue_transactions": 13936944,
-            "ECBackend::submit_transaction": 12571360,
-            "OSD::dequeue_op": 7833952,
-            "OSD::enqueue_op": 7926304,
-            "OpRequest::mark_flag_point": 18521296,
-            "OpRequest::mark_flag_point_string": 18521456,
-            "PrimaryLogPG::execute_ctx": 9583280,
-            "PrimaryLogPG::log_op_stats": 9185712,
-            "ReplicatedBackend::do_repop_reply": 12328816,
-            "ReplicatedBackend::generate_subop": 12302048,
-            "ReplicatedBackend::repop_commit": 12340256,
-            "ReplicatedBackend::submit_transaction": 12320208
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "19.2.0-0ubuntu0.24.04.2",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "6cac51923118fae61dd97b077cea3a0db3508da3",
+    "func2pc": {
+      "BlueStore::_do_write": 13814432,
+      "BlueStore::_txc_add_transaction": 13910560,
+      "BlueStore::_txc_apply_kv": 13528256,
+      "BlueStore::_txc_calc_cost": 13481520,
+      "BlueStore::_txc_state_proc": 13924704,
+      "BlueStore::_wctx_finish": 13632336,
+      "BlueStore::log_latency": 14162704,
+      "BlueStore::log_latency_fn": 14163408,
+      "BlueStore::queue_transactions": 13936944,
+      "ECBackend::submit_transaction": 12571360,
+      "OSD::dequeue_op": 7833952,
+      "OSD::enqueue_op": 7926304,
+      "OpRequest::mark_flag_point": 18521296,
+      "OpRequest::mark_flag_point_string": 18521456,
+      "PrimaryLogPG::execute_ctx": 9583280,
+      "PrimaryLogPG::log_op_stats": 9185712,
+      "ReplicatedBackend::do_repop_reply": 12328816,
+      "ReplicatedBackend::generate_subop": 12302048,
+      "ReplicatedBackend::repop_commit": 12340256,
+      "ReplicatedBackend::submit_transaction": 12320208
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 728,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 728,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 728,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 728,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 160,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-19.2.1-0ubuntu0.24.04.2_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.1-0ubuntu0.24.04.2_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "19.2.1-0ubuntu0.24.04.2",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "1539cf3578d86760212fcaf1cba3feab688130eb",
-        "func2pc": {
-            "BlueStore::_do_write": 13889792,
-            "BlueStore::_txc_add_transaction": 13899776,
-            "BlueStore::_txc_apply_kv": 13629696,
-            "BlueStore::_txc_calc_cost": 13626656,
-            "BlueStore::_txc_state_proc": 13657728,
-            "BlueStore::_wctx_finish": 13817888,
-            "BlueStore::log_latency": 14216896,
-            "BlueStore::log_latency_fn": 14217584,
-            "BlueStore::queue_transactions": 13964064,
-            "ECBackend::submit_transaction": 12635472,
-            "OSD::dequeue_op": 7881536,
-            "OSD::enqueue_op": 8010160,
-            "OpRequest::mark_flag_point": 18709264,
-            "OpRequest::mark_flag_point_string": 18709424,
-            "PrimaryLogPG::execute_ctx": 9615280,
-            "PrimaryLogPG::log_op_stats": 9211968,
-            "ReplicatedBackend::do_repop_reply": 12380928,
-            "ReplicatedBackend::generate_subop": 12354160,
-            "ReplicatedBackend::repop_commit": 12392400,
-            "ReplicatedBackend::submit_transaction": 12372320
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "19.2.1-0ubuntu0.24.04.2",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "1539cf3578d86760212fcaf1cba3feab688130eb",
+    "func2pc": {
+      "BlueStore::_do_write": 13889792,
+      "BlueStore::_txc_add_transaction": 13899776,
+      "BlueStore::_txc_apply_kv": 13629696,
+      "BlueStore::_txc_calc_cost": 13626656,
+      "BlueStore::_txc_state_proc": 13657728,
+      "BlueStore::_wctx_finish": 13817888,
+      "BlueStore::log_latency": 14216896,
+      "BlueStore::log_latency_fn": 14217584,
+      "BlueStore::queue_transactions": 13964064,
+      "ECBackend::submit_transaction": 12635472,
+      "OSD::dequeue_op": 7881536,
+      "OSD::enqueue_op": 8010160,
+      "OpRequest::mark_flag_point": 18709264,
+      "OpRequest::mark_flag_point_string": 18709424,
+      "PrimaryLogPG::execute_ctx": 9615280,
+      "PrimaryLogPG::log_op_stats": 9211968,
+      "ReplicatedBackend::do_repop_reply": 12380928,
+      "ReplicatedBackend::generate_subop": 12354160,
+      "ReplicatedBackend::repop_commit": 12392400,
+      "ReplicatedBackend::submit_transaction": 12372320
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 728,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 728,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 728,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 728,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 160,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-19.2.1-0ubuntu0.24.04.2_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.1-0ubuntu0.24.04.2_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "1539cf3578d86760212fcaf1cba3feab688130eb",
     "func2pc": {
+      "Allocator::get_name": 14348736,
+      "AvlAllocator::allocate": 14737488,
+      "BitmapAllocator::allocate": 14699200,
       "BlueStore::_do_write": 13889792,
       "BlueStore::_txc_add_transaction": 13899776,
       "BlueStore::_txc_apply_kv": 13629696,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 14216896,
       "BlueStore::log_latency_fn": 14217584,
       "BlueStore::queue_transactions": 13964064,
+      "BtreeAllocator::allocate": 14763120,
       "ECBackend::submit_transaction": 12635472,
+      "HybridAllocator::allocate": 14787504,
       "OSD::dequeue_op": 7881536,
       "OSD::enqueue_op": 8010160,
       "OpRequest::mark_flag_point": 18709264,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 12380928,
       "ReplicatedBackend::generate_subop": 12354160,
       "ReplicatedBackend::repop_commit": 12392400,
-      "ReplicatedBackend::submit_transaction": 12372320
+      "ReplicatedBackend::submit_transaction": 12372320,
+      "StupidAllocator::allocate": 14676880
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-19.2.1-0ubuntu0.24.04.2~cloud0_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.1-0ubuntu0.24.04.2~cloud0_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "19.2.1-0ubuntu0.24.04.2~cloud0",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "0d53e1cd97eca4d6b469ef503c3ab3faf0d57a5f",
-        "func2pc": {
-            "BlueStore::_do_write": 13321184,
-            "BlueStore::_txc_add_transaction": 13363024,
-            "BlueStore::_txc_apply_kv": 13340736,
-            "BlueStore::_txc_calc_cost": 13076128,
-            "BlueStore::_txc_state_proc": 13341872,
-            "BlueStore::_wctx_finish": 13294208,
-            "BlueStore::log_latency": 13676000,
-            "BlueStore::log_latency_fn": 13676624,
-            "BlueStore::queue_transactions": 13407632,
-            "ECBackend::submit_transaction": 12151184,
-            "OSD::dequeue_op": 7585136,
-            "OSD::enqueue_op": 7674336,
-            "OpRequest::mark_flag_point": 17884400,
-            "OpRequest::mark_flag_point_string": 17884544,
-            "PrimaryLogPG::execute_ctx": 9261120,
-            "PrimaryLogPG::log_op_stats": 8870784,
-            "ReplicatedBackend::do_repop_reply": 11892704,
-            "ReplicatedBackend::generate_subop": 11877456,
-            "ReplicatedBackend::repop_commit": 11903936,
-            "ReplicatedBackend::submit_transaction": 11883552
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "19.2.1-0ubuntu0.24.04.2~cloud0",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "0d53e1cd97eca4d6b469ef503c3ab3faf0d57a5f",
+    "func2pc": {
+      "BlueStore::_do_write": 13321184,
+      "BlueStore::_txc_add_transaction": 13363024,
+      "BlueStore::_txc_apply_kv": 13340736,
+      "BlueStore::_txc_calc_cost": 13076128,
+      "BlueStore::_txc_state_proc": 13341872,
+      "BlueStore::_wctx_finish": 13294208,
+      "BlueStore::log_latency": 13676000,
+      "BlueStore::log_latency_fn": 13676624,
+      "BlueStore::queue_transactions": 13407632,
+      "ECBackend::submit_transaction": 12151184,
+      "OSD::dequeue_op": 7585136,
+      "OSD::enqueue_op": 7674336,
+      "OpRequest::mark_flag_point": 17884400,
+      "OpRequest::mark_flag_point_string": 17884544,
+      "PrimaryLogPG::execute_ctx": 9261120,
+      "PrimaryLogPG::log_op_stats": 8870784,
+      "ReplicatedBackend::do_repop_reply": 11892704,
+      "ReplicatedBackend::generate_subop": 11877456,
+      "ReplicatedBackend::repop_commit": 11903936,
+      "ReplicatedBackend::submit_transaction": 11883552
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 728,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 728,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 728,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 728,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 160,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-19.2.1-0ubuntu0.24.04.2~cloud0_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.1-0ubuntu0.24.04.2~cloud0_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "0d53e1cd97eca4d6b469ef503c3ab3faf0d57a5f",
     "func2pc": {
+      "Allocator::get_name": 13801440,
+      "AvlAllocator::allocate": 14161856,
+      "BitmapAllocator::allocate": 14133120,
       "BlueStore::_do_write": 13321184,
       "BlueStore::_txc_add_transaction": 13363024,
       "BlueStore::_txc_apply_kv": 13340736,
@@ -13,7 +16,9 @@
       "BlueStore::log_latency": 13676000,
       "BlueStore::log_latency_fn": 13676624,
       "BlueStore::queue_transactions": 13407632,
+      "BtreeAllocator::allocate": 14184576,
       "ECBackend::submit_transaction": 12151184,
+      "HybridAllocator::allocate": 14207696,
       "OSD::dequeue_op": 7585136,
       "OSD::enqueue_op": 7674336,
       "OpRequest::mark_flag_point": 17884400,
@@ -23,7 +28,8 @@
       "ReplicatedBackend::do_repop_reply": 11892704,
       "ReplicatedBackend::generate_subop": 11877456,
       "ReplicatedBackend::repop_commit": 11903936,
-      "ReplicatedBackend::submit_transaction": 11883552
+      "ReplicatedBackend::submit_transaction": 11883552,
+      "StupidAllocator::allocate": 14110896
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +40,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +527,52 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +609,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1848,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.1_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.1_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "8991bbab4afaa0dc7931bed26ec3332a963728da",
     "func2pc": {
+      "Allocator::get_name": 14444816,
+      "AvlAllocator::allocate": 14843360,
+      "BitmapAllocator::allocate": 14815216,
       "BlueStore::_do_write": 13953952,
       "BlueStore::_txc_add_transaction": 14087616,
       "BlueStore::_txc_apply_kv": 13712192,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 14310768,
       "BlueStore::log_latency_fn": 14311456,
       "BlueStore::queue_transactions": 14096672,
+      "Btree2Allocator::allocate": 14908720,
+      "BtreeAllocator::allocate": 14866192,
       "ECBackend::submit_transaction": 12695744,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 14957936,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 14946192,
+      "HybridBtree2Allocator::allocate": 14935136,
       "OSD::dequeue_op": 7932144,
       "OSD::enqueue_op": 8036240,
       "OpRequest::mark_flag_point": 18825600,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 12452752,
       "ReplicatedBackend::generate_subop": 12425952,
       "ReplicatedBackend::repop_commit": 12464240,
-      "ReplicatedBackend::submit_transaction": 12444112
+      "ReplicatedBackend::submit_transaction": 12444112,
+      "StupidAllocator::allocate": 14793488
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.1_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.1_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "19.2.3-0ubuntu0.24.04.1",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "8991bbab4afaa0dc7931bed26ec3332a963728da",
-        "func2pc": {
-            "BlueStore::_do_write": 13953952,
-            "BlueStore::_txc_add_transaction": 14087616,
-            "BlueStore::_txc_apply_kv": 13712192,
-            "BlueStore::_txc_calc_cost": 13643104,
-            "BlueStore::_txc_state_proc": 13877264,
-            "BlueStore::_wctx_finish": 13942448,
-            "BlueStore::log_latency": 14310768,
-            "BlueStore::log_latency_fn": 14311456,
-            "BlueStore::queue_transactions": 14096672,
-            "ECBackend::submit_transaction": 12695744,
-            "OSD::dequeue_op": 7932144,
-            "OSD::enqueue_op": 8036240,
-            "OpRequest::mark_flag_point": 18825600,
-            "OpRequest::mark_flag_point_string": 18826016,
-            "PrimaryLogPG::execute_ctx": 9700288,
-            "PrimaryLogPG::log_op_stats": 9284592,
-            "ReplicatedBackend::do_repop_reply": 12452752,
-            "ReplicatedBackend::generate_subop": 12425952,
-            "ReplicatedBackend::repop_commit": 12464240,
-            "ReplicatedBackend::submit_transaction": 12444112
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "19.2.3-0ubuntu0.24.04.1",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "8991bbab4afaa0dc7931bed26ec3332a963728da",
+    "func2pc": {
+      "BlueStore::_do_write": 13953952,
+      "BlueStore::_txc_add_transaction": 14087616,
+      "BlueStore::_txc_apply_kv": 13712192,
+      "BlueStore::_txc_calc_cost": 13643104,
+      "BlueStore::_txc_state_proc": 13877264,
+      "BlueStore::_wctx_finish": 13942448,
+      "BlueStore::log_latency": 14310768,
+      "BlueStore::log_latency_fn": 14311456,
+      "BlueStore::queue_transactions": 14096672,
+      "ECBackend::submit_transaction": 12695744,
+      "OSD::dequeue_op": 7932144,
+      "OSD::enqueue_op": 8036240,
+      "OpRequest::mark_flag_point": 18825600,
+      "OpRequest::mark_flag_point_string": 18826016,
+      "PrimaryLogPG::execute_ctx": 9700288,
+      "PrimaryLogPG::log_op_stats": 9284592,
+      "ReplicatedBackend::do_repop_reply": 12452752,
+      "ReplicatedBackend::generate_subop": 12425952,
+      "ReplicatedBackend::repop_commit": 12464240,
+      "ReplicatedBackend::submit_transaction": 12444112
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 732,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 732,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 732,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 732,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 160,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.1~cloud0_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.1~cloud0_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "e5aa09c2c41c7a6fe89fd00d00d6377ed668e04e",
     "func2pc": {
+      "Allocator::get_name": 13934384,
+      "AvlAllocator::allocate": 14325616,
+      "BitmapAllocator::allocate": 14298976,
       "BlueStore::_do_write": 13452496,
       "BlueStore::_txc_add_transaction": 13479488,
       "BlueStore::_txc_apply_kv": 13131120,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 13811760,
       "BlueStore::log_latency_fn": 13812480,
       "BlueStore::queue_transactions": 13531472,
+      "Btree2Allocator::allocate": 14380992,
+      "BtreeAllocator::allocate": 14349296,
       "ECBackend::submit_transaction": 12250080,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 14436992,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 14425392,
+      "HybridBtree2Allocator::allocate": 14415120,
       "OSD::dequeue_op": 7626528,
       "OSD::enqueue_op": 7696448,
       "OpRequest::mark_flag_point": 18137712,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 11991040,
       "ReplicatedBackend::generate_subop": 11975888,
       "ReplicatedBackend::repop_commit": 12002272,
-      "ReplicatedBackend::submit_transaction": 11981984
+      "ReplicatedBackend::submit_transaction": 11981984,
+      "StupidAllocator::allocate": 14276064
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.1~cloud0_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.1~cloud0_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "19.2.3-0ubuntu0.24.04.1~cloud0",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "e5aa09c2c41c7a6fe89fd00d00d6377ed668e04e",
-        "func2pc": {
-            "BlueStore::_do_write": 13452496,
-            "BlueStore::_txc_add_transaction": 13479488,
-            "BlueStore::_txc_apply_kv": 13131120,
-            "BlueStore::_txc_calc_cost": 13088464,
-            "BlueStore::_txc_state_proc": 13343472,
-            "BlueStore::_wctx_finish": 13416992,
-            "BlueStore::log_latency": 13811760,
-            "BlueStore::log_latency_fn": 13812480,
-            "BlueStore::queue_transactions": 13531472,
-            "ECBackend::submit_transaction": 12250080,
-            "OSD::dequeue_op": 7626528,
-            "OSD::enqueue_op": 7696448,
-            "OpRequest::mark_flag_point": 18137712,
-            "OpRequest::mark_flag_point_string": 18138176,
-            "PrimaryLogPG::execute_ctx": 9348080,
-            "PrimaryLogPG::log_op_stats": 8943024,
-            "ReplicatedBackend::do_repop_reply": 11991040,
-            "ReplicatedBackend::generate_subop": 11975888,
-            "ReplicatedBackend::repop_commit": 12002272,
-            "ReplicatedBackend::submit_transaction": 11981984
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "19.2.3-0ubuntu0.24.04.1~cloud0",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "e5aa09c2c41c7a6fe89fd00d00d6377ed668e04e",
+    "func2pc": {
+      "BlueStore::_do_write": 13452496,
+      "BlueStore::_txc_add_transaction": 13479488,
+      "BlueStore::_txc_apply_kv": 13131120,
+      "BlueStore::_txc_calc_cost": 13088464,
+      "BlueStore::_txc_state_proc": 13343472,
+      "BlueStore::_wctx_finish": 13416992,
+      "BlueStore::log_latency": 13811760,
+      "BlueStore::log_latency_fn": 13812480,
+      "BlueStore::queue_transactions": 13531472,
+      "ECBackend::submit_transaction": 12250080,
+      "OSD::dequeue_op": 7626528,
+      "OSD::enqueue_op": 7696448,
+      "OpRequest::mark_flag_point": 18137712,
+      "OpRequest::mark_flag_point_string": 18138176,
+      "PrimaryLogPG::execute_ctx": 9348080,
+      "PrimaryLogPG::log_op_stats": 8943024,
+      "ReplicatedBackend::do_repop_reply": 11991040,
+      "ReplicatedBackend::generate_subop": 11975888,
+      "ReplicatedBackend::repop_commit": 12002272,
+      "ReplicatedBackend::submit_transaction": 11981984
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 732,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 732,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 732,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 732,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 160,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.2_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.2_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "19.2.3-0ubuntu0.24.04.2",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "a7efdc6d17bfe217c38e7070b33c32f72dfc6441",
-        "func2pc": {
-            "BlueStore::_do_write": 13953952,
-            "BlueStore::_txc_add_transaction": 14087616,
-            "BlueStore::_txc_apply_kv": 13712192,
-            "BlueStore::_txc_calc_cost": 13643104,
-            "BlueStore::_txc_state_proc": 13877264,
-            "BlueStore::_wctx_finish": 13942448,
-            "BlueStore::log_latency": 14310768,
-            "BlueStore::log_latency_fn": 14311456,
-            "BlueStore::queue_transactions": 14096672,
-            "ECBackend::submit_transaction": 12695744,
-            "OSD::dequeue_op": 7932144,
-            "OSD::enqueue_op": 8036240,
-            "OpRequest::mark_flag_point": 18825600,
-            "OpRequest::mark_flag_point_string": 18826016,
-            "PrimaryLogPG::execute_ctx": 9700288,
-            "PrimaryLogPG::log_op_stats": 9284592,
-            "ReplicatedBackend::do_repop_reply": 12452752,
-            "ReplicatedBackend::generate_subop": 12425952,
-            "ReplicatedBackend::repop_commit": 12464240,
-            "ReplicatedBackend::submit_transaction": 12444112
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "19.2.3-0ubuntu0.24.04.2",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "a7efdc6d17bfe217c38e7070b33c32f72dfc6441",
+    "func2pc": {
+      "BlueStore::_do_write": 13953952,
+      "BlueStore::_txc_add_transaction": 14087616,
+      "BlueStore::_txc_apply_kv": 13712192,
+      "BlueStore::_txc_calc_cost": 13643104,
+      "BlueStore::_txc_state_proc": 13877264,
+      "BlueStore::_wctx_finish": 13942448,
+      "BlueStore::log_latency": 14310768,
+      "BlueStore::log_latency_fn": 14311456,
+      "BlueStore::queue_transactions": 14096672,
+      "ECBackend::submit_transaction": 12695744,
+      "OSD::dequeue_op": 7932144,
+      "OSD::enqueue_op": 8036240,
+      "OpRequest::mark_flag_point": 18825600,
+      "OpRequest::mark_flag_point_string": 18826016,
+      "PrimaryLogPG::execute_ctx": 9700288,
+      "PrimaryLogPG::log_op_stats": 9284592,
+      "ReplicatedBackend::do_repop_reply": 12452752,
+      "ReplicatedBackend::generate_subop": 12425952,
+      "ReplicatedBackend::repop_commit": 12464240,
+      "ReplicatedBackend::submit_transaction": 12444112
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 732,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 732,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 732,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 732,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 160,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.2_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.2_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "a7efdc6d17bfe217c38e7070b33c32f72dfc6441",
     "func2pc": {
+      "Allocator::get_name": 14444816,
+      "AvlAllocator::allocate": 14843360,
+      "BitmapAllocator::allocate": 14815216,
       "BlueStore::_do_write": 13953952,
       "BlueStore::_txc_add_transaction": 14087616,
       "BlueStore::_txc_apply_kv": 13712192,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 14310768,
       "BlueStore::log_latency_fn": 14311456,
       "BlueStore::queue_transactions": 14096672,
+      "Btree2Allocator::allocate": 14908720,
+      "BtreeAllocator::allocate": 14866192,
       "ECBackend::submit_transaction": 12695744,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 14957936,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 14946192,
+      "HybridBtree2Allocator::allocate": 14935136,
       "OSD::dequeue_op": 7932144,
       "OSD::enqueue_op": 8036240,
       "OpRequest::mark_flag_point": 18825600,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 12452752,
       "ReplicatedBackend::generate_subop": 12425952,
       "ReplicatedBackend::repop_commit": 12464240,
-      "ReplicatedBackend::submit_transaction": 12444112
+      "ReplicatedBackend::submit_transaction": 12444112,
+      "StupidAllocator::allocate": 14793488
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.2~cloud0_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.2~cloud0_dwarf.json
@@ -1,1636 +1,1636 @@
 {
-    "version": "19.2.3-0ubuntu0.24.04.2~cloud0",
-    "arch": "amd64",
-    "ceph-osd": {
-        "build_id": "5bd61ff1ed12112d364fc34933945dab2399c7ca",
-        "func2pc": {
-            "BlueStore::_do_write": 13452496,
-            "BlueStore::_txc_add_transaction": 13479488,
-            "BlueStore::_txc_apply_kv": 13131120,
-            "BlueStore::_txc_calc_cost": 13088464,
-            "BlueStore::_txc_state_proc": 13343472,
-            "BlueStore::_wctx_finish": 13416992,
-            "BlueStore::log_latency": 13811760,
-            "BlueStore::log_latency_fn": 13812480,
-            "BlueStore::queue_transactions": 13531472,
-            "ECBackend::submit_transaction": 12250080,
-            "OSD::dequeue_op": 7626528,
-            "OSD::enqueue_op": 7696448,
-            "OpRequest::mark_flag_point": 18137712,
-            "OpRequest::mark_flag_point_string": 18138176,
-            "PrimaryLogPG::execute_ctx": 9348080,
-            "PrimaryLogPG::log_op_stats": 8943024,
-            "ReplicatedBackend::do_repop_reply": 11991040,
-            "ReplicatedBackend::generate_subop": 11975888,
-            "ReplicatedBackend::repop_commit": 12002272,
-            "ReplicatedBackend::submit_transaction": 11981984
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7
-        },
-        "func2vf": {
-            "BlueStore::_do_write": {
-                "var_fields": []
+  "version": "19.2.3-0ubuntu0.24.04.2~cloud0",
+  "arch": "amd64",
+  "ceph-osd": {
+    "build_id": "5bd61ff1ed12112d364fc34933945dab2399c7ca",
+    "func2pc": {
+      "BlueStore::_do_write": 13452496,
+      "BlueStore::_txc_add_transaction": 13479488,
+      "BlueStore::_txc_apply_kv": 13131120,
+      "BlueStore::_txc_calc_cost": 13088464,
+      "BlueStore::_txc_state_proc": 13343472,
+      "BlueStore::_wctx_finish": 13416992,
+      "BlueStore::log_latency": 13811760,
+      "BlueStore::log_latency_fn": 13812480,
+      "BlueStore::queue_transactions": 13531472,
+      "ECBackend::submit_transaction": 12250080,
+      "OSD::dequeue_op": 7626528,
+      "OSD::enqueue_op": 7696448,
+      "OpRequest::mark_flag_point": 18137712,
+      "OpRequest::mark_flag_point_string": 18138176,
+      "PrimaryLogPG::execute_ctx": 9348080,
+      "PrimaryLogPG::log_op_stats": 8943024,
+      "ReplicatedBackend::do_repop_reply": 11991040,
+      "ReplicatedBackend::generate_subop": 11975888,
+      "ReplicatedBackend::repop_commit": 12002272,
+      "ReplicatedBackend::submit_transaction": 11981984
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7
+    },
+    "func2vf": {
+      "BlueStore::_do_write": {
+        "var_fields": []
+      },
+      "BlueStore::_txc_add_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_add_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 28,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_apply_kv": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 732,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_calc_cost": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 160,
+                "pointer": true
+              },
+              {
+                "offset": 28,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_apply_kv": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_txc_state_proc": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 732,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 504,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 160,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 732,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_calc_cost": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::_wctx_finish": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 328,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 696,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_txc_state_proc": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::log_latency_fn": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "BlueStore::queue_transactions": {
-                "var_fields": []
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "ECBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 732,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::dequeue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 504,
+                "pointer": true
+              },
+              {
+                "offset": 160,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::_wctx_finish": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OSD::enqueue_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 216,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 224,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 208,
-                                "pointer": true
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 328,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 696,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "OpRequest::mark_flag_point_string": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::execute_ctx": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 64,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::log_latency_fn": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "PrimaryLogPG::log_op_stats": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 1,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 2,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 200,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::do_repop_reply": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 36,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "BlueStore::queue_transactions": {
+        "var_fields": []
+      },
+      "ECBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::generate_subop": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 8,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 96,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
             },
-            "ReplicatedBackend::repop_commit": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 280,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 168,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 24,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 424,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::dequeue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
             },
-            "ReplicatedBackend::submit_transaction": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 7,
-                            "offset": 48,
-                            "stack": true
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 16,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OSD::enqueue_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 216,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 224,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 208,
+                "pointer": true
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "OpRequest::mark_flag_point_string": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::execute_ctx": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 64,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "PrimaryLogPG::log_op_stats": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 1,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 2,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 200,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::do_repop_reply": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 36,
+                "pointer": false
+              },
+              {
+                "offset": 1,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::generate_subop": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 8,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 96,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::repop_commit": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 280,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 168,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 272,
+                "pointer": true
+              },
+              {
+                "offset": 424,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "ReplicatedBackend::submit_transaction": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 7,
+              "offset": 48,
+              "stack": true
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }

--- a/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.2~cloud0_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.2~cloud0_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "5bd61ff1ed12112d364fc34933945dab2399c7ca",
     "func2pc": {
+      "Allocator::get_name": 13934384,
+      "AvlAllocator::allocate": 14325616,
+      "BitmapAllocator::allocate": 14298976,
       "BlueStore::_do_write": 13452496,
       "BlueStore::_txc_add_transaction": 13479488,
       "BlueStore::_txc_apply_kv": 13131120,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 13811760,
       "BlueStore::log_latency_fn": 13812480,
       "BlueStore::queue_transactions": 13531472,
+      "Btree2Allocator::allocate": 14380992,
+      "BtreeAllocator::allocate": 14349296,
       "ECBackend::submit_transaction": 12250080,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 14436992,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 14425392,
+      "HybridBtree2Allocator::allocate": 14415120,
       "OSD::dequeue_op": 7626528,
       "OSD::enqueue_op": 7696448,
       "OpRequest::mark_flag_point": 18137712,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 11991040,
       "ReplicatedBackend::generate_subop": 11975888,
       "ReplicatedBackend::repop_commit": 12002272,
-      "ReplicatedBackend::submit_transaction": 11981984
+      "ReplicatedBackend::submit_transaction": 11981984,
+      "StupidAllocator::allocate": 14276064
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.3_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-19.2.3-0ubuntu0.24.04.3_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "45df538869b8fda1a891a073b59326d635b26d5b",
     "func2pc": {
+      "Allocator::get_name": 14444816,
+      "AvlAllocator::allocate": 14843360,
+      "BitmapAllocator::allocate": 14815216,
       "BlueStore::_do_write": 13953952,
       "BlueStore::_txc_add_transaction": 14087616,
       "BlueStore::_txc_apply_kv": 13712192,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 14310768,
       "BlueStore::log_latency_fn": 14311456,
       "BlueStore::queue_transactions": 14096672,
+      "Btree2Allocator::allocate": 14908720,
+      "BtreeAllocator::allocate": 14866192,
       "ECBackend::submit_transaction": 12695744,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 14957936,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 14946192,
+      "HybridBtree2Allocator::allocate": 14935136,
       "OSD::dequeue_op": 7932144,
       "OSD::enqueue_op": 8036240,
       "OpRequest::mark_flag_point": 18825600,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 12452752,
       "ReplicatedBackend::generate_subop": 12425952,
       "ReplicatedBackend::repop_commit": 12464240,
-      "ReplicatedBackend::submit_transaction": 12444112
+      "ReplicatedBackend::submit_transaction": 12444112,
+      "StupidAllocator::allocate": 14793488
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "Allocator::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-20.2.0-0ubuntu2_amd64v3_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-20.2.0-0ubuntu2_amd64v3_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "20bbaa35a85fc9fad7534f286a7087f81cc35074",
     "func2pc": {
+      "AllocatorBase::get_name": 16226896,
+      "AvlAllocator::allocate": 16638560,
+      "BitmapAllocator::allocate": 16616656,
       "BlueStore::_do_write": 15689168,
       "BlueStore::_txc_add_transaction": 15771568,
       "BlueStore::_txc_apply_kv": 15260720,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 15991728,
       "BlueStore::log_latency_fn": 15992512,
       "BlueStore::queue_transactions": 15783664,
+      "Btree2Allocator::allocate": 16707136,
+      "BtreeAllocator::allocate": 16664256,
       "ECBackend::submit_transaction": 13522672,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 16753808,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 16745040,
+      "HybridBtree2Allocator::allocate": 16730400,
       "OSD::dequeue_op": 8814848,
       "OSD::enqueue_op": 8886928,
       "OpRequest::mark_flag_point": 21325232,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 11072736,
       "ReplicatedBackend::generate_subop": 11047760,
       "ReplicatedBackend::repop_commit": 11084096,
-      "ReplicatedBackend::submit_transaction": 11068640
+      "ReplicatedBackend::submit_transaction": 11068640,
+      "StupidAllocator::allocate": 16590944
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "AllocatorBase::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/osdtrace/osd-20.2.0-0ubuntu2_dwarf.json
+++ b/files/ubuntu/osdtrace/osd-20.2.0-0ubuntu2_dwarf.json
@@ -4,6 +4,9 @@
   "ceph-osd": {
     "build_id": "0e6c06a0aefaddbe0d5aea7b7d5b94f5befd3ce3",
     "func2pc": {
+      "AllocatorBase::get_name": 16060384,
+      "AvlAllocator::allocate": 16469808,
+      "BitmapAllocator::allocate": 16447888,
       "BlueStore::_do_write": 15514720,
       "BlueStore::_txc_add_transaction": 15532544,
       "BlueStore::_txc_apply_kv": 15095392,
@@ -13,7 +16,12 @@
       "BlueStore::log_latency": 15826944,
       "BlueStore::log_latency_fn": 15827728,
       "BlueStore::queue_transactions": 15540512,
+      "Btree2Allocator::allocate": 16539136,
+      "BtreeAllocator::allocate": 16495312,
       "ECBackend::submit_transaction": 13373248,
+      "HybridAllocatorBase<AvlAllocator>::allocate": 16587632,
+      "HybridAllocatorBase<Btree2Allocator>::allocate": 16576160,
+      "HybridBtree2Allocator::allocate": 16563552,
       "OSD::dequeue_op": 8671808,
       "OSD::enqueue_op": 8743936,
       "OpRequest::mark_flag_point": 21053488,
@@ -23,7 +31,8 @@
       "ReplicatedBackend::do_repop_reply": 10918112,
       "ReplicatedBackend::generate_subop": 10893152,
       "ReplicatedBackend::repop_commit": 10929504,
-      "ReplicatedBackend::submit_transaction": 10914000
+      "ReplicatedBackend::submit_transaction": 10914000,
+      "StupidAllocator::allocate": 16422384
     },
     "type_sizes": {
       "OSDOp": 112
@@ -34,6 +43,131 @@
       "OSDOp::op.cls.method_len": 7
     },
     "func2vf": {
+      "AllocatorBase::get_name": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 24,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "AvlAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BitmapAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "BlueStore::_do_write": {
         "var_fields": []
       },
@@ -396,6 +530,98 @@
       "BlueStore::queue_transactions": {
         "var_fields": []
       },
+      "Btree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "BtreeAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
       "ECBackend::submit_transaction": {
         "var_fields": [
           {
@@ -432,6 +658,144 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<AvlAllocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridAllocatorBase<Btree2Allocator>::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "HybridBtree2Allocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]
@@ -1625,6 +1989,52 @@
               },
               {
                 "offset": 16,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "StupidAllocator::allocate": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 16,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 9,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": true
+              },
+              {
+                "offset": 24,
                 "pointer": false
               }
             ]

--- a/files/ubuntu/radostrace/15.2.17-0ubuntu0.20.04.6_dwarf.json
+++ b/files/ubuntu/radostrace/15.2.17-0ubuntu0.20.04.6_dwarf.json
@@ -1,181 +1,181 @@
 {
-    "version": "15.2.17-0ubuntu0.20.04.6",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "2e9588e73ed6d4089f8f08ec17e20ccd478a7e6e",
-        "func2pc": {
-            "Objecter::_finish_op": 8097360
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 624,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1408,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 380,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "15.2.17-0ubuntu0.20.04.6",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "2e9588e73ed6d4089f8f08ec17e20ccd478a7e6e",
+    "func2pc": {
+      "Objecter::_finish_op": 8097360
     },
-    "librados.so.2": {
-        "build_id": "4892287953c8a981e4000287d4f381e7ac599e4e",
-        "func2pc": {
-            "Objecter::_finish_op": 812976
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 624,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1408,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 380,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "c043034c5de5e0891f2e30b97865607c5535bfbf",
-        "func2pc": {},
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {}
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 624,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1408,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 380,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "4892287953c8a981e4000287d4f381e7ac599e4e",
+    "func2pc": {
+      "Objecter::_finish_op": 812976
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 624,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1408,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 380,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "c043034c5de5e0891f2e30b97865607c5535bfbf",
+    "func2pc": {},
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {}
+  }
 }

--- a/files/ubuntu/radostrace/17.2.0-0ubuntu0.22.04.1_dwarf.json
+++ b/files/ubuntu/radostrace/17.2.0-0ubuntu0.22.04.1_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "17.2.0-0ubuntu0.22.04.1",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "a600f6536ef9708af4d55b9bd3a6d8f7f8893408",
-        "func2pc": {
-            "Objecter::_finish_op": 7968208,
-            "Objecter::_send_op": 7912960
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "17.2.0-0ubuntu0.22.04.1",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "a600f6536ef9708af4d55b9bd3a6d8f7f8893408",
+    "func2pc": {
+      "Objecter::_finish_op": 7968208,
+      "Objecter::_send_op": 7912960
     },
-    "librados.so.2": {
-        "build_id": "68732f12aa9483799d7c5dfe7d905e8bff50099d",
-        "func2pc": {
-            "Objecter::_finish_op": 911328,
-            "Objecter::_send_op": 856080
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "56a0177507e26cbceb1ad3a9651acee35c19fb01",
-        "func2pc": {
-            "Objecter::_finish_op": 6642512,
-            "Objecter::_send_op": 6587264
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "68732f12aa9483799d7c5dfe7d905e8bff50099d",
+    "func2pc": {
+      "Objecter::_finish_op": 911328,
+      "Objecter::_send_op": 856080
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "56a0177507e26cbceb1ad3a9651acee35c19fb01",
+    "func2pc": {
+      "Objecter::_finish_op": 6642512,
+      "Objecter::_send_op": 6587264
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/17.2.0-0ubuntu0.22.04.2_dwarf.json
+++ b/files/ubuntu/radostrace/17.2.0-0ubuntu0.22.04.2_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "17.2.0-0ubuntu0.22.04.2",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "f3415ab4ff8752563dc9f450183b3e284e975591",
-        "func2pc": {
-            "Objecter::_finish_op": 7968208,
-            "Objecter::_send_op": 7912960
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "17.2.0-0ubuntu0.22.04.2",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "f3415ab4ff8752563dc9f450183b3e284e975591",
+    "func2pc": {
+      "Objecter::_finish_op": 7968208,
+      "Objecter::_send_op": 7912960
     },
-    "librados.so.2": {
-        "build_id": "5a73375a8af561cde3e9cc1654f8836329a30943",
-        "func2pc": {
-            "Objecter::_finish_op": 911328,
-            "Objecter::_send_op": 856080
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "b323f3ab71e82d6d32e4130345a4649f8d33a995",
-        "func2pc": {
-            "Objecter::_finish_op": 6642192,
-            "Objecter::_send_op": 6586944
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "5a73375a8af561cde3e9cc1654f8836329a30943",
+    "func2pc": {
+      "Objecter::_finish_op": 911328,
+      "Objecter::_send_op": 856080
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "b323f3ab71e82d6d32e4130345a4649f8d33a995",
+    "func2pc": {
+      "Objecter::_finish_op": 6642192,
+      "Objecter::_send_op": 6586944
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/17.2.5-0ubuntu0.22.04.1_dwarf.json
+++ b/files/ubuntu/radostrace/17.2.5-0ubuntu0.22.04.1_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "17.2.5-0ubuntu0.22.04.1",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "2218872463fc65de6e1db349edd95b2de1cce190",
-        "func2pc": {
-            "Objecter::_finish_op": 7998080,
-            "Objecter::_send_op": 7942832
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "17.2.5-0ubuntu0.22.04.1",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "2218872463fc65de6e1db349edd95b2de1cce190",
+    "func2pc": {
+      "Objecter::_finish_op": 7998080,
+      "Objecter::_send_op": 7942832
     },
-    "librados.so.2": {
-        "build_id": "a32e01d04b948842425ada3adcd60dd8779cd2dd",
-        "func2pc": {
-            "Objecter::_finish_op": 911184,
-            "Objecter::_send_op": 855936
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "0b8681e7da80bc58c1dc67bd753c21e3d6ad60cb",
-        "func2pc": {
-            "Objecter::_finish_op": 6650432,
-            "Objecter::_send_op": 6595184
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "a32e01d04b948842425ada3adcd60dd8779cd2dd",
+    "func2pc": {
+      "Objecter::_finish_op": 911184,
+      "Objecter::_send_op": 855936
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "0b8681e7da80bc58c1dc67bd753c21e3d6ad60cb",
+    "func2pc": {
+      "Objecter::_finish_op": 6650432,
+      "Objecter::_send_op": 6595184
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/17.2.5-0ubuntu0.22.04.2_dwarf.json
+++ b/files/ubuntu/radostrace/17.2.5-0ubuntu0.22.04.2_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "17.2.5-0ubuntu0.22.04.2",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "7e15d123a3a7052331a7026274fd352a46067e12",
-        "func2pc": {
-            "Objecter::_finish_op": 7998080,
-            "Objecter::_send_op": 7942832
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "17.2.5-0ubuntu0.22.04.2",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "7e15d123a3a7052331a7026274fd352a46067e12",
+    "func2pc": {
+      "Objecter::_finish_op": 7998080,
+      "Objecter::_send_op": 7942832
     },
-    "librados.so.2": {
-        "build_id": "ae9bbfe8e10aec3c51b671a3fee66c40f69eebbd",
-        "func2pc": {
-            "Objecter::_finish_op": 911184,
-            "Objecter::_send_op": 855936
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "7b2cd4a351fd07be6ef5066fc260492aae5d72ea",
-        "func2pc": {
-            "Objecter::_finish_op": 6650432,
-            "Objecter::_send_op": 6595184
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "ae9bbfe8e10aec3c51b671a3fee66c40f69eebbd",
+    "func2pc": {
+      "Objecter::_finish_op": 911184,
+      "Objecter::_send_op": 855936
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "7b2cd4a351fd07be6ef5066fc260492aae5d72ea",
+    "func2pc": {
+      "Objecter::_finish_op": 6650432,
+      "Objecter::_send_op": 6595184
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/17.2.5-0ubuntu0.22.04.3_dwarf.json
+++ b/files/ubuntu/radostrace/17.2.5-0ubuntu0.22.04.3_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "17.2.5-0ubuntu0.22.04.3",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "b33db934809bfa4cb77d099a19d75d0657621133",
-        "func2pc": {
-            "Objecter::_finish_op": 7998080,
-            "Objecter::_send_op": 7942832
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "17.2.5-0ubuntu0.22.04.3",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "b33db934809bfa4cb77d099a19d75d0657621133",
+    "func2pc": {
+      "Objecter::_finish_op": 7998080,
+      "Objecter::_send_op": 7942832
     },
-    "librados.so.2": {
-        "build_id": "643dd2929e775d93334749097932857543cfa1fc",
-        "func2pc": {
-            "Objecter::_finish_op": 911184,
-            "Objecter::_send_op": 855936
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "5c6e6bcb3ca7c8d546148fba8f051bede34cacfd",
-        "func2pc": {
-            "Objecter::_finish_op": 6650432,
-            "Objecter::_send_op": 6595184
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1352,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "643dd2929e775d93334749097932857543cfa1fc",
+    "func2pc": {
+      "Objecter::_finish_op": 911184,
+      "Objecter::_send_op": 855936
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "5c6e6bcb3ca7c8d546148fba8f051bede34cacfd",
+    "func2pc": {
+      "Objecter::_finish_op": 6650432,
+      "Objecter::_send_op": 6595184
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1352,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/17.2.6-0ubuntu0.22.04.1_dwarf.json
+++ b/files/ubuntu/radostrace/17.2.6-0ubuntu0.22.04.1_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "17.2.6-0ubuntu0.22.04.1",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "f48b8b47c0ddcb39351f8de5cb660df3eadf0713",
-        "func2pc": {
-            "Objecter::_finish_op": 8015824,
-            "Objecter::_send_op": 7960576
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "17.2.6-0ubuntu0.22.04.1",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "f48b8b47c0ddcb39351f8de5cb660df3eadf0713",
+    "func2pc": {
+      "Objecter::_finish_op": 8015824,
+      "Objecter::_send_op": 7960576
     },
-    "librados.so.2": {
-        "build_id": "c954a96ff5fe2b64e6ded8187f203c799a11768f",
-        "func2pc": {
-            "Objecter::_finish_op": 911264,
-            "Objecter::_send_op": 856016
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "ce5c5fbf27f371387f2566be0759affe2d47ec3e",
-        "func2pc": {
-            "Objecter::_finish_op": 6657552,
-            "Objecter::_send_op": 6602304
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "c954a96ff5fe2b64e6ded8187f203c799a11768f",
+    "func2pc": {
+      "Objecter::_finish_op": 911264,
+      "Objecter::_send_op": 856016
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "ce5c5fbf27f371387f2566be0759affe2d47ec3e",
+    "func2pc": {
+      "Objecter::_finish_op": 6657552,
+      "Objecter::_send_op": 6602304
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/17.2.6-0ubuntu0.22.04.2_dwarf.json
+++ b/files/ubuntu/radostrace/17.2.6-0ubuntu0.22.04.2_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "17.2.6-0ubuntu0.22.04.2",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "29532fd24051236703d09cee5217d7b42e5ce2ab",
-        "func2pc": {
-            "Objecter::_finish_op": 8022128,
-            "Objecter::_send_op": 7966864
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "17.2.6-0ubuntu0.22.04.2",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "29532fd24051236703d09cee5217d7b42e5ce2ab",
+    "func2pc": {
+      "Objecter::_finish_op": 8022128,
+      "Objecter::_send_op": 7966864
     },
-    "librados.so.2": {
-        "build_id": "923e5e5d13554c263fa615bcc4e16c2dc039b1ef",
-        "func2pc": {
-            "Objecter::_finish_op": 911152,
-            "Objecter::_send_op": 855888
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "ec9806c8c9149360eb9a51357791c3d982de8dc9",
-        "func2pc": {
-            "Objecter::_finish_op": 6658672,
-            "Objecter::_send_op": 6603408
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "923e5e5d13554c263fa615bcc4e16c2dc039b1ef",
+    "func2pc": {
+      "Objecter::_finish_op": 911152,
+      "Objecter::_send_op": 855888
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "ec9806c8c9149360eb9a51357791c3d982de8dc9",
+    "func2pc": {
+      "Objecter::_finish_op": 6658672,
+      "Objecter::_send_op": 6603408
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/17.2.6-0ubuntu0.22.04.3_dwarf.json
+++ b/files/ubuntu/radostrace/17.2.6-0ubuntu0.22.04.3_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "17.2.6-0ubuntu0.22.04.3",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "d25ebfac79b7a9395904bf93bb8dd04df31d8721",
-        "func2pc": {
-            "Objecter::_finish_op": 8022128,
-            "Objecter::_send_op": 7966864
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "17.2.6-0ubuntu0.22.04.3",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "d25ebfac79b7a9395904bf93bb8dd04df31d8721",
+    "func2pc": {
+      "Objecter::_finish_op": 8022128,
+      "Objecter::_send_op": 7966864
     },
-    "librados.so.2": {
-        "build_id": "21ef9b94e2f96e6f5c767a35e1fc6a74a9fb5c73",
-        "func2pc": {
-            "Objecter::_finish_op": 911152,
-            "Objecter::_send_op": 855888
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "6005fbe9f0c62cc81fcf79643d9e5875f6eb967c",
-        "func2pc": {
-            "Objecter::_finish_op": 6658672,
-            "Objecter::_send_op": 6603408
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "21ef9b94e2f96e6f5c767a35e1fc6a74a9fb5c73",
+    "func2pc": {
+      "Objecter::_finish_op": 911152,
+      "Objecter::_send_op": 855888
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "6005fbe9f0c62cc81fcf79643d9e5875f6eb967c",
+    "func2pc": {
+      "Objecter::_finish_op": 6658672,
+      "Objecter::_send_op": 6603408
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/17.2.7-0ubuntu0.22.04.1_dwarf.json
+++ b/files/ubuntu/radostrace/17.2.7-0ubuntu0.22.04.1_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "17.2.7-0ubuntu0.22.04.1",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "d8d28791be0c47901ede5933d2b05a9d3f0d4683",
-        "func2pc": {
-            "Objecter::_finish_op": 8029888,
-            "Objecter::_send_op": 7974624
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "17.2.7-0ubuntu0.22.04.1",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "d8d28791be0c47901ede5933d2b05a9d3f0d4683",
+    "func2pc": {
+      "Objecter::_finish_op": 8029888,
+      "Objecter::_send_op": 7974624
     },
-    "librados.so.2": {
-        "build_id": "cafadffdf5eb235b5d18c6c05f48a3c378ee4b69",
-        "func2pc": {
-            "Objecter::_finish_op": 911504,
-            "Objecter::_send_op": 856240
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "868313943d1043b82b0b2e5cc8c60874a32cc98b",
-        "func2pc": {
-            "Objecter::_finish_op": 6648928,
-            "Objecter::_send_op": 6593664
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "cafadffdf5eb235b5d18c6c05f48a3c378ee4b69",
+    "func2pc": {
+      "Objecter::_finish_op": 911504,
+      "Objecter::_send_op": 856240
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "868313943d1043b82b0b2e5cc8c60874a32cc98b",
+    "func2pc": {
+      "Objecter::_finish_op": 6648928,
+      "Objecter::_send_op": 6593664
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/17.2.7-0ubuntu0.22.04.1~cloud0_dwarf.json
+++ b/files/ubuntu/radostrace/17.2.7-0ubuntu0.22.04.1~cloud0_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "17.2.7-0ubuntu0.22.04.1~cloud0",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "60540ba00e9c885fe1cbc20fc66a6bcbcef6e7dc",
-        "func2pc": {
-            "Objecter::_finish_op": 8471872,
-            "Objecter::_send_op": 8411440
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "17.2.7-0ubuntu0.22.04.1~cloud0",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "60540ba00e9c885fe1cbc20fc66a6bcbcef6e7dc",
+    "func2pc": {
+      "Objecter::_finish_op": 8471872,
+      "Objecter::_send_op": 8411440
     },
-    "librados.so.2": {
-        "build_id": "fc2b885a83d389143d21b0e436d1039c6169d8e0",
-        "func2pc": {
-            "Objecter::_finish_op": 946544,
-            "Objecter::_send_op": 886112
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "62f088942b7767eabf3f7a211d55e1570a3b7bdd",
-        "func2pc": {
-            "Objecter::_finish_op": 7051904,
-            "Objecter::_send_op": 6991472
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "fc2b885a83d389143d21b0e436d1039c6169d8e0",
+    "func2pc": {
+      "Objecter::_finish_op": 946544,
+      "Objecter::_send_op": 886112
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "62f088942b7767eabf3f7a211d55e1570a3b7bdd",
+    "func2pc": {
+      "Objecter::_finish_op": 7051904,
+      "Objecter::_send_op": 6991472
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/17.2.7-0ubuntu0.22.04.2_dwarf.json
+++ b/files/ubuntu/radostrace/17.2.7-0ubuntu0.22.04.2_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "17.2.7-0ubuntu0.22.04.2",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "8e95b1bfe63e7389cb79c6004d83cc09740a8db6",
-        "func2pc": {
-            "Objecter::_finish_op": 8029888,
-            "Objecter::_send_op": 7974624
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "17.2.7-0ubuntu0.22.04.2",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "8e95b1bfe63e7389cb79c6004d83cc09740a8db6",
+    "func2pc": {
+      "Objecter::_finish_op": 8029888,
+      "Objecter::_send_op": 7974624
     },
-    "librados.so.2": {
-        "build_id": "36b8f62bbf6399f81a7182b8b086bc440e62cf0e",
-        "func2pc": {
-            "Objecter::_finish_op": 911504,
-            "Objecter::_send_op": 856240
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "19b1be8cdc9f193a53da13e3e8a69f22dd272bc4",
-        "func2pc": {
-            "Objecter::_finish_op": 6648928,
-            "Objecter::_send_op": 6593664
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "36b8f62bbf6399f81a7182b8b086bc440e62cf0e",
+    "func2pc": {
+      "Objecter::_finish_op": 911504,
+      "Objecter::_send_op": 856240
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "19b1be8cdc9f193a53da13e3e8a69f22dd272bc4",
+    "func2pc": {
+      "Objecter::_finish_op": 6648928,
+      "Objecter::_send_op": 6593664
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/17.2.9-0ubuntu0.22.04.1_dwarf.json
+++ b/files/ubuntu/radostrace/17.2.9-0ubuntu0.22.04.1_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "17.2.9-0ubuntu0.22.04.1",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "377e998560a9285eccfa13858e549388418a5262",
-        "func2pc": {
-            "Objecter::_finish_op": 8068480,
-            "Objecter::_send_op": 8013216
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "17.2.9-0ubuntu0.22.04.1",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "377e998560a9285eccfa13858e549388418a5262",
+    "func2pc": {
+      "Objecter::_finish_op": 8068480,
+      "Objecter::_send_op": 8013216
     },
-    "librados.so.2": {
-        "build_id": "9eb36079123e5d0c82aa570ecfb39509e00630ff",
-        "func2pc": {
-            "Objecter::_finish_op": 912400,
-            "Objecter::_send_op": 857136
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "d4f4b4a472dd702d803a2e52df299e9759113395",
-        "func2pc": {
-            "Objecter::_finish_op": 6656176,
-            "Objecter::_send_op": 6600912
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "9eb36079123e5d0c82aa570ecfb39509e00630ff",
+    "func2pc": {
+      "Objecter::_finish_op": 912400,
+      "Objecter::_send_op": 857136
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "d4f4b4a472dd702d803a2e52df299e9759113395",
+    "func2pc": {
+      "Objecter::_finish_op": 6656176,
+      "Objecter::_send_op": 6600912
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/17.2.9-0ubuntu0.22.04.1~cloud0_dwarf.json
+++ b/files/ubuntu/radostrace/17.2.9-0ubuntu0.22.04.1~cloud0_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "17.2.9-0ubuntu0.22.04.1~cloud0",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "31393363d4adfc6ba4c8e4e58ba7a84792193077",
-        "func2pc": {
-            "Objecter::_finish_op": 8508416,
-            "Objecter::_send_op": 8448224
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "17.2.9-0ubuntu0.22.04.1~cloud0",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "31393363d4adfc6ba4c8e4e58ba7a84792193077",
+    "func2pc": {
+      "Objecter::_finish_op": 8508416,
+      "Objecter::_send_op": 8448224
     },
-    "librados.so.2": {
-        "build_id": "f2dbc3fd0e66e74c4c5582daaad7345f855cc082",
-        "func2pc": {
-            "Objecter::_finish_op": 945200,
-            "Objecter::_send_op": 885008
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "c97db865428223b868711d89be1546d6ac65b55c",
-        "func2pc": {
-            "Objecter::_finish_op": 7074592,
-            "Objecter::_send_op": 7014400
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "f2dbc3fd0e66e74c4c5582daaad7345f855cc082",
+    "func2pc": {
+      "Objecter::_finish_op": 945200,
+      "Objecter::_send_op": 885008
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "c97db865428223b868711d89be1546d6ac65b55c",
+    "func2pc": {
+      "Objecter::_finish_op": 7074592,
+      "Objecter::_send_op": 7014400
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/17.2.9-0ubuntu0.22.04.2_dwarf.json
+++ b/files/ubuntu/radostrace/17.2.9-0ubuntu0.22.04.2_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "17.2.9-0ubuntu0.22.04.2",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "57f970773446c1df4a4565308d26a790189cb0da",
-        "func2pc": {
-            "Objecter::_finish_op": 8068480,
-            "Objecter::_send_op": 8013216
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "17.2.9-0ubuntu0.22.04.2",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "57f970773446c1df4a4565308d26a790189cb0da",
+    "func2pc": {
+      "Objecter::_finish_op": 8068480,
+      "Objecter::_send_op": 8013216
     },
-    "librados.so.2": {
-        "build_id": "a463bb64f70ebb6a40d2705472181460d8a88368",
-        "func2pc": {
-            "Objecter::_finish_op": 912400,
-            "Objecter::_send_op": 857136
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 152
     },
-    "librbd.so.1": {
-        "build_id": "d547af0b0399ed47a5ca02ff405833e43a65e4f7",
-        "func2pc": {
-            "Objecter::_finish_op": 6656176,
-            "Objecter::_send_op": 6600912
-        },
-        "type_sizes": {
-            "OSDOp": 152
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 96,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1144,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1360,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "a463bb64f70ebb6a40d2705472181460d8a88368",
+    "func2pc": {
+      "Objecter::_finish_op": 912400,
+      "Objecter::_send_op": 857136
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "d547af0b0399ed47a5ca02ff405833e43a65e4f7",
+    "func2pc": {
+      "Objecter::_finish_op": 6656176,
+      "Objecter::_send_op": 6600912
+    },
+    "type_sizes": {
+      "OSDOp": 152
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 96,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1144,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1360,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/19.2.0-0ubuntu0.24.04.2_dwarf.json
+++ b/files/ubuntu/radostrace/19.2.0-0ubuntu0.24.04.2_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "19.2.0-0ubuntu0.24.04.2",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "611e483f63289443c1d5f51f8af125b593723ea6",
-        "func2pc": {
-            "Objecter::_finish_op": 8908560,
-            "Objecter::_send_op": 8851104
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "19.2.0-0ubuntu0.24.04.2",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "611e483f63289443c1d5f51f8af125b593723ea6",
+    "func2pc": {
+      "Objecter::_finish_op": 8908560,
+      "Objecter::_send_op": 8851104
     },
-    "librados.so.2": {
-        "build_id": "91f01ef79488aa7d971d460d220a7fc31fec6645",
-        "func2pc": {
-            "Objecter::_finish_op": 1012832,
-            "Objecter::_send_op": 955376
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 112
     },
-    "librbd.so.1": {
-        "build_id": "1a30a0bfe2760961020d56c7c9a60e3d6ee6a7e3",
-        "func2pc": {
-            "Objecter::_finish_op": 6869280,
-            "Objecter::_send_op": 6811824
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "91f01ef79488aa7d971d460d220a7fc31fec6645",
+    "func2pc": {
+      "Objecter::_finish_op": 1012832,
+      "Objecter::_send_op": 955376
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "1a30a0bfe2760961020d56c7c9a60e3d6ee6a7e3",
+    "func2pc": {
+      "Objecter::_finish_op": 6869280,
+      "Objecter::_send_op": 6811824
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/19.2.0-0ubuntu0.24.04.2~cloud0_dwarf.json
+++ b/files/ubuntu/radostrace/19.2.0-0ubuntu0.24.04.2~cloud0_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "19.2.0-0ubuntu0.24.04.2~cloud0",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "f5b2886579b5c465471b9b71d4e8ecf2f5147562",
-        "func2pc": {
-            "Objecter::_finish_op": 8655344,
-            "Objecter::_send_op": 8595888
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "19.2.0-0ubuntu0.24.04.2~cloud0",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "f5b2886579b5c465471b9b71d4e8ecf2f5147562",
+    "func2pc": {
+      "Objecter::_finish_op": 8655344,
+      "Objecter::_send_op": 8595888
     },
-    "librados.so.2": {
-        "build_id": "b88ed685ad283f9259df920fa969bdc266e5cf3f",
-        "func2pc": {
-            "Objecter::_finish_op": 960560,
-            "Objecter::_send_op": 901104
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 112
     },
-    "librbd.so.1": {
-        "build_id": "a3f1e9db89cee48c44ae9d23434a7da70aea7317",
-        "func2pc": {
-            "Objecter::_finish_op": 7129760,
-            "Objecter::_send_op": 7070304
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "b88ed685ad283f9259df920fa969bdc266e5cf3f",
+    "func2pc": {
+      "Objecter::_finish_op": 960560,
+      "Objecter::_send_op": 901104
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "a3f1e9db89cee48c44ae9d23434a7da70aea7317",
+    "func2pc": {
+      "Objecter::_finish_op": 7129760,
+      "Objecter::_send_op": 7070304
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/19.2.1-0ubuntu0.24.04.2_dwarf.json
+++ b/files/ubuntu/radostrace/19.2.1-0ubuntu0.24.04.2_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "19.2.1-0ubuntu0.24.04.2",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "9c132c525a73ef4cab19b088f8e7723ac6171281",
-        "func2pc": {
-            "Objecter::_finish_op": 9105376,
-            "Objecter::_send_op": 9047536
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "19.2.1-0ubuntu0.24.04.2",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "9c132c525a73ef4cab19b088f8e7723ac6171281",
+    "func2pc": {
+      "Objecter::_finish_op": 9105376,
+      "Objecter::_send_op": 9047536
     },
-    "librados.so.2": {
-        "build_id": "94838690d797823defbfa137510ce9b4d3772551",
-        "func2pc": {
-            "Objecter::_finish_op": 1009184,
-            "Objecter::_send_op": 951344
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 112
     },
-    "librbd.so.1": {
-        "build_id": "8f660675cd4b45b1f7015b6f2b72e8764b6b70b4",
-        "func2pc": {
-            "Objecter::_finish_op": 7431936,
-            "Objecter::_send_op": 7374096
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "94838690d797823defbfa137510ce9b4d3772551",
+    "func2pc": {
+      "Objecter::_finish_op": 1009184,
+      "Objecter::_send_op": 951344
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "8f660675cd4b45b1f7015b6f2b72e8764b6b70b4",
+    "func2pc": {
+      "Objecter::_finish_op": 7431936,
+      "Objecter::_send_op": 7374096
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/19.2.3-0ubuntu0.24.04.1_dwarf.json
+++ b/files/ubuntu/radostrace/19.2.3-0ubuntu0.24.04.1_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "19.2.3-0ubuntu0.24.04.1",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "6add8450230eaccfcfcd85f103f77cfb3b06cff7",
-        "func2pc": {
-            "Objecter::_finish_op": 8977024,
-            "Objecter::_send_op": 8919424
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "19.2.3-0ubuntu0.24.04.1",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "6add8450230eaccfcfcd85f103f77cfb3b06cff7",
+    "func2pc": {
+      "Objecter::_finish_op": 8977024,
+      "Objecter::_send_op": 8919424
     },
-    "librados.so.2": {
-        "build_id": "7a09e56c25e53664261df4bc6815ce24d672e646",
-        "func2pc": {
-            "Objecter::_finish_op": 1149312,
-            "Objecter::_send_op": 1091712
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 112
     },
-    "librbd.so.1": {
-        "build_id": "2a72ed7b3b4d374c5c6a7443a2339928631952e0",
-        "func2pc": {
-            "Objecter::_finish_op": 7118656,
-            "Objecter::_send_op": 7061056
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "7a09e56c25e53664261df4bc6815ce24d672e646",
+    "func2pc": {
+      "Objecter::_finish_op": 1149312,
+      "Objecter::_send_op": 1091712
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "2a72ed7b3b4d374c5c6a7443a2339928631952e0",
+    "func2pc": {
+      "Objecter::_finish_op": 7118656,
+      "Objecter::_send_op": 7061056
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/19.2.3-0ubuntu0.24.04.1~cloud0_dwarf.json
+++ b/files/ubuntu/radostrace/19.2.3-0ubuntu0.24.04.1~cloud0_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "19.2.3-0ubuntu0.24.04.1~cloud0",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "1b3c93f1a202ebdbaa723ccd8df0ceaaffeea83d",
-        "func2pc": {
-            "Objecter::_finish_op": 8738144,
-            "Objecter::_send_op": 8678368
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "19.2.3-0ubuntu0.24.04.1~cloud0",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "1b3c93f1a202ebdbaa723ccd8df0ceaaffeea83d",
+    "func2pc": {
+      "Objecter::_finish_op": 8738144,
+      "Objecter::_send_op": 8678368
     },
-    "librados.so.2": {
-        "build_id": "3fdbb3d7688d1fc7cee7e3424de889a907bb12cc",
-        "func2pc": {
-            "Objecter::_finish_op": 1087760,
-            "Objecter::_send_op": 1027984
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 112
     },
-    "librbd.so.1": {
-        "build_id": "36664c484f5b45508525c52badfe5fbbd9b2ca29",
-        "func2pc": {
-            "Objecter::_finish_op": 7416048,
-            "Objecter::_send_op": 7356272
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "3fdbb3d7688d1fc7cee7e3424de889a907bb12cc",
+    "func2pc": {
+      "Objecter::_finish_op": 1087760,
+      "Objecter::_send_op": 1027984
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "36664c484f5b45508525c52badfe5fbbd9b2ca29",
+    "func2pc": {
+      "Objecter::_finish_op": 7416048,
+      "Objecter::_send_op": 7356272
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/19.2.3-0ubuntu0.24.04.2_dwarf.json
+++ b/files/ubuntu/radostrace/19.2.3-0ubuntu0.24.04.2_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "19.2.3-0ubuntu0.24.04.2",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "8e05084d6ecbbebdcd583bb8795bd9ddf9c616c6",
-        "func2pc": {
-            "Objecter::_finish_op": 8977024,
-            "Objecter::_send_op": 8919424
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "19.2.3-0ubuntu0.24.04.2",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "8e05084d6ecbbebdcd583bb8795bd9ddf9c616c6",
+    "func2pc": {
+      "Objecter::_finish_op": 8977024,
+      "Objecter::_send_op": 8919424
     },
-    "librados.so.2": {
-        "build_id": "2b2295354fbf99334da15d29b221a09f4e8bcba5",
-        "func2pc": {
-            "Objecter::_finish_op": 1149312,
-            "Objecter::_send_op": 1091712
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 112
     },
-    "librbd.so.1": {
-        "build_id": "a9715e6a4aa511f5a1bd1d55799a311e1b790855",
-        "func2pc": {
-            "Objecter::_finish_op": 7118656,
-            "Objecter::_send_op": 7061056
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "2b2295354fbf99334da15d29b221a09f4e8bcba5",
+    "func2pc": {
+      "Objecter::_finish_op": 1149312,
+      "Objecter::_send_op": 1091712
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "a9715e6a4aa511f5a1bd1d55799a311e1b790855",
+    "func2pc": {
+      "Objecter::_finish_op": 7118656,
+      "Objecter::_send_op": 7061056
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/files/ubuntu/radostrace/19.2.3-0ubuntu0.24.04.2~cloud0_dwarf.json
+++ b/files/ubuntu/radostrace/19.2.3-0ubuntu0.24.04.2~cloud0_dwarf.json
@@ -1,1186 +1,1186 @@
 {
-    "version": "19.2.3-0ubuntu0.24.04.2~cloud0",
-    "arch": "amd64",
-    "libceph-common.so.2": {
-        "build_id": "99f34aec2b1169ecb0267a773842bf77cbb95484",
-        "func2pc": {
-            "Objecter::_finish_op": 8738144,
-            "Objecter::_send_op": 8678368
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+  "version": "19.2.3-0ubuntu0.24.04.2~cloud0",
+  "arch": "amd64",
+  "libceph-common.so.2": {
+    "build_id": "99f34aec2b1169ecb0267a773842bf77cbb95484",
+    "func2pc": {
+      "Objecter::_finish_op": 8738144,
+      "Objecter::_send_op": 8678368
     },
-    "librados.so.2": {
-        "build_id": "fcd825f262d3644f10281be3dc3f1ef092a1cee7",
-        "func2pc": {
-            "Objecter::_finish_op": 1087760,
-            "Objecter::_send_op": 1027984
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+    "type_sizes": {
+      "OSDOp": 112
     },
-    "librbd.so.1": {
-        "build_id": "c7a5be6db83749187542a7ae6a14ccbda1a4155c",
-        "func2pc": {
-            "Objecter::_finish_op": 7416048,
-            "Objecter::_send_op": 7356272
-        },
-        "type_sizes": {
-            "OSDOp": 112
-        },
-        "member_offsets": {
-            "OSDOp::indata._carriage": 56,
-            "OSDOp::op.cls.class_len": 6,
-            "OSDOp::op.cls.method_len": 7,
-            "OSDOp::op.extent.length": 14,
-            "OSDOp::op.extent.offset": 6
-        },
-        "func2vf": {
-            "Objecter::_finish_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
             },
-            "Objecter::_send_op": {
-                "var_fields": [
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 1064,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 5,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 32,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 1368,
-                                "pointer": true
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 400,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 272,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 40,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 336,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            }
-                        ]
-                    },
-                    {
-                        "location": {
-                            "reg": 4,
-                            "offset": 0,
-                            "stack": false
-                        },
-                        "fields": [
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 464,
-                                "pointer": true
-                            },
-                            {
-                                "offset": 0,
-                                "pointer": false
-                            },
-                            {
-                                "offset": 8,
-                                "pointer": false
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
     }
+  },
+  "librados.so.2": {
+    "build_id": "fcd825f262d3644f10281be3dc3f1ef092a1cee7",
+    "func2pc": {
+      "Objecter::_finish_op": 1087760,
+      "Objecter::_send_op": 1027984
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "librbd.so.1": {
+    "build_id": "c7a5be6db83749187542a7ae6a14ccbda1a4155c",
+    "func2pc": {
+      "Objecter::_finish_op": 7416048,
+      "Objecter::_send_op": 7356272
+    },
+    "type_sizes": {
+      "OSDOp": 112
+    },
+    "member_offsets": {
+      "OSDOp::indata._carriage": 56,
+      "OSDOp::op.cls.class_len": 6,
+      "OSDOp::op.cls.method_len": 7,
+      "OSDOp::op.extent.length": 14,
+      "OSDOp::op.extent.offset": 6
+    },
+    "func2vf": {
+      "Objecter::_finish_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      },
+      "Objecter::_send_op": {
+        "var_fields": [
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 1064,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 5,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 32,
+                "pointer": true
+              },
+              {
+                "offset": 1368,
+                "pointer": true
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 400,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 272,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 40,
+                "pointer": true
+              },
+              {
+                "offset": 336,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              }
+            ]
+          },
+          {
+            "location": {
+              "reg": 4,
+              "offset": 0,
+              "stack": false
+            },
+            "fields": [
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 464,
+                "pointer": true
+              },
+              {
+                "offset": 0,
+                "pointer": false
+              },
+              {
+                "offset": 8,
+                "pointer": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 }

--- a/src/bpf_ceph_types.h
+++ b/src/bpf_ceph_types.h
@@ -167,6 +167,63 @@ enum objectstore_txn_opcode {
 #undef GENERATE_TXN_ENUM
 };
 
+/* Allocator tracing (-A) */
+#define ALLOC_NAME_LEN 32
+#define ALLOC_MAX_EXTENTS 6
+// nested allocate() calls per thread we track (HybridAllocator falls
+// through to its internal BitmapAllocator, HybridBtree2Allocator calls
+// its base class allocate)
+#define ALLOC_MAX_DEPTH 4
+// hprobes slot holding the {"this","asok_hook","name","_M_dataplus","_M_p"}
+// varpath harvested from {AllocatorBase,Allocator}::get_name; every
+// allocate() entry probe reuses it ("this" sits in the same register)
+#define ALLOC_NAME_VARID 390
+
+// key of an in-flight allocate() call; depth disambiguates nesting.
+// Contains implicit padding, always memset before filling.
+struct alloc_k {
+  __u64 ptid;
+  __u32 depth;
+};
+
+// stashed at allocate() entry, consumed by the shared uretprobe
+struct alloc_inflight {
+  char name[ALLOC_NAME_LEN];
+  char comm[16];
+  __u32 tid;
+  __u32 start_off;   // offset of _M_start within PExtentVector
+  __u32 finish_off;  // offset of _M_finish within PExtentVector
+  __u64 want;
+  __u64 unit;
+  __u64 max_alloc;
+  __s64 hint;
+  __u64 extents;     // PExtentVector *
+  __u64 ts;
+};
+
+struct alloc_ext {
+  __u64 offset;
+  __u64 length;
+};
+
+// ringbuf event; sizeof() must stay distinct from op_v, bluestore_lat_v
+// (handle_event dispatches ringbuf events by size)
+struct alloc_v {
+  __u32 pid;
+  __u32 tid;
+  char comm[16];
+  char name[ALLOC_NAME_LEN];
+  __u32 depth;       // >0 = nested (e.g. hybrid fell back to its bitmap)
+  __u32 nextents;    // total extents returned (may exceed the array below)
+  __u64 want;
+  __u64 unit;
+  __u64 max_alloc;
+  __s64 hint;
+  __s64 rval;        // bytes allocated, or -errno
+  __u64 lat;         // ns
+  struct alloc_ext ext[ALLOC_MAX_EXTENTS];
+};
+
 struct op_v {
   __u32 pid;
   unsigned long long owner;

--- a/src/dwarf_parser.cc
+++ b/src/dwarf_parser.cc
@@ -727,19 +727,24 @@ Dwarf_Die * DwarfParser::dwarf_attr_die(Dwarf_Die *die, unsigned int attr_flag, 
 }
 
 bool DwarfParser::find_class_member(Dwarf_Die *vardie, Dwarf_Die *typedie,
-                                    string member, Dwarf_Attribute *attr) {
-  // TODO deal with inheritance later
-
-  std::queue<Dwarf_Die> die_queue;
-  die_queue.push(*typedie);
+                                    string member, Dwarf_Attribute *attr,
+                                    Dwarf_Word *base_offset) {
+  // BFS through the class and its base classes. A member inherited from a
+  // base has its DW_AT_data_member_location relative to that base, so the
+  // base's own offset within the derived class is accumulated and returned
+  // via *base_offset.
+  std::queue<std::pair<Dwarf_Die, Dwarf_Word>> die_queue;
+  die_queue.push({*typedie, 0});
   bool found = false;
+  Dwarf_Word found_off = 0;
   while (!die_queue.empty()) {
+    Dwarf_Die cur = die_queue.front().first;
+    Dwarf_Word cur_off = die_queue.front().second;
+    die_queue.pop();
     Dwarf_Die die;
-    int r = dwarf_child(&die_queue.front(), &die);
-    if (r != 0) {
-      cerr << "the class " << dwarf_diename(typedie)
-           << " has no children, unexpected; skipping" << endl;
-      return false;
+    if (dwarf_child(&cur, &die) != 0) {
+      // declaration-only or empty class: nothing to search here
+      continue;
     }
     do {
       int tag = dwarf_tag(&die);
@@ -750,20 +755,38 @@ bool DwarfParser::find_class_member(Dwarf_Die *vardie, Dwarf_Die *typedie,
       const char *name = dwarf_diename(&die);
       if (tag == DW_TAG_inheritance) {
         Dwarf_Die inheritee;
-        if (dwarf_attr_die (&die, DW_AT_type, &inheritee))
-          die_queue.push(inheritee);
+        if (!dwarf_attr_die(&die, DW_AT_type, &inheritee))
+          continue;
+        // non-virtual base offset within the derived class (constant
+        // form); virtual bases use a location expression, unsupported
+        Dwarf_Word boff = 0;
+        Dwarf_Attribute battr_mem;
+        Dwarf_Attribute *battr = dwarf_attr_integrate(
+            &die, DW_AT_data_member_location, &battr_mem);
+        if (battr != NULL && dwarf_formudata(battr, &boff) != 0)
+          continue;
+        // the base class is often only a declaration in this CU (e.g.
+        // BlockDevice in KernelDevice.cc); resolve the definition
+        // through the global type cache
+        if (dwarf_hasattr(&inheritee, DW_AT_declaration)) {
+          Dwarf_Die *resolved = resolve_typedecl(&inheritee);
+          if (resolved == NULL)
+            continue;
+          inheritee = *resolved;
+        }
+        die_queue.push({inheritee, cur_off + boff});
       } else if (tag == DW_TAG_enumeration_type) {
         // TODO
       } else if (name == NULL) {
         // TODO
       } else if (name == member) {
         *vardie = die;
+        found_off = cur_off;
         found = true;
         break;
       }
 
     } while (dwarf_siblingof(&die, &die) == 0);
-    die_queue.pop();
     if (found)
       break;
   }
@@ -772,6 +795,8 @@ bool DwarfParser::find_class_member(Dwarf_Die *vardie, Dwarf_Die *typedie,
     cerr << "couldn't find member " << member << endl;
     return false;
   }
+  if (base_offset != NULL)
+    *base_offset = found_off;
   if (dwarf_hasattr_integrate(vardie, DW_AT_data_member_location)) {
     dwarf_attr_integrate(vardie, DW_AT_data_member_location, attr);
     return true;
@@ -857,7 +882,8 @@ bool DwarfParser::translate_fields(Dwarf_Die *vardie, Dwarf_Die *typedie,
           *typedie = *tmpdie;
         }
         Dwarf_Attribute attr;
-        if (!find_class_member(vardie, typedie, fields[i], &attr)) {
+        Dwarf_Word base_off = 0;
+        if (!find_class_member(vardie, typedie, fields[i], &attr, &base_off)) {
           clog << "failed to find member location for " << fields[i] << endl;
           return false;
         }
@@ -872,7 +898,9 @@ bool DwarfParser::translate_fields(Dwarf_Die *vardie, Dwarf_Die *typedie,
           clog << "failed to translate location of " << fields[i] << endl;
           return false;
         }
-        field.offset = varloc.offset;
+        // for a member inherited from a base class, add the base class
+        // offset within the derived class
+        field.offset = varloc.offset + (int)base_off;
         res.push_back(field);
         field = {0, false};
 
@@ -1002,7 +1030,16 @@ static int handle_function(Dwarf_Die *die, void *data) {
     Dwarf_Die vardie, typedie;
     VarLocation varloc;
     bool ok = dp->translate_param_location(die, varname, pc, vardie, varloc);
-    assert(ok);
+    if (!ok) {
+      // don't abort the whole tool over one unresolvable probe; drop the
+      // function so attach later skips it with the addr==0 warning
+      cerr << "Warning: failed to resolve location of variable '" << varname
+           << "' in " << fullname << ", skipping probes on this function"
+           << endl;
+      func2pc.erase(fullname);
+      func2vf.erase(fullname);
+      return 0;
+    }
     //printf("var %s location : register %d, offset %d, stack %d\n",
      //varname.c_str(), varloc.reg, varloc.offset, varloc.stack);
     vf[i].varloc = varloc;
@@ -1010,7 +1047,14 @@ static int handle_function(Dwarf_Die *die, void *data) {
     // translate fileds
     dp->dwarf_die_type(&vardie, &typedie);
     ok = dp->translate_fields(&vardie, &typedie, pc, arr[i], vf[i].fields);
-    assert(ok);
+    if (!ok) {
+      cerr << "Warning: failed to resolve member path from variable '"
+           << varname << "' in " << fullname
+           << ", skipping probes on this function" << endl;
+      func2pc.erase(fullname);
+      func2vf.erase(fullname);
+      return 0;
+    }
     for (int j = 1; j < (int)vf[i].fields.size(); ++j) {
        //printf("Field %s is at offset %d, defref %d\n", arr[i][j].c_str(),
        //vf[i].fields[j].offset, vf[i].fields[j].pointer);

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -118,7 +118,7 @@ class DwarfParser {
   bool find_prologue(Dwarf_Die *func, Dwarf_Addr &pc);
   void dwarf_die_type(Dwarf_Die *, Dwarf_Die *);
   bool find_class_member(Dwarf_Die *, Dwarf_Die *, std::string,
-                         Dwarf_Attribute *);
+                         Dwarf_Attribute *, Dwarf_Word *base_offset = NULL);
   bool translate_fields(Dwarf_Die *, Dwarf_Die *, Dwarf_Addr,
                         std::vector<std::string>, std::vector<Field> &);
   bool filter_func(std::string);

--- a/src/osdtrace.bpf.c
+++ b/src/osdtrace.bpf.c
@@ -135,6 +135,23 @@ static __always_inline void capture_decoded_osd_ops(
   }
 }
 
+// per-thread allocate() nesting depth (-A mode)
+struct {
+  __uint(type, BPF_MAP_TYPE_HASH);
+  __type(key, __u64);
+  __type(value, __u32);
+  __uint(max_entries, 256);
+} alloc_depth SEC(".maps");
+
+// in-flight allocate() calls, keyed by {pid_tgid, depth}. LRU so entries
+// orphaned by a missed return probe self-evict.
+struct {
+  __uint(type, BPF_MAP_TYPE_LRU_HASH);
+  __type(key, struct alloc_k);
+  __type(value, struct alloc_inflight);
+  __uint(max_entries, 1024);
+} allocs_inflight SEC(".maps");
+
 SEC("uprobe")
 int uprobe_enqueue_op(struct pt_regs *ctx) {
   int varid = 0;
@@ -967,5 +984,180 @@ int uprobe_txc_add_transaction(struct pt_regs *ctx)
     vp->detail_ops_captured = captured + 1;
   }
 
+  return 0;
+}
+
+/*
+ * Allocator tracing (-A).
+ *
+ * Every concrete allocator overrides the pure-virtual
+ * Allocator::allocate(want, unit, max_alloc_size, hint, PExtentVector*),
+ * so the overrides are guaranteed out-of-line and form a choke point for
+ * both BlueStore data allocations and BlueFS file allocations. Entry
+ * probes stash the request per {thread, nesting depth}; a shared
+ * uretprobe computes the latency and walks the returned PExtentVector.
+ *
+ * Nesting matters: HybridAllocator's allocate() falls back to its
+ * internal BitmapAllocator's allocate(), and HybridBtree2Allocator's
+ * allocate() calls its base class version -- all probed, so a per-thread
+ * depth counter keeps the entry/return pairs matched.
+ */
+
+// shared entry body; varid points at this function's
+// {"extents","_M_impl","_M_start"} / {"_M_finish"} varpaths
+static __always_inline int alloc_entry(struct pt_regs *ctx, int varid) {
+  __u64 ptid = bpf_get_current_pid_tgid();
+  __u32 depth = 0;
+  __u32 *dp = bpf_map_lookup_elem(&alloc_depth, &ptid);
+  if (NULL != dp)
+    depth = *dp;
+  __u32 ndepth = depth + 1;
+  bpf_map_update_elem(&alloc_depth, &ptid, &ndepth, 0);
+  if (depth >= ALLOC_MAX_DEPTH)
+    return 0;  // not stashed; the uretprobe still decrements
+
+  struct alloc_inflight in;
+  memset(&in, 0, sizeof(in));
+
+  // allocator instance name ("block", "bluefs-db", ...) via the varpath
+  // harvested from {AllocatorBase,Allocator}::get_name -- `this` sits in
+  // the same register at any method entry, so the location is reusable
+  int nvarid = ALLOC_NAME_VARID;
+  struct VarField *vf = bpf_map_lookup_elem(&hprobes, &nvarid);
+  if (NULL != vf) {
+    __u64 v = fetch_register(ctx, vf->varloc.reg);
+    __u64 mp_addr = fetch_var_member_addr(v, vf);
+    __u64 str_addr = 0;
+    bpf_probe_read_user(&str_addr, sizeof(str_addr), (void *)mp_addr);
+    bpf_probe_read_user_str(in.name, sizeof(in.name), (void *)str_addr);
+  }
+
+  // offsets of _M_start/_M_finish inside PExtentVector, for the uretprobe
+  // (member chain is offset-only: base classes and direct members)
+  vf = bpf_map_lookup_elem(&hprobes, &varid);
+  if (NULL != vf && vf->size >= 3)
+    in.start_off = vf->fields[1].offset + vf->fields[2].offset;
+  else
+    bpf_printk("alloc_entry got NULL/short vf at varid %d\n", varid);
+  ++varid;
+  vf = bpf_map_lookup_elem(&hprobes, &varid);
+  if (NULL != vf && vf->size >= 3)
+    in.finish_off = vf->fields[1].offset + vf->fields[2].offset;
+
+  in.want = PT_REGS_PARM2(ctx);
+  in.unit = PT_REGS_PARM3(ctx);
+  in.max_alloc = PT_REGS_PARM4(ctx);
+  in.hint = (__s64)PT_REGS_PARM5(ctx);
+  in.extents = PT_REGS_PARM6(ctx);
+  in.tid = get_tid();
+  bpf_get_current_comm(in.comm, sizeof(in.comm));
+  in.ts = bpf_ktime_get_boot_ns();
+
+  struct alloc_k key;
+  memset(&key, 0, sizeof(key));
+  key.ptid = ptid;
+  key.depth = depth;
+  bpf_map_update_elem(&allocs_inflight, &key, &in, 0);
+  return 0;
+}
+
+SEC("uprobe")
+int uprobe_alloc_stupid(struct pt_regs *ctx) { return alloc_entry(ctx, 300); }
+
+SEC("uprobe")
+int uprobe_alloc_bitmap(struct pt_regs *ctx) { return alloc_entry(ctx, 310); }
+
+SEC("uprobe")
+int uprobe_alloc_avl(struct pt_regs *ctx) { return alloc_entry(ctx, 320); }
+
+SEC("uprobe")
+int uprobe_alloc_btree(struct pt_regs *ctx) { return alloc_entry(ctx, 330); }
+
+SEC("uprobe")
+int uprobe_alloc_btree2(struct pt_regs *ctx) { return alloc_entry(ctx, 340); }
+
+// HybridAllocatorBase<AvlAllocator> / HybridAllocator<AvlAllocator> /
+// HybridAllocator (pre-template releases)
+SEC("uprobe")
+int uprobe_alloc_hybrid_avl(struct pt_regs *ctx) { return alloc_entry(ctx, 350); }
+
+// HybridAllocatorBase<Btree2Allocator> / HybridAllocator<Btree2Allocator>
+SEC("uprobe")
+int uprobe_alloc_hybrid_btree2(struct pt_regs *ctx) { return alloc_entry(ctx, 360); }
+
+// HybridBtree2Allocator's own override (cache fast path wrapper)
+SEC("uprobe")
+int uprobe_alloc_hybrid_btree2_outer(struct pt_regs *ctx) { return alloc_entry(ctx, 370); }
+
+// shared return probe for all allocate() variants
+SEC("uretprobe")
+int uretprobe_allocator(struct pt_regs *ctx) {
+  __u64 ptid = bpf_get_current_pid_tgid();
+  __u32 *dp = bpf_map_lookup_elem(&alloc_depth, &ptid);
+  if (NULL == dp)
+    return 0;
+  __u32 depth = *dp;
+  if (depth == 0) {
+    bpf_map_delete_elem(&alloc_depth, &ptid);
+    return 0;
+  }
+  depth -= 1;
+  if (depth == 0)
+    bpf_map_delete_elem(&alloc_depth, &ptid);
+  else
+    bpf_map_update_elem(&alloc_depth, &ptid, &depth, 0);
+  if (depth >= ALLOC_MAX_DEPTH)
+    return 0;  // entry was not stashed
+
+  struct alloc_k key;
+  memset(&key, 0, sizeof(key));
+  key.ptid = ptid;
+  key.depth = depth;
+  struct alloc_inflight *in = bpf_map_lookup_elem(&allocs_inflight, &key);
+  if (NULL == in)
+    return 0;
+
+  __u64 now = bpf_ktime_get_boot_ns();
+  struct alloc_v *e = bpf_ringbuf_reserve(&rb, sizeof(struct alloc_v), 0);
+  if (NULL == e) {
+    bpf_map_delete_elem(&allocs_inflight, &key);
+    return 0;
+  }
+  memset(e, 0, sizeof(*e));
+  e->pid = get_pid();
+  e->tid = in->tid;
+  __builtin_memcpy(e->comm, in->comm, sizeof(e->comm));
+  __builtin_memcpy(e->name, in->name, sizeof(e->name));
+  e->depth = depth;
+  e->want = in->want;
+  e->unit = in->unit;
+  e->max_alloc = in->max_alloc;
+  e->hint = in->hint;
+  e->rval = (__s64)PT_REGS_RC(ctx);
+  e->lat = now - in->ts;
+
+  // walk the returned PExtentVector: {_M_start, _M_finish} pointers,
+  // elements are bluestore_pextent_t {u64 offset; u32 length;} = 16 bytes
+  __u64 vstart = 0, vfinish = 0;
+  bpf_probe_read_user(&vstart, sizeof(vstart),
+                      (void *)(in->extents + in->start_off));
+  bpf_probe_read_user(&vfinish, sizeof(vfinish),
+                      (void *)(in->extents + in->finish_off));
+  __u32 n = 0;
+  if (vfinish > vstart)
+    n = (vfinish - vstart) / 16;
+  e->nextents = n;
+  for (int i = 0; i < ALLOC_MAX_EXTENTS; i++) {
+    if ((__u32)i >= n)
+      break;
+    __u64 base = vstart + 16ULL * (__u64)i;
+    bpf_probe_read_user(&e->ext[i].offset, sizeof(__u64), (void *)base);
+    __u32 l = 0;
+    bpf_probe_read_user(&l, sizeof(l), (void *)(base + 8));
+    e->ext[i].length = l;
+  }
+
+  bpf_ringbuf_submit(e, 0);
+  bpf_map_delete_elem(&allocs_inflight, &key);
   return 0;
 }

--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -38,7 +38,11 @@ using namespace std;
 typedef std::map<std::string, int> func_id_t;
 
 std::vector<std::string> probe_units = {
-    "OpRequest.cc", "OSD.cc", "BlueStore.cc", "PrimaryLogPG.cc", "ReplicatedBackend.cc", "ECBackend.cc"};
+    "OpRequest.cc", "OSD.cc", "BlueStore.cc", "PrimaryLogPG.cc", "ReplicatedBackend.cc", "ECBackend.cc",
+    // allocator tracing (-A)
+    "StupidAllocator.cc", "BitmapAllocator.cc", "AvlAllocator.cc",
+    "BtreeAllocator.cc", "Btree2Allocator.cc", "HybridAllocator.cc",
+    "AllocatorBase.cc", "Allocator.cc"};
 
 func_id_t func_id = {
     {"OSD::enqueue_op", 0},
@@ -61,7 +65,24 @@ func_id_t func_id = {
     {"ReplicatedBackend::repop_commit", 170},
     {"OpRequest::mark_flag_point", 180},
     {"BlueStore::log_latency_fn", 190},
-    {"BlueStore::_txc_add_transaction", 200}
+    {"BlueStore::_txc_add_transaction", 200},
+    // Allocator tracing (-A). Several names may map to the same varid
+    // base: they are the same method under different class names across
+    // Ceph releases, and at most one exists in a given binary.
+    {"StupidAllocator::allocate", 300},
+    {"BitmapAllocator::allocate", 310},
+    {"AvlAllocator::allocate", 320},
+    {"BtreeAllocator::allocate", 330},
+    {"Btree2Allocator::allocate", 340},
+    {"HybridAllocatorBase<AvlAllocator>::allocate", 350},
+    {"HybridAllocator<AvlAllocator>::allocate", 350},
+    {"HybridAllocator::allocate", 350},
+    {"HybridAllocatorBase<Btree2Allocator>::allocate", 360},
+    {"HybridAllocator<Btree2Allocator>::allocate", 360},
+    {"HybridBtree2Allocator::allocate", 370},
+    // name-varpath donors, never attached (see ALLOC_NAME_VARID)
+    {"AllocatorBase::get_name", 390},
+    {"Allocator::get_name", 390}
 };
 
 std::map<std::string, int> func_progid = {
@@ -85,7 +106,35 @@ std::map<std::string, int> func_progid = {
     {"ReplicatedBackend::repop_commit", 17},
     {"OpRequest::mark_flag_point", 18},
     {"BlueStore::log_latency_fn", 19},
-    {"BlueStore::_txc_add_transaction", 20}
+    {"BlueStore::_txc_add_transaction", 20},
+    // Allocator tracing (-A). Several names may map to the same program: they are
+    // the same method under different class names across Ceph releases, and
+    // at most one exists in a given binary. All returns share one uretprobe
+    // (the *_v2 entries; attach_probe(..., v=2) looks up "<func>_v2").
+    // NOTE: ids are skeleton program indices: all SEC("uprobe") programs in
+    // source order, then SEC("uretprobe").
+    {"StupidAllocator::allocate", 21},
+    {"BitmapAllocator::allocate", 22},
+    {"AvlAllocator::allocate", 23},
+    {"BtreeAllocator::allocate", 24},
+    {"Btree2Allocator::allocate", 25},
+    {"HybridAllocatorBase<AvlAllocator>::allocate", 26},
+    {"HybridAllocator<AvlAllocator>::allocate", 26},
+    {"HybridAllocator::allocate", 26},
+    {"HybridAllocatorBase<Btree2Allocator>::allocate", 27},
+    {"HybridAllocator<Btree2Allocator>::allocate", 27},
+    {"HybridBtree2Allocator::allocate", 28},
+    {"StupidAllocator::allocate_v2", 29},
+    {"BitmapAllocator::allocate_v2", 29},
+    {"AvlAllocator::allocate_v2", 29},
+    {"BtreeAllocator::allocate_v2", 29},
+    {"Btree2Allocator::allocate_v2", 29},
+    {"HybridAllocatorBase<AvlAllocator>::allocate_v2", 29},
+    {"HybridAllocator<AvlAllocator>::allocate_v2", 29},
+    {"HybridAllocator::allocate_v2", 29},
+    {"HybridAllocatorBase<Btree2Allocator>::allocate_v2", 29},
+    {"HybridAllocator<Btree2Allocator>::allocate_v2", 29},
+    {"HybridBtree2Allocator::allocate_v2", 29}
 };
 
 DwarfParser::probes_t osd_probes = {
@@ -206,7 +255,63 @@ DwarfParser::probes_t osd_probes = {
     {"BlueStore::_txc_add_transaction",
      {{"t", "data", "ops"},
       {"t", "op_bl", "_carriage"},
-      {"t", "op_bl", "_num"}}}
+      {"t", "op_bl", "_num"}}},
+    // Allocator tracing (-A). Each allocate() declares the PExtentVector
+    // internals so the uretprobe can walk the returned extents; scalar
+    // args (want/unit/max/hint) are read straight from registers.
+    {"StupidAllocator::allocate",
+     {{"extents", "_M_impl", "_M_start"},
+      {"extents", "_M_impl", "_M_finish"}}},
+
+    {"BitmapAllocator::allocate",
+     {{"extents", "_M_impl", "_M_start"},
+      {"extents", "_M_impl", "_M_finish"}}},
+
+    {"AvlAllocator::allocate",
+     {{"extents", "_M_impl", "_M_start"},
+      {"extents", "_M_impl", "_M_finish"}}},
+
+    {"BtreeAllocator::allocate",
+     {{"extents", "_M_impl", "_M_start"},
+      {"extents", "_M_impl", "_M_finish"}}},
+
+    {"Btree2Allocator::allocate",
+     {{"extents", "_M_impl", "_M_start"},
+      {"extents", "_M_impl", "_M_finish"}}},
+
+    {"HybridAllocatorBase<AvlAllocator>::allocate",
+     {{"extents", "_M_impl", "_M_start"},
+      {"extents", "_M_impl", "_M_finish"}}},
+
+    // older releases: non-Base template / plain class names
+    {"HybridAllocator<AvlAllocator>::allocate",
+     {{"extents", "_M_impl", "_M_start"},
+      {"extents", "_M_impl", "_M_finish"}}},
+
+    {"HybridAllocator::allocate",
+     {{"extents", "_M_impl", "_M_start"},
+      {"extents", "_M_impl", "_M_finish"}}},
+
+    {"HybridAllocatorBase<Btree2Allocator>::allocate",
+     {{"extents", "_M_impl", "_M_start"},
+      {"extents", "_M_impl", "_M_finish"}}},
+
+    {"HybridAllocator<Btree2Allocator>::allocate",
+     {{"extents", "_M_impl", "_M_start"},
+      {"extents", "_M_impl", "_M_finish"}}},
+
+    {"HybridBtree2Allocator::allocate",
+     {{"extents", "_M_impl", "_M_start"},
+      {"extents", "_M_impl", "_M_finish"}}},
+
+    // never attached: donates the allocator-name varpath (ALLOC_NAME_VARID).
+    // The name lives in the SocketHook, whose full DWARF definition only
+    // exists in the CU that defines get_name.
+    {"AllocatorBase::get_name",
+     {{"this", "asok_hook", "name", "_M_dataplus", "_M_p"}}},
+
+    {"Allocator::get_name",
+     {{"this", "asok_hook", "name", "_M_dataplus", "_M_p"}}}
 };
 
 enum mode_e { MODE_AVG = 1, MODE_MAX, MODE_ALL };
@@ -216,7 +321,9 @@ enum mode_e mode = MODE_ALL;
 enum probe_mode_e {
     OP_SINGLE_PROBE = 1,
     OP_FULL_PROBE = 2,
-    BLUESTORE_PROBE = 4
+    BLUESTORE_PROBE = 4,
+    // 8 is reserved for BDEV_PROBE (feat/bdev-io-tracing)
+    ALLOC_PROBE = 16
 };
 
 int probe_mode = OP_FULL_PROBE;
@@ -763,6 +870,43 @@ void handle_bluestore(struct bluestore_lat_v *val, int osd_id) {
     printf("osd %d bluestore %s lat %lld us\n", osd_id, name, lat_us);
 }
 
+// ring buffer events are dispatched by size, keep the event structs distinct
+static_assert(sizeof(struct alloc_v) != sizeof(struct op_v),
+              "alloc_v and op_v must have distinct sizes");
+static_assert(sizeof(struct alloc_v) != sizeof(struct bluestore_lat_v),
+              "alloc_v and bluestore_lat_v must have distinct sizes");
+
+void handle_alloc(struct alloc_v *val, int osd_id) {
+  __u64 lat_us = val->lat / 1000;
+  // -l threshold is in milliseconds
+  if (threshold > 0 && lat_us / 1000 < threshold)
+    return;
+
+  printf("osd %d alloc %-10s ", osd_id, val->name[0] ? val->name : "?");
+  if (val->depth)
+    printf("(nested d%u) ", val->depth);
+  printf("want 0x%llx unit 0x%llx ", val->want, val->unit);
+  if (val->hint > 0)  // 0 and -1 both mean "no hint"
+    printf("hint 0x%llx ", (unsigned long long)val->hint);
+
+  if (val->rval < 0) {
+    printf("-> ret %lld%s ", val->rval, val->rval == -28 ? " (ENOSPC)" : "");
+  } else {
+    printf("-> 0x%llx%s ", (unsigned long long)val->rval,
+           (__u64)val->rval < val->want ? " SHORT" : "");
+  }
+
+  printf("exts %u [", val->nextents);
+  __u32 shown = val->nextents < ALLOC_MAX_EXTENTS ? val->nextents
+                                                  : ALLOC_MAX_EXTENTS;
+  for (__u32 i = 0; i < shown; ++i)
+    printf("%s0x%llx~0x%llx", i ? " " : "", val->ext[i].offset,
+           val->ext[i].length);
+  if (val->nextents > shown)
+    printf(" ...");
+  printf("] lat %lluus comm %s\n", lat_us, val->comm);
+}
+
 static int handle_event(void *ctx, void *data, size_t size) {
   (void)ctx;
   int osd_id = -1;
@@ -771,6 +915,7 @@ static int handle_event(void *ctx, void *data, size_t size) {
   // Determine event type based on size
   bool is_bluestore_event = (size == sizeof(struct bluestore_lat_v));
   bool is_op_event = (size == sizeof(struct op_v));
+  bool is_alloc_event = (size == sizeof(struct alloc_v));
 
   if (is_op_event && (probe_mode & (OP_SINGLE_PROBE | OP_FULL_PROBE))) {
     struct op_v *val = (struct op_v *)data;
@@ -787,6 +932,11 @@ static int handle_event(void *ctx, void *data, size_t size) {
     pid = val->pid;
     osd_id = osd_pid_to_id(pid);
     handle_bluestore(val, osd_id);
+  } else if (is_alloc_event && (probe_mode & ALLOC_PROBE)) {
+    struct alloc_v *val = (struct alloc_v *)data;
+    pid = val->pid;
+    osd_id = osd_pid_to_id(pid);
+    handle_alloc(val, osd_id);
   }
 
   if (!exists(osd_id)) {
@@ -980,7 +1130,7 @@ int parse_args(int argc, char **argv) {
   // it in a plain char is unsafe on platforms where char is unsigned by
   // default (the `!= -1` test can then loop forever).  Match kfstrace.
   int opt;
-  while ((opt = getopt_long(argc, argv, ":st:bj:i:l:p:Va", long_options, &option_index)) != -1) {
+  while ((opt = getopt_long(argc, argv, ":st:bAj:i:l:p:Va", long_options, &option_index)) != -1) {
     switch (opt) {
       case 0:
         // Handle long options
@@ -1025,6 +1175,11 @@ int parse_args(int argc, char **argv) {
       case 'b':
         probe_mode |= BLUESTORE_PROBE;
         break;
+      case 'A':
+        // focused allocator view; composes with -b like -s does
+        probe_mode &= ~OP_FULL_PROBE;
+        probe_mode |= ALLOC_PROBE;
+        break;
       case 'j':
         export_json = true;
         json_output_file = optarg;
@@ -1060,10 +1215,11 @@ int parse_args(int argc, char **argv) {
         break;
       case '?':
       case 'h':
-        std::cout << "Usage: " << argv[0] << " [-s] [-l <milliseconds>] [-b] [-j] [-i <filename>] [-t <seconds>] [-a] [-p <pid1,pid2,...>] [--id <osd-id1,osd-id2,...>] [--skip-version-check] [--list] [--list-embedded]\n";
+        std::cout << "Usage: " << argv[0] << " [-s] [-l <milliseconds>] [-b] [-A] [-j] [-i <filename>] [-t <seconds>] [-a] [-p <pid1,pid2,...>] [--id <osd-id1,osd-id2,...>] [--skip-version-check] [--list] [--list-embedded]\n";
         std::cout << "  -s                        Set probe mode to Single OP (logs PrimaryLogPG::log_op_stats only)\n";
         std::cout << "  -l <milliseconds>         Set operation latency threshold to capture\n";
         std::cout << "  -b                        Set probe mode to Bluestore\n";
+        std::cout << "  -A                        Trace BlueStore/BlueFS allocator calls (allocator, requested size, returned extents, latency)\n";
         std::cout << "  -j                        Export DWARF info to JSON file\n";
         std::cout << "  -i <filename>             Import DWARF info from JSON file\n";
         std::cout << "  -t <seconds>              Set execution timeout in seconds\n";
@@ -1526,27 +1682,53 @@ struct AttachEntry {
   int mode;
   bool exact;
   int v;
+  bool ret;  // attach as uretprobe
 };
 
 static const AttachEntry ATTACH_LIST[] = {
-    {"PrimaryLogPG::log_op_stats", OP_SINGLE_PROBE, /*exact=*/true, 2},
-    {"OSD::dequeue_op", OP_FULL_PROBE, false, 0},
-    {"PrimaryLogPG::execute_ctx", OP_FULL_PROBE, false, 0},
-    {"ReplicatedBackend::submit_transaction", OP_FULL_PROBE, false, 0},
-    {"ECBackend::submit_transaction", OP_FULL_PROBE, false, 0},
-    {"OpRequest::mark_flag_point_string", OP_FULL_PROBE, false, 0},
-    {"OpRequest::mark_flag_point", OP_FULL_PROBE, false, 0},
-    {"ReplicatedBackend::generate_subop", OP_FULL_PROBE, false, 0},
-    {"ReplicatedBackend::do_repop_reply", OP_FULL_PROBE, false, 0},
-    {"BlueStore::queue_transactions", OP_FULL_PROBE, false, 0},
-    {"BlueStore::_txc_calc_cost", OP_FULL_PROBE, false, 0},
-    {"BlueStore::_txc_state_proc", OP_FULL_PROBE, false, 0},
-    {"BlueStore::_txc_add_transaction", OP_FULL_PROBE, false, 0},
-    {"PrimaryLogPG::log_op_stats", OP_FULL_PROBE, false, 0},
-    {"ReplicatedBackend::repop_commit", OP_FULL_PROBE, false, 0},
-    {"OSD::enqueue_op", OP_FULL_PROBE, false, 0},
-    {"BlueStore::log_latency", BLUESTORE_PROBE, false, 0},
-    {"BlueStore::log_latency_fn", BLUESTORE_PROBE, false, 0},
+    {"PrimaryLogPG::log_op_stats", OP_SINGLE_PROBE, /*exact=*/true, 2, false},
+    {"OSD::dequeue_op", OP_FULL_PROBE, false, 0, false},
+    {"PrimaryLogPG::execute_ctx", OP_FULL_PROBE, false, 0, false},
+    {"ReplicatedBackend::submit_transaction", OP_FULL_PROBE, false, 0, false},
+    {"ECBackend::submit_transaction", OP_FULL_PROBE, false, 0, false},
+    {"OpRequest::mark_flag_point_string", OP_FULL_PROBE, false, 0, false},
+    {"OpRequest::mark_flag_point", OP_FULL_PROBE, false, 0, false},
+    {"ReplicatedBackend::generate_subop", OP_FULL_PROBE, false, 0, false},
+    {"ReplicatedBackend::do_repop_reply", OP_FULL_PROBE, false, 0, false},
+    {"BlueStore::queue_transactions", OP_FULL_PROBE, false, 0, false},
+    {"BlueStore::_txc_calc_cost", OP_FULL_PROBE, false, 0, false},
+    {"BlueStore::_txc_state_proc", OP_FULL_PROBE, false, 0, false},
+    {"BlueStore::_txc_add_transaction", OP_FULL_PROBE, false, 0, false},
+    {"PrimaryLogPG::log_op_stats", OP_FULL_PROBE, false, 0, false},
+    {"ReplicatedBackend::repop_commit", OP_FULL_PROBE, false, 0, false},
+    {"OSD::enqueue_op", OP_FULL_PROBE, false, 0, false},
+    {"BlueStore::log_latency", BLUESTORE_PROBE, false, 0, false},
+    {"BlueStore::log_latency_fn", BLUESTORE_PROBE, false, 0, false},
+    // Allocator tracing (-A): one entry uprobe + the shared uretprobe (v=2,
+    // "<func>_v2" in func_progid) per concrete allocate() override.  A given
+    // binary only defines some of these; the rest skip with a warning.
+    {"StupidAllocator::allocate", ALLOC_PROBE, false, 0, false},
+    {"StupidAllocator::allocate", ALLOC_PROBE, false, 2, true},
+    {"BitmapAllocator::allocate", ALLOC_PROBE, false, 0, false},
+    {"BitmapAllocator::allocate", ALLOC_PROBE, false, 2, true},
+    {"AvlAllocator::allocate", ALLOC_PROBE, false, 0, false},
+    {"AvlAllocator::allocate", ALLOC_PROBE, false, 2, true},
+    {"BtreeAllocator::allocate", ALLOC_PROBE, false, 0, false},
+    {"BtreeAllocator::allocate", ALLOC_PROBE, false, 2, true},
+    {"Btree2Allocator::allocate", ALLOC_PROBE, false, 0, false},
+    {"Btree2Allocator::allocate", ALLOC_PROBE, false, 2, true},
+    {"HybridAllocatorBase<AvlAllocator>::allocate", ALLOC_PROBE, false, 0, false},
+    {"HybridAllocatorBase<AvlAllocator>::allocate", ALLOC_PROBE, false, 2, true},
+    {"HybridAllocator<AvlAllocator>::allocate", ALLOC_PROBE, false, 0, false},
+    {"HybridAllocator<AvlAllocator>::allocate", ALLOC_PROBE, false, 2, true},
+    {"HybridAllocator::allocate", ALLOC_PROBE, false, 0, false},
+    {"HybridAllocator::allocate", ALLOC_PROBE, false, 2, true},
+    {"HybridAllocatorBase<Btree2Allocator>::allocate", ALLOC_PROBE, false, 0, false},
+    {"HybridAllocatorBase<Btree2Allocator>::allocate", ALLOC_PROBE, false, 2, true},
+    {"HybridAllocator<Btree2Allocator>::allocate", ALLOC_PROBE, false, 0, false},
+    {"HybridAllocator<Btree2Allocator>::allocate", ALLOC_PROBE, false, 2, true},
+    {"HybridBtree2Allocator::allocate", ALLOC_PROBE, false, 0, false},
+    {"HybridBtree2Allocator::allocate", ALLOC_PROBE, false, 2, true},
 };
 
 // Load the BPF skeleton, attach the probes selected by probe_mode, and poll
@@ -1611,11 +1793,15 @@ static int run_tracer(DwarfParser &dwarfparser, const TraceTarget &target) {
     bool enabled = e.exact ? (probe_mode == e.mode) : (probe_mode & e.mode);
     if (!enabled) continue;
     if (attach_probes(skel.get(), dwarfparser, target.osd_path, target.pids,
-                      e.func, /*is_retprobe=*/false, e.v) == 0)
+                      e.func, e.ret, e.v) == 0)
       ++attached;
   }
   if (attached == 0) {
     cerr << "Error: no probes could be attached to " << target.osd_path << endl;
+    if (probe_mode & ALLOC_PROBE)
+      cerr << "Hint: -A needs DWARF data that includes the allocator probes; "
+              "DWARF JSONs / embedded data generated before allocator tracing "
+              "was added lack them (regenerate with -j)" << endl;
     return 1;
   }
 

--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -85,56 +85,57 @@ func_id_t func_id = {
     {"Allocator::get_name", 390}
 };
 
-std::map<std::string, int> func_progid = {
-    {"OSD::enqueue_op", 0},
-    {"OSD::dequeue_op", 1},
-    {"PrimaryLogPG::execute_ctx", 2},
-    {"ReplicatedBackend::submit_transaction", 3},
-    {"BlueStore::queue_transactions", 4},
-    {"BlueStore::_do_write", 5},
-    {"BlueStore::_wctx_finish", 6},
-    {"BlueStore::_txc_state_proc", 7},
-    {"PrimaryLogPG::log_op_stats", 8},
-    {"PrimaryLogPG::log_op_stats_v2", 9},
-    {"ReplicatedBackend::generate_subop", 10},
-    {"ReplicatedBackend::do_repop_reply", 11},
-    {"OpRequest::mark_flag_point_string", 12},
-    {"BlueStore::log_latency", 13},
-    {"log_subop_stats", 14},
-    {"ECBackend::submit_transaction", 15},
-    {"BlueStore::_txc_calc_cost", 16},
-    {"ReplicatedBackend::repop_commit", 17},
-    {"OpRequest::mark_flag_point", 18},
-    {"BlueStore::log_latency_fn", 19},
-    {"BlueStore::_txc_add_transaction", 20},
-    // Allocator tracing (-A). Several names may map to the same program: they are
+// Ceph function -> BPF program (by name, resolved through
+// bpf_object__find_program_by_name at attach time, so this table does not
+// depend on the order programs appear in the skeleton).  A "<func>_v2"
+// entry is the variant attach_probe() selects for v=2.
+std::map<std::string, const char *> func_prog = {
+    {"OSD::enqueue_op", "uprobe_enqueue_op"},
+    {"OSD::dequeue_op", "uprobe_dequeue_op"},
+    {"PrimaryLogPG::execute_ctx", "uprobe_execute_ctx"},
+    {"ReplicatedBackend::submit_transaction", "uprobe_submit_transaction"},
+    {"BlueStore::queue_transactions", "uprobe_queue_transactions"},
+    {"BlueStore::_do_write", "uprobe_do_write"},
+    {"BlueStore::_wctx_finish", "uprobe_wctx_finish"},
+    {"BlueStore::_txc_state_proc", "uprobe_txc_state_proc"},
+    {"PrimaryLogPG::log_op_stats", "uprobe_log_op_stats"},
+    {"PrimaryLogPG::log_op_stats_v2", "uprobe_log_op_stats_v2"},
+    {"ReplicatedBackend::generate_subop", "uprobe_generate_subop"},
+    {"ReplicatedBackend::do_repop_reply", "uprobe_do_repop_reply"},
+    {"OpRequest::mark_flag_point_string", "uprobe_mark_flag_point_string"},
+    {"BlueStore::log_latency", "uprobe_log_latency"},
+    {"log_subop_stats", "uprobe_log_subop_stats"},
+    {"ECBackend::submit_transaction", "uprobe_ec_submit_transaction"},
+    {"BlueStore::_txc_calc_cost", "uprobe_txc_calc_cost"},
+    {"ReplicatedBackend::repop_commit", "uprobe_repop_commit"},
+    {"OpRequest::mark_flag_point", "uprobe_mark_flag_point"},
+    {"BlueStore::log_latency_fn", "uprobe_log_latency_fn"},
+    {"BlueStore::_txc_add_transaction", "uprobe_txc_add_transaction"},
+    // Allocator tracing (-A). Several names map to the same program: they are
     // the same method under different class names across Ceph releases, and
-    // at most one exists in a given binary. All returns share one uretprobe
-    // (the *_v2 entries; attach_probe(..., v=2) looks up "<func>_v2").
-    // NOTE: ids are skeleton program indices: all SEC("uprobe") programs in
-    // source order, then SEC("uretprobe").
-    {"StupidAllocator::allocate", 21},
-    {"BitmapAllocator::allocate", 22},
-    {"AvlAllocator::allocate", 23},
-    {"BtreeAllocator::allocate", 24},
-    {"Btree2Allocator::allocate", 25},
-    {"HybridAllocatorBase<AvlAllocator>::allocate", 26},
-    {"HybridAllocator<AvlAllocator>::allocate", 26},
-    {"HybridAllocator::allocate", 26},
-    {"HybridAllocatorBase<Btree2Allocator>::allocate", 27},
-    {"HybridAllocator<Btree2Allocator>::allocate", 27},
-    {"HybridBtree2Allocator::allocate", 28},
-    {"StupidAllocator::allocate_v2", 29},
-    {"BitmapAllocator::allocate_v2", 29},
-    {"AvlAllocator::allocate_v2", 29},
-    {"BtreeAllocator::allocate_v2", 29},
-    {"Btree2Allocator::allocate_v2", 29},
-    {"HybridAllocatorBase<AvlAllocator>::allocate_v2", 29},
-    {"HybridAllocator<AvlAllocator>::allocate_v2", 29},
-    {"HybridAllocator::allocate_v2", 29},
-    {"HybridAllocatorBase<Btree2Allocator>::allocate_v2", 29},
-    {"HybridAllocator<Btree2Allocator>::allocate_v2", 29},
-    {"HybridBtree2Allocator::allocate_v2", 29}
+    // at most one exists in a given binary. All returns share one uretprobe.
+    {"StupidAllocator::allocate", "uprobe_alloc_stupid"},
+    {"BitmapAllocator::allocate", "uprobe_alloc_bitmap"},
+    {"AvlAllocator::allocate", "uprobe_alloc_avl"},
+    {"BtreeAllocator::allocate", "uprobe_alloc_btree"},
+    {"Btree2Allocator::allocate", "uprobe_alloc_btree2"},
+    {"HybridAllocatorBase<AvlAllocator>::allocate", "uprobe_alloc_hybrid_avl"},
+    {"HybridAllocator<AvlAllocator>::allocate", "uprobe_alloc_hybrid_avl"},
+    {"HybridAllocator::allocate", "uprobe_alloc_hybrid_avl"},
+    {"HybridAllocatorBase<Btree2Allocator>::allocate", "uprobe_alloc_hybrid_btree2"},
+    {"HybridAllocator<Btree2Allocator>::allocate", "uprobe_alloc_hybrid_btree2"},
+    {"HybridBtree2Allocator::allocate", "uprobe_alloc_hybrid_btree2_outer"},
+    {"StupidAllocator::allocate_v2", "uretprobe_allocator"},
+    {"BitmapAllocator::allocate_v2", "uretprobe_allocator"},
+    {"AvlAllocator::allocate_v2", "uretprobe_allocator"},
+    {"BtreeAllocator::allocate_v2", "uretprobe_allocator"},
+    {"Btree2Allocator::allocate_v2", "uretprobe_allocator"},
+    {"HybridAllocatorBase<AvlAllocator>::allocate_v2", "uretprobe_allocator"},
+    {"HybridAllocator<AvlAllocator>::allocate_v2", "uretprobe_allocator"},
+    {"HybridAllocator::allocate_v2", "uretprobe_allocator"},
+    {"HybridAllocatorBase<Btree2Allocator>::allocate_v2", "uretprobe_allocator"},
+    {"HybridAllocator<Btree2Allocator>::allocate_v2", "uretprobe_allocator"},
+    {"HybridBtree2Allocator::allocate_v2", "uretprobe_allocator"}
 };
 
 DwarfParser::probes_t osd_probes = {
@@ -1281,11 +1282,22 @@ int attach_probe(struct osdtrace_bpf *skel,
   }
   if (v > 0)
       funcname = funcname + "_v" + std::to_string(v);
-  int pid = func_progid[funcname];
+  auto pit = func_prog.find(funcname);
+  if (pit == func_prog.end()) {
+    cerr << "Error: no BPF program mapped for " << funcname << endl;
+    return -1;
+  }
+  struct bpf_program *prog =
+      bpf_object__find_program_by_name(skel->obj, pit->second);
+  if (prog == NULL) {
+    cerr << "Error: BPF program " << pit->second << " (for " << funcname
+         << ") not found in the skeleton" << endl;
+    return -1;
+  }
 
   std::string attach_path = (process_id == -1) ? path : "/proc/" + std::to_string(process_id) + "/root/" + path;
   struct bpf_link *ulink = bpf_program__attach_uprobe(
-      *skel->skeleton->progs[pid].prog,
+      prog,
       is_retprobe,
       process_id,
       attach_path.c_str(), func_addr);
@@ -1705,7 +1717,7 @@ static const AttachEntry ATTACH_LIST[] = {
     {"BlueStore::log_latency", BLUESTORE_PROBE, false, 0, false},
     {"BlueStore::log_latency_fn", BLUESTORE_PROBE, false, 0, false},
     // Allocator tracing (-A): one entry uprobe + the shared uretprobe (v=2,
-    // "<func>_v2" in func_progid) per concrete allocate() override.  A given
+    // "<func>_v2" in func_prog) per concrete allocate() override.  A given
     // binary only defines some of these; the rest skip with a warning.
     {"StupidAllocator::allocate", ALLOC_PROBE, false, 0, false},
     {"StupidAllocator::allocate", ALLOC_PROBE, false, 2, true},
@@ -1747,6 +1759,17 @@ static int run_tracer(DwarfParser &dwarfparser, const TraceTarget &target) {
   if (!skel) {
     cerr << "Failed to open BPF skeleton" << endl;
     return 1;
+  }
+
+  // Every BPF program named in func_prog must exist in the object; catch a
+  // renamed/mistyped program up front rather than at attach time for whatever
+  // subset the current probe_mode happens to use.
+  for (const auto &fp : func_prog) {
+    if (bpf_object__find_program_by_name(skel->obj, fp.second) == NULL) {
+      cerr << "Error: func_prog maps " << fp.first << " to unknown BPF program "
+           << fp.second << endl;
+      return 1;
+    }
   }
 
   // sizeof(OSDOp) is the stride used to walk the decoded op vector, so a wrong


### PR DESCRIPTION
## Summary

Adds `osdtrace -A`, an allocator tracing mode: one line per call into the BlueStore free-space allocator (`Allocator::allocate()` overrides — stupid/bitmap/avl/btree/btree2 and the hybrid wrappers, across the class-name variants used by different releases). BlueFS allocators go through the same method, so RocksDB/BlueFS file growth shows up next to object-data allocations.

```
osd 2 alloc block      want 0x1000 unit 0x1000 -> 0x1000 exts 1 [0xe1b1000~0x1000] lat 12us comm tp_osd_tp
osd 0 alloc bluefs-wal want 0x1200000 unit 0x100000 hint 0x16300000 -> 0x1200000 exts 1 [0x16300000~0x1200000] lat 9us comm bstore_kv_sync
```

Per call: allocator instance name, want / unit / hint, bytes actually allocated (`SHORT`, `ENOSPC` flagged), returned physical extents (first 6 — a split request is a direct fragmentation signal), latency (lock wait + free-space search) and calling thread. `-l <ms>` filters on latency; `-A -b` composes with the BlueStore latency probes.

Rebased onto current `main` (over #156/#163/#165/#175/#177): the probes now go through `ATTACH_LIST` (with a `ret` flag for the shared uretprobe) instead of the pre-refactor ad-hoc attach block.

## Commits

1. **dwarf_parser: resolve inherited members; skip unresolvable probes** — `find_class_member()` resolves declaration-only base-class DIEs through the type cache and adds the base's offset within the derived class to the member offset (an inherited member previously came back with a base-relative offset). `handle_function()` warns and drops the probes on that function instead of `assert()`ing when a varpath doesn't resolve on some build.
2. **osdtrace: add allocator tracing mode (-A)** — entry uprobes stash the request per {thread, nesting depth}; one shared uretprobe computes latency and walks the returned `PExtentVector` with `_M_start`/`_M_finish` offsets from DWARF (the mempool allocator puts two pointers ahead of them, so they sit at 16/24, not 0/8). Nested calls (hybrid → its internal bitmap) are matched by depth and tagged `(nested dN)`. The allocator name is read via a never-attached varpath on `{AllocatorBase,Allocator}::get_name` (its `SocketHook` is only fully defined in that CU) reused at every `allocate()` entry.
3. **osdtrace: look up BPF programs by name, not skeleton index** — `func_progid` mapped functions to a position in the skeleton's `progs` array; adding a program anywhere but last silently shifted every later index (rebasing the allocator probes onto `_txc_add_transaction` did exactly that — every allocator id was off by one). Now a function → BPF program *name* map resolved with `bpf_object__find_program_by_name()`, plus a check at skeleton open that every mapped name exists.
4. **gitignore: ignore generated `src/ceph_btf_local.h`** — Makefile-generated, removed by `make clean`, like `embedded_dwarf_data.h`.
5. **dwarf: regenerate Ubuntu 20.2.0 osdtrace references (amd64, amd64v3)** — exported with `osdtrace -j` on hosts whose ceph-osd build-ids match the two references (the amd64v3 file is the one the regenerate workflow deliberately skips).
6. **dwarf: normalize workflow-written references to the tool's native format** — 39 files the old workflow had re-serialized with `indent=4`, rewritten as the tools emit them (2-space); whitespace only, every file parses to the identical document. One-time consequence of #180's "commit tool output verbatim".
7. **dwarf: regenerate osdtrace references with the allocator probes** — output of a `Regenerate all DWARF references` dispatch on this branch (run 32146786374 — first full end-to-end run of the #180 workflow: 52/52 jobs; 3 `~cloud0` jobs needed a rerun after a 4 h apt-mirror hang). All 43 osdtrace references now carry the allocate()/get_name entries present in each binary (5 on Octopus, 6 on Quincy/Reef, 9 on Squid+); the 20.2.0 amd64 file it produced is byte-identical to the one exported on the live host in commit 5. Radostrace references are unchanged and no existing value moved anywhere.

## Compatibility

- Default/`-s`/`-b` modes are unchanged; existing DWARF JSONs and embedded data keep working for them.
- Every embedded reference now includes the allocator probes, so `-A` works out of the box; with an older user-supplied JSON (`-i`) it fails to attach with a hint (`-A needs DWARF data that includes the allocator probes … regenerate with -j`).

## Verification (Ceph 20.2.0, Ubuntu 26.04 VM, live osd.2 with debug symbols)

- `osdtrace -j` on the live OSD exports all 9 allocator functions present in that binary plus the `get_name` name donor; `_M_start`/`_M_finish` resolve at 16/24 (inherited-member path).
- `osdtrace -A -i <that json>` under `rados bench 4K writes`: 16 probes attached (8 entry + 8 return), **10,747 alloc events for 10,739 writes**, sequential 4K extents from `block`, latency p50 19 µs / p99 358 µs / max 3.7 ms; BlueFS calls appear from `bstore_kv_sync`.
- `-A -b -l 1`: alloc lines all ≥ 1 ms (20) alongside 40 k bluestore lines; `-A` against the embedded reference prints the hint and exits.
- Default mode regression: embedded DWARF path, 15 probes attached, 7,200 op rows, no warnings.
- Final binary (regenerated references embedded): `osdtrace -A` **without `-i`** on the same OSD — embedded match, 16 probes attached, 11,729 alloc events for 11,721 writes.
- `make -j all` warning-free, `make test`, `tox -e test` pass; clang-tidy runs in CI.
