### PR TITLE
perf(osdtrace): remove debug bpf_printk calls from uprobe_log_op_stats_v2

### DIFF
--- a/src/osdtrace.bpf.c
+++ b/src/osdtrace.bpf.c
@@ -521,7 +521,6 @@ int uprobe_log_op_stats(struct pt_regs *ctx) {
 
 SEC("uprobe")
 int uprobe_log_op_stats_v2(struct pt_regs *ctx) {
-  bpf_printk("Entered into uprobe_log_op_stats v2\n");
   int varid = 90;
   struct op_v *op = bpf_ringbuf_reserve(&rb, sizeof(struct op_v), 0);
   if (op == NULL)
@@ -551,8 +550,6 @@ int uprobe_log_op_stats_v2(struct pt_regs *ctx) {
     return 0;
   }
 
-  bpf_printk(" log_op_stats_v2 client %lld tid %lld recv_stamp %lld ", op->owner, op->tid, op->recv_stamp);
-  bpf_printk(" inb %lld outb %lld op type %lld\n",op->wb, op->rb, op->op_type);
   bpf_ringbuf_submit(op, 0);
   return 0;
 }


### PR DESCRIPTION
## Summary

Removes remaining diagnostic `bpf_printk()` calls from `uprobe_log_op_stats_v2` in `src/osdtrace.bpf.c`.

### Performance Impact
- `bpf_printk()` writes formatted strings to `/sys/kernel/debug/tracing/trace_pipe`, which acquires an internal kernel tracing lock and adds ~350–450 ns of latency per probe invocation.
- Removing these print statements eliminates lock contention and reduces the BPF handler execution cost in single-mode (`-s`).

### Verification
- Tested locally against `ceph-osd` under high-concurrency `rados bench` workload.
- Verified build and ring buffer event delivery.