### PR TITLE
perf(osdtrace): optimize single-mode DWARF field retrieval with base address reuse and rodata offset caching

### DIFF
--- a/src/bpf_ceph_types.h
+++ b/src/bpf_ceph_types.h
@@ -240,6 +240,18 @@ struct VarField_Kernel {
 };
 #endif
 
+struct single_op_offsets {
+  __u32 req_reg;
+  __u32 req_msg_off;
+  __u32 req_reqid_off;
+  __u32 msg_stamp_sec_off;
+  __u32 msg_stamp_nsec_off;
+  __u32 reqid_owner_off;
+  __u32 reqid_tid_off;
+  __u32 msg_op_type_off;
+  __u32 valid;
+};
+
 
 /*
  * osd ops

--- a/src/dwarf_parser.cc
+++ b/src/dwarf_parser.cc
@@ -18,6 +18,7 @@
 #include <queue>
 #include <fstream>
 
+#include "bpf_ceph_types.h"
 #include "osdtrace.skel.h"
 extern "C" {
 #include <dwarf.h>

--- a/src/osdtrace.bpf.c
+++ b/src/osdtrace.bpf.c
@@ -548,9 +548,23 @@ int uprobe_log_op_stats_v2(struct pt_regs *ctx) {
 
   __u64 owner = 0;
   __u64 tid = 0;
-  read_hprobe_varfield(ctx, base_varid, &owner, sizeof(owner));
-  if (read_hprobe_varfield(ctx, base_varid + 1, &tid, sizeof(tid)) != 0) {
-    return 0;
+  struct VarField *vf_owner = bpf_map_lookup_elem(&hprobes, &base_varid);
+  if (vf_owner != NULL) {
+    __u64 v = fetch_register(ctx, vf_owner->varloc.reg);
+    __u64 owner_addr = fetch_var_member_addr(v, vf_owner);
+    if (owner_addr != 0) {
+      bpf_probe_read_user(&owner, sizeof(owner), (void *)owner_addr);
+      // tid is at offset +8 from owner in struct osd_reqid_t { entity_name_t name; uint64_t tid; }
+      bpf_probe_read_user(&tid, sizeof(tid), (void *)(owner_addr + sizeof(owner)));
+    }
+  }
+
+  if (tid == 0 && owner == 0) {
+    // Fallback in case of unexpected struct layout
+    int tid_varid = base_varid + 1;
+    if (read_hprobe_varfield(ctx, tid_varid, &tid, sizeof(tid)) != 0) {
+      return 0;
+    }
   }
 
   __u16 op_type = 0;

--- a/src/osdtrace.bpf.c
+++ b/src/osdtrace.bpf.c
@@ -87,6 +87,8 @@ const volatile __u32 CEPH_OSD_OP_CLS_METHOD_OFFSET = 0;
 const volatile __u64 LATENCY_THRESHOLD_NS = 0;
 const volatile __u64 BOOTSTAMP_NS = 0;
 
+const volatile struct single_op_offsets SINGLE_OFFSETS = {};
+
 static __always_inline void capture_decoded_osd_ops(
     struct op_v *vp, __u64 ops_start, __u64 ops_finish)
 {
@@ -525,9 +527,32 @@ SEC("uprobe")
 int uprobe_log_op_stats_v2(struct pt_regs *ctx) {
   int base_varid = 90;
   __u64 recv_stamp = 0;
-  if (read_hprobe_utime(ctx, base_varid + 4, &recv_stamp) != 0 || recv_stamp == 0) {
-    return 0;
+  __u64 req_addr = 0;
+  __u64 msg_addr = 0;
+
+  if (SINGLE_OFFSETS.valid) {
+    req_addr = fetch_register(ctx, SINGLE_OFFSETS.req_reg);
+    if (req_addr == 0)
+      return 0;
+
+    bpf_probe_read_user(&msg_addr, sizeof(msg_addr),
+                        (void *)(req_addr + SINGLE_OFFSETS.req_msg_off));
+    if (msg_addr == 0)
+      return 0;
+
+    struct utime_t stamp;
+    bpf_probe_read_user(&stamp.sec, sizeof(stamp.sec),
+                        (void *)(msg_addr + SINGLE_OFFSETS.msg_stamp_sec_off));
+    bpf_probe_read_user(&stamp.nsec, sizeof(stamp.nsec),
+                        (void *)(msg_addr + SINGLE_OFFSETS.msg_stamp_nsec_off));
+    recv_stamp = to_nsec(&stamp);
+  } else {
+    if (read_hprobe_utime(ctx, base_varid + 4, &recv_stamp) != 0)
+      return 0;
   }
+
+  if (recv_stamp == 0)
+    return 0;
 
   __u64 reply_stamp = bpf_ktime_get_boot_ns();
 
@@ -548,28 +573,47 @@ int uprobe_log_op_stats_v2(struct pt_regs *ctx) {
 
   __u64 owner = 0;
   __u64 tid = 0;
-  struct VarField *vf_owner = bpf_map_lookup_elem(&hprobes, &base_varid);
-  if (vf_owner != NULL) {
-    __u64 v = fetch_register(ctx, vf_owner->varloc.reg);
-    __u64 owner_addr = fetch_var_member_addr(v, vf_owner);
-    if (owner_addr != 0) {
-      bpf_probe_read_user(&owner, sizeof(owner), (void *)owner_addr);
-      // tid is at offset +8 from owner in struct osd_reqid_t { entity_name_t name; uint64_t tid; }
-      bpf_probe_read_user(&tid, sizeof(tid), (void *)(owner_addr + sizeof(owner)));
-    }
-  }
+  __u16 op_type = 0;
 
-  if (tid == 0 && owner == 0) {
-    // Fallback in case of unexpected struct layout
-    int tid_varid = base_varid + 1;
-    if (read_hprobe_varfield(ctx, tid_varid, &tid, sizeof(tid)) != 0) {
+  if (SINGLE_OFFSETS.valid) {
+    __u64 reqid_addr = 0;
+    bpf_probe_read_user(&reqid_addr, sizeof(reqid_addr),
+                        (void *)(req_addr + SINGLE_OFFSETS.req_reqid_off));
+    if (reqid_addr != 0) {
+      bpf_probe_read_user(&owner, sizeof(owner),
+                          (void *)(reqid_addr + SINGLE_OFFSETS.reqid_owner_off));
+      bpf_probe_read_user(&tid, sizeof(tid),
+                          (void *)(reqid_addr + SINGLE_OFFSETS.reqid_tid_off));
+    }
+
+    __u64 op_ptr = 0;
+    bpf_probe_read_user(&op_ptr, sizeof(op_ptr),
+                        (void *)(msg_addr + 24)); // &MOSDOp::ops vector pointer
+    if (op_ptr != 0) {
+      bpf_probe_read_user(&op_type, sizeof(op_type),
+                          (void *)(op_ptr + SINGLE_OFFSETS.msg_op_type_off));
+    }
+  } else {
+    struct VarField *vf_owner = bpf_map_lookup_elem(&hprobes, &base_varid);
+    if (vf_owner != NULL) {
+      __u64 v = fetch_register(ctx, vf_owner->varloc.reg);
+      __u64 owner_addr = fetch_var_member_addr(v, vf_owner);
+      if (owner_addr != 0) {
+        bpf_probe_read_user(&owner, sizeof(owner), (void *)owner_addr);
+        bpf_probe_read_user(&tid, sizeof(tid), (void *)(owner_addr + sizeof(owner)));
+      }
+    }
+
+    if (tid == 0 && owner == 0) {
+      int tid_varid = base_varid + 1;
+      if (read_hprobe_varfield(ctx, tid_varid, &tid, sizeof(tid)) != 0) {
+        return 0;
+      }
+    }
+
+    if (read_hprobe_varfield(ctx, base_varid + 5, &op_type, sizeof(op_type)) != 0) {
       return 0;
     }
-  }
-
-  __u16 op_type = 0;
-  if (read_hprobe_varfield(ctx, base_varid + 5, &op_type, sizeof(op_type)) != 0) {
-    return 0;
   }
 
   __u32 pid = get_pid();

--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -20,6 +20,7 @@
 #include <dirent.h>
 #include <ctype.h>
 
+#include "bpf_ceph_types.h"
 #include "osdtrace.skel.h"
 
 extern "C" {
@@ -27,7 +28,6 @@ extern "C" {
 #include <unistd.h>
 }
 
-#include "bpf_ceph_types.h"
 #include "dwarf_parser.h"
 #include "version_utils.h"
 #include "utils.h"
@@ -1602,6 +1602,30 @@ static int run_tracer(DwarfParser &dwarfparser, const TraceTarget &target) {
     skel->rodata->LATENCY_THRESHOLD_NS = threshold * 1000000ull; // convert ms to ns
     clog << "Using in-kernel latency threshold: " << threshold << " ms ("
          << skel->rodata->LATENCY_THRESHOLD_NS << " ns)" << endl;
+  }
+
+  // Pre-calculate and cache single-mode member offsets in BPF rodata to bypass hprobes hash map
+  std::string target_basename = get_basename(target.osd_path);
+  auto &func2vf = dwarfparser.mod_func2vf[target_basename];
+  auto it_log_op = func2vf.find("PrimaryLogPG::log_op_stats");
+  if (it_log_op != func2vf.end() && it_log_op->second.size() >= 6) {
+    const auto &vfs = it_log_op->second;
+    // vfs[0]: owner ({op, px, reqid, name, _num}) -> reg, fields: [0, 392, 0, 8]
+    // vfs[1]: tid ({op, px, reqid, tid}) -> reg, fields: [0, 392, 16]
+    // vfs[4]: recv_stamp ({op, px, request, recv_stamp}) -> reg, fields: [0, 384, 200]
+    // vfs[5]: op_type ({op, px, request, ops, _M_impl, _M_start, op}) -> reg, fields: [0, 384, 24, 16]
+    if (vfs[4].fields.size() >= 3 && vfs[0].fields.size() >= 4 && vfs[1].fields.size() >= 3 && vfs[5].fields.size() >= 4) {
+      skel->rodata->SINGLE_OFFSETS.req_reg = vfs[4].varloc.reg;
+      skel->rodata->SINGLE_OFFSETS.req_msg_off = vfs[4].fields[1].offset;
+      skel->rodata->SINGLE_OFFSETS.req_reqid_off = vfs[0].fields[1].offset;
+      skel->rodata->SINGLE_OFFSETS.msg_stamp_sec_off = vfs[4].fields[2].offset;
+      skel->rodata->SINGLE_OFFSETS.msg_stamp_nsec_off = vfs[4].fields[2].offset + 4;
+      skel->rodata->SINGLE_OFFSETS.reqid_owner_off = vfs[0].fields[3].offset;
+      skel->rodata->SINGLE_OFFSETS.reqid_tid_off = vfs[1].fields[2].offset;
+      skel->rodata->SINGLE_OFFSETS.msg_op_type_off = vfs[5].fields[3].offset;
+      skel->rodata->SINGLE_OFFSETS.valid = 1;
+      clog << "Cached single-mode DWARF member offsets in BPF rodata (direct access enabled)" << endl;
+    }
   }
 
   int load_ret = osdtrace_bpf__load(skel.get());


### PR DESCRIPTION
## Summary

Optimizes `uprobe_log_op_stats_v2` variable resolution in single mode (`osdtrace -s`) across two separate improvements:

### Commit 1: Reuse `reqid` Struct Address
- Both `owner` (client id) and `tid` reside within the same `osd_reqid_t` struct in `OpRequest`.
- Reuses the base address of `reqid` once resolved instead of performing redundant map lookups and pointer traversals.

### Commit 2: Cache DWARF Member Offsets in BPF `.rodata`
- Pre-calculates the field offset chain for `PrimaryLogPG::log_op_stats` once at startup during userspace DWARF loading and stores them in `skel->rodata->SINGLE_OFFSETS`.
- Directly indexes `OpRequest` / `MOSDOp` fields inside BPF, completely bypassing the dynamic `&hprobes` BPF hash map lookups.
- Retains automatic fallback to `&hprobes` if static offsets are unavailable.