### PR TITLE
osdtrace: trace replica subop writes in single mode

### DIFF
--- a/doc/man/8/osdtrace.rst
+++ b/doc/man/8/osdtrace.rst
@@ -33,7 +33,10 @@ OPTIONS
 
 -s
 
-   Single OP probe mode: log PrimaryLogPG::log_op_stats only (lower overhead).
+   Single OP probe mode (lower overhead): one lightweight probe per event
+   prints a per-op line for client ops (PrimaryLogPG::log_op_stats) and for
+   replica subop writes (ReplicatedBackend::repop_commit), plus exit-time
+   latency histograms for the client ops.
    The default mode is full tracing with the complete latency breakdown.
 
 -b

--- a/src/osdtrace.bpf.c
+++ b/src/osdtrace.bpf.c
@@ -1048,3 +1048,82 @@ int uprobe_txc_add_transaction(struct pt_regs *ctx)
 
   return 0;
 }
+
+// Single-mode replica subop (MSG_OSD_REPOP) tracing.  Standalone like
+// uprobe_log_op_stats_v2: no map state, latency computed in-kernel from the
+// message's recv_stamp, subject to the same LATENCY_THRESHOLD_NS gate.
+// repop_commit runs on the replica right before the MOSDRepOpReply is sent
+// and only ever handles MSG_OSD_REPOP, so no message-type filter is needed.
+//
+// Varid layout for ReplicatedBackend::repop_commit (base 170), declaration
+// order of its varpath list in osdtrace.cc:
+//   +0 owner  +1 tid  +2 request data._len  +3 poid-name len  +4 poid-name ptr
+//   +5 recv_stamp  +6 pg m_pool  +7 pg m_seed
+// Varids 5..7 may be absent when tracing with DWARF JSON exported before they
+// were added; +5 aborts the event (no latency without it), +6/+7 degrade to
+// zeroed fields.
+//
+// This program must stay the last SEC("uprobe") in the file: func_progid
+// indices in osdtrace.cc are positional in skeleton declaration order.
+SEC("uprobe")
+int uprobe_repop_commit_v2(struct pt_regs *ctx) {
+  int base_varid = 170;
+  __u64 recv_stamp = 0;
+  if (read_hprobe_utime(ctx, base_varid + 5, &recv_stamp) != 0 || recv_stamp == 0)
+    return 0;
+
+  __u64 reply_stamp = bpf_ktime_get_boot_ns();
+
+  if (LATENCY_THRESHOLD_NS > 0) {
+    __u64 op_lat_ns = 0;
+    if (recv_stamp > BOOTSTAMP_NS) {
+      __u64 recv_boot_ns = recv_stamp - BOOTSTAMP_NS;
+      if (reply_stamp > recv_boot_ns)
+        op_lat_ns = reply_stamp - recv_boot_ns;
+    }
+    if (op_lat_ns < LATENCY_THRESHOLD_NS)
+      return 0;
+  }
+
+  __u64 owner = 0;
+  __u64 tid = 0;
+  read_hprobe_varfield(ctx, base_varid, &owner, sizeof(owner));
+  if (read_hprobe_varfield(ctx, base_varid + 1, &tid, sizeof(tid)) != 0)
+    return 0;
+
+  // bufferlist::_len is a 32-bit unsigned; read exactly 4 bytes.
+  __u32 len = 0;
+  if (read_hprobe_varfield(ctx, base_varid + 2, &len, sizeof(len)) != 0)
+    return 0;
+
+  struct op_v *op = bpf_ringbuf_reserve(&rb, sizeof(struct op_v), 0);
+  if (op == NULL)
+    return 0;
+  *op = zero_op_v;
+
+  op->owner = owner;
+  op->tid = tid;
+  op->pid = get_pid();
+  op->reply_stamp = reply_stamp;
+  op->recv_stamp = recv_stamp;
+  op->op_type = MSG_OSD_REPOP;
+  op->wb = len;
+
+  read_hprobe_varfield_opt(ctx, base_varid + 6, &op->m_pool, sizeof(op->m_pool));
+  read_hprobe_varfield_opt(ctx, base_varid + 7, &op->m_seed, sizeof(op->m_seed));
+
+  __u64 name_len = 0;
+  __u64 str_addr = 0;
+  if (read_hprobe_varfield_opt(ctx, base_varid + 3, &name_len, sizeof(name_len)) == 0 &&
+      read_hprobe_varfield_opt(ctx, base_varid + 4, &str_addr, sizeof(str_addr)) == 0 &&
+      name_len > 0 && str_addr != 0) {
+    __u32 nlen = name_len;
+    if (nlen > OBJECT_NAME_LEN - 1)
+      nlen = OBJECT_NAME_LEN - 1;
+    bpf_probe_read_user(op->object_name, nlen & (OBJECT_NAME_LEN - 1),
+                        (void *)str_addr);
+  }
+
+  bpf_ringbuf_submit(op, 0);
+  return 0;
+}

--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -85,7 +85,8 @@ std::map<std::string, int> func_progid = {
     {"ReplicatedBackend::repop_commit", 17},
     {"OpRequest::mark_flag_point", 18},
     {"BlueStore::log_latency_fn", 19},
-    {"BlueStore::_txc_add_transaction", 20}
+    {"BlueStore::_txc_add_transaction", 20},
+    {"ReplicatedBackend::repop_commit_v2", 21}
 };
 
 DwarfParser::probes_t osd_probes = {
@@ -201,6 +202,10 @@ DwarfParser::probes_t osd_probes = {
     {"ECBackend::submit_transaction",
      {{"reqid", "name", "_num"}, {"reqid", "tid"}}},
 
+    // List order is ABI: varids 170..177 in declaration order, hardcoded in
+    // uprobe_repop_commit{,_v2}.  The trailing three entries (recv_stamp and
+    // the pg id via cast:MOSDRepOp) exist for the single-mode v2 program;
+    // full mode's v1 reads only the first five.
     {"ReplicatedBackend::repop_commit",
      {{"rm", "_M_ptr", "op", "px", "reqid", "name", "_num"},
       {"rm", "_M_ptr", "op", "px", "reqid", "tid"},
@@ -208,7 +213,12 @@ DwarfParser::probes_t osd_probes = {
       {"rm", "_M_ptr", "op", "px", "request", "cast:MOSDRepOp",
        "poid", "oid", "name", "_M_string_length"},
       {"rm", "_M_ptr", "op", "px", "request", "cast:MOSDRepOp",
-       "poid", "oid", "name", "_M_dataplus", "_M_p"}}},
+       "poid", "oid", "name", "_M_dataplus", "_M_p"},
+      {"rm", "_M_ptr", "op", "px", "request", "recv_stamp"},
+      {"rm", "_M_ptr", "op", "px", "request", "cast:MOSDRepOp",
+       "pgid", "pgid", "m_pool"},
+      {"rm", "_M_ptr", "op", "px", "request", "cast:MOSDRepOp",
+       "pgid", "pgid", "m_seed"}}},
 
     {"OpRequest::mark_flag_point",
      {{"flag"},
@@ -418,6 +428,11 @@ void handle_single(struct op_v *val, int osd_id) {
     return ;
   }
   print_single_op(val, osd_id);
+  // The histograms measure client-visible op latency; replica subops would
+  // both skew them and count each client write once per replica, so they get
+  // per-op lines only.
+  if (val->op_type == MSG_OSD_REPOP)
+    return;
   __u64 op_lat = (val->reply_stamp - (val->recv_stamp - bootstamp));
   __u64 wb = val->wb;
   __u64 rb = val->rb;
@@ -616,22 +631,39 @@ static bool detail_ops_indicate_write(const osd_op_t &op) {
   return false;
 }
 
-// Single-mode per-op line.  Only fields the one log_op_stats probe supplies;
-// the full-mode stage latencies (queue/osd/bluestore/peers) are omitted
-// rather than printed as zeros.
+// Single-mode per-op line.  Only fields the lightweight single-mode probes
+// supply; the full-mode stage latencies (queue/osd/bluestore/peers) are
+// omitted rather than printed as zeros.
 void print_single_op(struct op_v *val, int osd_id) {
   osd_op_t op = osd_op_t();
   fill_op_identity(op, val);
-  // Fall back to the payload heuristic when detail ops are unavailable
-  // (DWARF JSON exported before the pg/object/ops varpaths existed).
-  op.is_write = op.detail_ops.empty() ? (op.wb > 0)
-                                      : detail_ops_indicate_write(op);
   op.op_lat = (val->reply_stamp - (val->recv_stamp - bootstamp)) / 1000;
 
   std::stringstream ss;
   ss << std::hex << op.pg.m_seed;
   std::string pgid(ss.str());
   std::string object_name = format_object_name(op.object_name);
+
+  // Replica subop write (from uprobe_repop_commit_v2).  A repop carries a
+  // serialized ObjectStore transaction, not a decoded OSDOp vector, so there
+  // is no osd_ops field; decoding it would need the full-mode
+  // _txc_add_transaction probe.
+  if (op.type == MSG_OSD_REPOP) {
+    printf("osd %d pg %lld.%s subop_w "
+           "size %d client %lld tid %lld "
+           "object %s "
+           "subop_lat %lld\n",
+           osd_id, op.pg.m_pool, pgid.c_str(),
+           op.wb, op.client_id, op.req_id,
+           object_name.c_str(),
+           op.op_lat);
+    return;
+  }
+
+  // Fall back to the payload heuristic when detail ops are unavailable
+  // (DWARF JSON exported before the pg/object/ops varpaths existed).
+  op.is_write = op.detail_ops.empty() ? (op.wb > 0)
+                                      : detail_ops_indicate_write(op);
   std::string detail_ops = format_detail_ops(op, false);
 
   printf("osd %d pg %lld.%s %s "
@@ -1122,7 +1154,7 @@ int parse_args(int argc, char **argv) {
       case '?':
       case 'h':
         std::cout << "Usage: " << argv[0] << " [-s] [-l <milliseconds>] [-b] [-j] [-i <filename>] [-t <seconds>] [-a] [-p <pid1,pid2,...>] [--id <osd-id1,osd-id2,...>] [--skip-version-check] [--list] [--list-embedded]\n";
-        std::cout << "  -s                        Set probe mode to Single OP (logs PrimaryLogPG::log_op_stats only)\n";
+        std::cout << "  -s                        Set probe mode to Single OP (low overhead: per-op lines for client ops and replica subop writes)\n";
         std::cout << "  -l <milliseconds>         Set operation latency threshold to capture\n";
         std::cout << "  -b                        Set probe mode to Bluestore\n";
         std::cout << "  -j                        Export DWARF info to JSON file\n";
@@ -1603,6 +1635,7 @@ struct AttachEntry {
 
 static const AttachEntry ATTACH_LIST[] = {
     {"PrimaryLogPG::log_op_stats", OP_SINGLE_PROBE, /*exact=*/true, 2},
+    {"ReplicatedBackend::repop_commit", OP_SINGLE_PROBE, /*exact=*/true, 2},
     {"OSD::dequeue_op", OP_FULL_PROBE, false, 0},
     {"PrimaryLogPG::execute_ctx", OP_FULL_PROBE, false, 0},
     {"ReplicatedBackend::submit_transaction", OP_FULL_PROBE, false, 0},


### PR DESCRIPTION
## Summary

Stacked on #186. Single mode traced only `PrimaryLogPG::log_op_stats`, which fires solely for client ops on the primary — replica write subops (MSG_OSD_REPOP) were invisible, although on a replicated pool they are two thirds of the write work. This adds a second lightweight probe so `-s` prints one line per replica subop write, with the same in-kernel `-l` threshold behavior:

```
osd 0 pg 1.18 subop_w size 4483 client 4126 tid 500 object benchmark_data_..._object499 subop_lat 4886
osd 1 pg 1.18 subop_w size 4483 client 4126 tid 500 object benchmark_data_..._object499 subop_lat 5575
osd 2 pg 1.18 op_w   size 4096 client 4126 tid 500 object benchmark_data_..._object499 osd_ops [set-alloc-hint,write] op_lat 6396
```

### Anchor choice: `repop_commit`, not `log_subop_stats`

Both fire at essentially the same instant — in current Ceph, `log_subop_stats` is a `static` function whose only call site is the last statement of `repop_commit`. But a static single-caller function is inlined at `-O2`: it is **absent from every embedded release DWARF JSON** (checked quincy 17.2.6/el8, reef 18.2.4/el9, squid 19.2.0/el9) and only exists out-of-line on debug builds. `ReplicatedBackend::repop_commit` is invoked through the `C_OSD_RepModifyCommit` callback, so it cannot be inlined away, and is present in all embedded release JSONs. It also only ever handles MSG_OSD_REPOP, so no message-type filter is needed.

### Changes

- **Varpaths**: append `recv_stamp` and pg id (`cast:MOSDRepOp → pgid.pgid.m_pool/m_seed`, layout gdb-verified: `MOSDRepOp::pgid` declared directly at 0x1a0) to the `repop_commit` list — varids 175-177; 170-174 keep their positions so full mode's v1 program is untouched. 8/10 varid budget.
- **BPF**: `uprobe_repop_commit_v2`, a standalone sibling of `uprobe_log_op_stats_v2` — recv_stamp first, in-kernel `-l` gate, then owner/tid/payload/object-name/pg into a ringbuf event; no map state, no printk. Appended as the **last** program in the file since `func_progid` indices are positional in skeleton declaration order.
- **Userspace**: attach-table entry (`OP_SINGLE_PROBE, exact, v=2`), `print_single_op` branch for `subop_w` lines (no `osd_ops` field — a repop carries a serialized ObjectStore transaction, not a decoded OSDOp vector), and **subops are excluded from the size-range histograms** (they measure client-visible latency and would count each client write once per replica).
- **Docs**: `-s` help text and man page updated.

### Verification (3-OSD vstart cluster, size-3 pool, tentacle dev build)

- [x] `subop_w` line count = exactly 2× the client `op_w` count (136,438 vs 68,218 over a bench run)
- [x] for any tid, the primary's `op_w` pairs with two replica `subop_w` lines on the same pg/object, with `subop_lat < op_lat`
- [x] `-l 15`: only above-threshold ops and subops print — including matched slow pairs (client op slow because its replica subop was slow)
- [x] histograms unchanged: entry count equals the 4K writes only (34,109), subops and deletes excluded
- [x] full-mode regression: 15 probes × 3 OSDs attach, identical output — now with live `peers [(0, 7136), (2, 5906)]` on the replicated cluster
- [x] probe body cost via `bpftool` stats: ~3.5 µs per subop event (debug build, contended laptop); `-l` fast path structurally identical to the validated log_op_stats_v2 gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQMVEJezhKCMbVMWFpNi5B