### PR TITLE
perf(osdtrace): submit ring buffer events with BPF_RB_NO_WAKEUP

### DIFF
--- a/src/osdtrace.bpf.c
+++ b/src/osdtrace.bpf.c
@@ -507,6 +507,7 @@ int uprobe_log_op_stats(struct pt_regs *ctx) {
     vp->rb = PT_REGS_PARM4(ctx);
     struct op_v *e = bpf_ringbuf_reserve(&rb, sizeof(struct op_v), 0);
     if (NULL == e) {
+      bpf_map_delete_elem(&ops, &key);
       return 0;
     }
     *e = *vp;
@@ -734,6 +735,7 @@ int uprobe_log_subop_stats(struct pt_regs *ctx)
 
   struct op_v *e = bpf_ringbuf_reserve(&rb, sizeof(struct op_v), 0);
   if (NULL == e) {
+    bpf_map_delete_elem(&ops, &key);
     return 0;
   }
   *e = *vp;
@@ -843,6 +845,7 @@ int uprobe_repop_commit(struct pt_regs *ctx)
 
   struct op_v *e = bpf_ringbuf_reserve(&rb, sizeof(struct op_v), 0);
   if (NULL == e) {
+    bpf_map_delete_elem(&ops, &key);
     return 0;
   }
   *e = *vp;

--- a/src/osdtrace.bpf.c
+++ b/src/osdtrace.bpf.c
@@ -42,6 +42,13 @@ struct {
 } rb SEC(".maps"); // all submits use BPF_RB_NO_WAKEUP; userspace drains periodically
 
 struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __type(key, __u32);
+  __type(value, __u64);
+  __uint(max_entries, 1);
+} rb_drops SEC(".maps"); // events lost to a full ring buffer; reported by userspace at exit
+
+struct {
   __uint(type, BPF_MAP_TYPE_HASH);
   __type(key, int);
   __type(value, struct VarField);
@@ -50,6 +57,13 @@ struct {
 
 // struct op_v no longer fits on the BPF stack after adding object_name.
 static struct op_v zero_op_v = {};
+
+static __always_inline void count_rb_drop(void) {
+  __u32 zero = 0;
+  __u64 *cnt = bpf_map_lookup_elem(&rb_drops, &zero);
+  if (NULL != cnt)
+    (*cnt)++;
+}
 
 static __always_inline int read_hprobe_varfield(struct pt_regs *ctx, int varid, void *dst, size_t size) {
   struct VarField *vf = bpf_map_lookup_elem(&hprobes, &varid);
@@ -507,6 +521,7 @@ int uprobe_log_op_stats(struct pt_regs *ctx) {
     vp->rb = PT_REGS_PARM4(ctx);
     struct op_v *e = bpf_ringbuf_reserve(&rb, sizeof(struct op_v), 0);
     if (NULL == e) {
+      count_rb_drop();
       bpf_map_delete_elem(&ops, &key);
       return 0;
     }
@@ -565,8 +580,10 @@ int uprobe_log_op_stats_v2(struct pt_regs *ctx) {
 
   // Slow / matched operation: reserve ring buffer and populate event
   struct op_v *op = bpf_ringbuf_reserve(&rb, sizeof(struct op_v), 0);
-  if (op == NULL)
+  if (op == NULL) {
+    count_rb_drop();
     return 0;
+  }
   *op = zero_op_v;
 
   op->owner = owner;
@@ -702,6 +719,7 @@ int uprobe_log_latency(struct pt_regs *ctx)
 
   struct bluestore_lat_v *e = bpf_ringbuf_reserve(&rb, sizeof(struct bluestore_lat_v), 0);
   if (NULL == e) {
+    count_rb_drop();
     return 0;
   }
   *e = bsl;
@@ -735,6 +753,7 @@ int uprobe_log_subop_stats(struct pt_regs *ctx)
 
   struct op_v *e = bpf_ringbuf_reserve(&rb, sizeof(struct op_v), 0);
   if (NULL == e) {
+    count_rb_drop();
     bpf_map_delete_elem(&ops, &key);
     return 0;
   }
@@ -845,6 +864,7 @@ int uprobe_repop_commit(struct pt_regs *ctx)
 
   struct op_v *e = bpf_ringbuf_reserve(&rb, sizeof(struct op_v), 0);
   if (NULL == e) {
+    count_rb_drop();
     bpf_map_delete_elem(&ops, &key);
     return 0;
   }
@@ -907,6 +927,7 @@ int uprobe_log_latency_fn(struct pt_regs *ctx)
 
   struct bluestore_lat_v *e = bpf_ringbuf_reserve(&rb, sizeof(struct bluestore_lat_v), 0);
   if (NULL == e) {
+    count_rb_drop();
     return 0;
   }
 

--- a/src/osdtrace.bpf.c
+++ b/src/osdtrace.bpf.c
@@ -39,7 +39,7 @@ struct {
 struct {
   __uint(type, BPF_MAP_TYPE_RINGBUF);
   __uint(max_entries, 256 * 1024);
-} rb SEC(".maps");
+} rb SEC(".maps"); // all submits use BPF_RB_NO_WAKEUP; userspace drains periodically
 
 struct {
   __uint(type, BPF_MAP_TYPE_HASH);
@@ -510,7 +510,7 @@ int uprobe_log_op_stats(struct pt_regs *ctx) {
       return 0;
     }
     *e = *vp;
-    bpf_ringbuf_submit(e, 0);
+    bpf_ringbuf_submit(e, BPF_RB_NO_WAKEUP);
   } else {
     bpf_printk(
         "uprobe_log_op_stats, no previous op info, owner %lld, tid %lld\n",
@@ -577,7 +577,7 @@ int uprobe_log_op_stats_v2(struct pt_regs *ctx) {
   op->recv_stamp = recv_stamp;
   op->op_type = op_type;
 
-  bpf_ringbuf_submit(op, 0);
+  bpf_ringbuf_submit(op, BPF_RB_NO_WAKEUP);
   return 0;
 }
 
@@ -704,7 +704,7 @@ int uprobe_log_latency(struct pt_regs *ctx)
     return 0;
   }
   *e = bsl;
-  bpf_ringbuf_submit(e, 0);
+  bpf_ringbuf_submit(e, BPF_RB_NO_WAKEUP);
 
   return 0;
 }
@@ -737,7 +737,7 @@ int uprobe_log_subop_stats(struct pt_regs *ctx)
     return 0;
   }
   *e = *vp;
-  bpf_ringbuf_submit(e, 0);
+  bpf_ringbuf_submit(e, BPF_RB_NO_WAKEUP);
 
   bpf_map_delete_elem(&ops, &key);
   return 0;
@@ -846,7 +846,7 @@ int uprobe_repop_commit(struct pt_regs *ctx)
     return 0;
   }
   *e = *vp;
-  bpf_ringbuf_submit(e, 0);
+  bpf_ringbuf_submit(e, BPF_RB_NO_WAKEUP);
 
   bpf_map_delete_elem(&ops, &key);
   return 0;
@@ -908,7 +908,7 @@ int uprobe_log_latency_fn(struct pt_regs *ctx)
   }
 
   *e = bsl;
-  bpf_ringbuf_submit(e, 0);
+  bpf_ringbuf_submit(e, BPF_RB_NO_WAKEUP);
 
   return 0;
 }

--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -222,6 +222,9 @@ enum probe_mode_e {
 int probe_mode = OP_FULL_PROBE;
 
 static __u64 bootstamp = 0;
+// How often userspace drains the BPF ring buffer.  Events are submitted with
+// BPF_RB_NO_WAKEUP so the tracer, not the traced OSD, pays for delivery.
+static const unsigned RINGBUF_DRAIN_INTERVAL_MS = 10;
 
 __u64 threshold = 0; //in millisecond
 int timeout = -1; //in seconds
@@ -1650,15 +1653,24 @@ static int run_tracer(DwarfParser &dwarfparser, const TraceTarget &target) {
 
   clog << "Started to poll from ring buffer" << endl;
 
+  // BPF programs submit events with BPF_RB_NO_WAKEUP, so the kernel never
+  // sends a wakeup (irq_work / IPI) from inside the uprobe.  Instead we drain
+  // the ring buffer ourselves at a fixed interval.  Output latency is bounded
+  // by RINGBUF_DRAIN_INTERVAL_MS, which is irrelevant for a latency tracer.
   int ret = 0;
-  while ((!timeout_occurred || timeout == -1) && (ret = ring_buffer__poll(rb.get(), 1000)) >= 0) {
-    // Continue polling while timeout hasn't occurred or if unlimited execution time
+  while (!timeout_occurred || timeout == -1) {
+    ret = ring_buffer__consume(rb.get());
+    if (ret < 0)
+      break;
+    usleep(RINGBUF_DRAIN_INTERVAL_MS * 1000);
   }
+  if (ret >= 0)
+    ring_buffer__consume(rb.get()); // final drain
 
   if (timeout_occurred)
     cerr << "Timeout occurred. Exiting." << endl;
   else
-    cerr << "Ring buffer poll failed: " << ret << endl;
+    cerr << "Ring buffer consume failed: " << ret << endl;
 
   clog << "Clean up the eBPF program" << endl;
   return timeout_occurred ? -1 : -errno;

--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -1655,14 +1655,17 @@ static int run_tracer(DwarfParser &dwarfparser, const TraceTarget &target) {
 
   // BPF programs submit events with BPF_RB_NO_WAKEUP, so the kernel never
   // sends a wakeup (irq_work / IPI) from inside the uprobe.  Instead we drain
-  // the ring buffer ourselves at a fixed interval.  Output latency is bounded
-  // by RINGBUF_DRAIN_INTERVAL_MS, which is irrelevant for a latency tracer.
+  // the ring buffer ourselves, sleeping only when a drain found it empty so
+  // that a burst larger than the ring can be consumed without dropping
+  // events.  Output latency is bounded by RINGBUF_DRAIN_INTERVAL_MS, which is
+  // irrelevant for a latency tracer.
   int ret = 0;
   while (!timeout_occurred || timeout == -1) {
     ret = ring_buffer__consume(rb.get());
     if (ret < 0)
       break;
-    usleep(RINGBUF_DRAIN_INTERVAL_MS * 1000);
+    if (ret == 0)
+      usleep(RINGBUF_DRAIN_INTERVAL_MS * 1000);
   }
   if (ret >= 0)
     ring_buffer__consume(rb.get()); // final drain

--- a/src/osdtrace.cc
+++ b/src/osdtrace.cc
@@ -1,3 +1,4 @@
+#include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 #include <errno.h>
 #include <getopt.h>
@@ -225,6 +226,8 @@ static __u64 bootstamp = 0;
 // How often userspace drains the BPF ring buffer.  Events are submitted with
 // BPF_RB_NO_WAKEUP so the tracer, not the traced OSD, pays for delivery.
 static const unsigned RINGBUF_DRAIN_INTERVAL_MS = 10;
+
+static int rb_drops_fd = -1;
 
 __u64 threshold = 0; //in millisecond
 int timeout = -1; //in seconds
@@ -645,10 +648,28 @@ void print_op_w(osd_op_t &op, int osd_id) {
   print_delayed_info(op);
 }
 
+// Events dropped because bpf_ringbuf_reserve() found the ring full are
+// counted per-CPU by the BPF programs; without this report they would
+// silently bias the output during exactly the load spikes being traced.
+void report_ringbuf_drops() {
+  if (rb_drops_fd < 0) return;
+  int ncpus = libbpf_num_possible_cpus();
+  if (ncpus <= 0) return;
+  std::vector<__u64> vals(ncpus, 0);
+  __u32 zero = 0;
+  if (bpf_map_lookup_elem(rb_drops_fd, &zero, vals.data()) != 0) return;
+  __u64 total = 0;
+  for (auto v : vals) total += v;
+  if (total > 0)
+    cerr << "Warning: " << total
+         << " events were dropped because the ring buffer was full" << endl;
+}
+
 void signal_handler(int signum){
   clog << "Caught signal " << signum << endl;
   if (signum == SIGINT) {
       print_all_srl();
+      report_ringbuf_drops();
   }
   exit(signum);
 }
@@ -1614,6 +1635,7 @@ static int run_tracer(DwarfParser &dwarfparser, const TraceTarget &target) {
   }
 
   fill_map_hprobes(target.osd_path, dwarfparser, skel->maps.hprobes);
+  rb_drops_fd = bpf_map__fd(skel->maps.rb_drops);
 
   clog << "BPF prog loaded" << endl;
 
@@ -1674,6 +1696,8 @@ static int run_tracer(DwarfParser &dwarfparser, const TraceTarget &target) {
     cerr << "Timeout occurred. Exiting." << endl;
   else
     cerr << "Ring buffer consume failed: " << ret << endl;
+
+  report_ringbuf_drops();
 
   clog << "Clean up the eBPF program" << endl;
   return timeout_occurred ? -1 : -errno;


### PR DESCRIPTION
### Summary

Every `bpf_ringbuf_submit(rec, 0)` in osdtrace uses adaptive notification: whenever the userspace consumer has caught up — which is always the case with a `ring_buffer__poll()` loop — the kernel queues an `irq_work` and raises a self-IPI to wake it. That work runs on the OSD thread's CPU, **inside the uprobe**, for every event.

This PR submits every event with `BPF_RB_NO_WAKEUP` and replaces the epoll-driven `ring_buffer__poll()` loop with `ring_buffer__consume()` every 10 ms (`RINGBUF_DRAIN_INTERVAL_MS`). Output latency is bounded by the drain interval, which is irrelevant for a latency tracer; the cost of delivery moves from the traced OSD to osdtrace.

---

### Isolated microbenchmark

[`taodd/uprobe-benchmark` branch `ringbuf-benchmark`](https://github.com/taodd/uprobe-benchmark/tree/ringbuf-benchmark/ringbuf) attaches one uprobe program per ring-buffer strategy to a hot loop and reports in-kernel BPF run time via `BPF_ENABLE_STATS`. Linux 6.17.0-1032-oem, AMD Ryzen AI 7 PRO 350, ~10k events/s, 888-byte records (`sizeof(struct op_v)`), median of 3:

| BPF program | userspace consumer | BPF body / hit |
| :--- | :--- | ---: |
| noop | – | 18 ns |
| reserve + submit, flags=0 | none | 25 ns |
| reserve + submit, flags=0 | `ring_buffer__poll()` | **1,410 ns** |
| reserve + discard | `ring_buffer__poll()` | 1,459 ns |
| reserve + submit, `BPF_RB_NO_WAKEUP` | `ring_buffer__consume()` every 10 ms | **45 ns** |
| reserve + submit, `BPF_RB_FORCE_WAKEUP` | `ring_buffer__consume()` every 10 ms | 888 ns |

The ring buffer itself is ~25–45 ns; the consumer wakeup is ~1.4 µs — about 3× the int3 trap — and fires even on `discard`. Record size (64 vs 888 B) barely matters. This also explains why the earlier `live_breakdown` measurement attributed only ~137 ns to the ring buffer: that harness had no consumer attached, so the wakeup never fired.

---

### Live Ceph OSD, single mode, unfiltered

`osdtrace -s` against a vstart `ceph-osd` (3-OSD cluster, same host/kernel), `rados bench 15 write -b 4096 -t 16`, `uprobe_log_op_stats_v2` in-kernel time from `bpf_stats`, two alternating rounds:

| Binary | Invocations | Avg BPF body / hit |
| :--- | ---: | ---: |
| main (`134daef`) | 13,168 | 5,064 ns |
| this PR | 8,310 | 3,004 ns |
| main (`134daef`) | 8,692 | 5,296 ns |
| this PR | 7,704 | 3,194 ns |

**≈2.1 µs (~40%) less in-kernel time per event.** Functionally verified: the periodic drain delivers all events and the SIGINT summary histogram is unchanged.

---

### Live OSD re-verification: wall-clock `log_op_stats` latency (2026-08-31)

Independent re-run measuring the metric that matters to the traced OSD: the **wall-clock execution time of `PrimaryLogPG::log_op_stats`** (bpftrace uprobe+uretprobe pair on the function, filtered to one OSD pid), with and without `osdtrace -s` attached. Unlike `bpf_stats` run_time, this window also captures the wakeup's irq_work/IPI cost when it lands on the OSD's CPU mid-function. Same host/kernel; 3-OSD vstart, OSDs pinned to dedicated Zen 5 cores, tracer on its own core; `rados bench 30 write -b 4096 -t 16` (~2.9k IOPS); osdtrace attached before bpftrace so the measured window includes the osdtrace handler; clean-environment check (no stray tracers / leftover BPF programs) before each cell and a 10-minute cool-down between the two cells; ~43k samples per cell.

| | without osdtrace | with `osdtrace -s` | added overhead per op |
| :--- | ---: | ---: | ---: |
| main (`134daef`, wakeup per event) | 3.16 µs | 6.35 µs | **+3.19 µs** |
| this PR (`BPF_RB_NO_WAKEUP`) | 3.22 µs | 4.57 µs | **+1.35 µs** |

**−1.84 µs/op (−58%) added overhead on the traced OSD.** The distribution shifts accordingly: with main the traced histogram bulk sits in the 4–8 µs bucket (26.8k of 44.4k samples); with this PR it moves to 1–4 µs (28.6k of 42.0k), and the 8–16 µs tail halves (1041 → 532).

`bpf_stats` over the same windows: 2060 ns/hit (44,350 hits) → 882 ns/hit (42,012 hits), −57%. The wall-clock delta being larger than the bpf_stats delta (1.84 µs vs 1.18 µs) is expected — part of the wakeup cost lands outside the BPF program's accounted runtime but inside the function's wall-clock window.

Client-observed throughput was unchanged in all cells (~2.8–2.9k IOPS, within run-to-run noise).

---

### Notes

- Ring capacity: 256 KiB holds ~290 `op_v` records. A fixed 10 ms drain would have capped delivery at ~29k events/s; the follow-up commits on this branch remove that ceiling (the drain loop skips the sleep while events are still arriving), plug an `ops` map leak on `bpf_ringbuf_reserve` failure, and count + report any events that are still dropped on ring-buffer full.
- SIGINT handling is unchanged (the handler already calls `exit()`); SIGALRM timeout exits within one drain interval.
