### PR TITLE
perf(radostrace): submit ring buffer events with BPF_RB_NO_WAKEUP

### DIFF
--- a/src/radostrace.bpf.c
+++ b/src/radostrace.bpf.c
@@ -232,6 +232,7 @@ int uprobe_finish_op(struct pt_regs *ctx) {
   // submit to ringbuf
   struct client_op_v *e = bpf_ringbuf_reserve(&rb, sizeof(struct client_op_v), 0);
   if (NULL == e) {
+    bpf_map_delete_elem(&ops, &key);
     return 0;
   }
   *e = *opv;

--- a/src/radostrace.bpf.c
+++ b/src/radostrace.bpf.c
@@ -20,7 +20,7 @@ struct {
 struct {
   __uint(type, BPF_MAP_TYPE_RINGBUF);
   __uint(max_entries, 256 * 1024);
-} rb SEC(".maps");
+} rb SEC(".maps"); // all submits use BPF_RB_NO_WAKEUP; userspace drains periodically
 
 struct {
   __uint(type, BPF_MAP_TYPE_HASH);
@@ -235,7 +235,7 @@ int uprobe_finish_op(struct pt_regs *ctx) {
     return 0;
   }
   *e = *opv;
-  bpf_ringbuf_submit(e, 0);
+  bpf_ringbuf_submit(e, BPF_RB_NO_WAKEUP);
 
   bpf_map_delete_elem(&ops, &key);
   

--- a/src/radostrace.cc
+++ b/src/radostrace.cc
@@ -510,6 +510,9 @@ std::vector<CephClientInfo> discover_ceph_clients() {
 
 
 int timeout = -1;
+// How often userspace drains the BPF ring buffer.  Events are submitted with
+// BPF_RB_NO_WAKEUP so the tracer, not the traced client, pays for delivery.
+static const unsigned RINGBUF_DRAIN_INTERVAL_MS = 10;
 bool export_json = false;
 bool import_json = false;
 bool skip_version_check = false;
@@ -911,9 +914,20 @@ int main(int argc, char **argv) {
 
   clog << "Started to poll from ring buffer" << endl;
 
-  while ((!timeout_occurred || timeout == -1) && (ret = ring_buffer__poll(rb, 1000)) >= 0) {
-      // Continue polling while timeout hasn't occurred or if unlimited execution time
+  // BPF programs submit events with BPF_RB_NO_WAKEUP, so the kernel never
+  // sends a wakeup (irq_work / IPI) from inside the uprobe.  Instead we drain
+  // the ring buffer ourselves, sleeping only when a drain found it empty so
+  // that a burst larger than the ring can be consumed without dropping
+  // events.  Output latency is bounded by RINGBUF_DRAIN_INTERVAL_MS.
+  while (!timeout_occurred || timeout == -1) {
+    ret = ring_buffer__consume(rb);
+    if (ret < 0)
+      break;
+    if (ret == 0)
+      usleep(RINGBUF_DRAIN_INTERVAL_MS * 1000);
   }
+  if (ret >= 0)
+    ring_buffer__consume(rb); // final drain
 
   if (timeout_occurred) {
       cerr << "Timeout occurred. Exiting." << endl;


### PR DESCRIPTION
### Summary

Port of #188 to radostrace. The single `bpf_ringbuf_submit(e, 0)` in `uprobe_finish_op` used adaptive notification: with a `ring_buffer__poll()` consumer that keeps up, the kernel queues an `irq_work` and raises a self-IPI **on the traced client's CPU, inside the uprobe**, for essentially every completed op.

This PR submits with `BPF_RB_NO_WAKEUP` and replaces the epoll-driven poll loop with a periodic `ring_buffer__consume()` drain (10 ms interval, sleeping only when a drain found the ring empty so bursts larger than the ring are consumed without loss). A second commit fixes the matching `ops` map leak: `uprobe_finish_op` returned early on reserve failure, skipping the `bpf_map_delete_elem`, which becomes a realistic under-load path once the ring absorbs full drain intervals.

---

### Live measurements

vstart cluster (Ryzen AI 7 PRO 350, kernel 6.17), traced process = `rados bench 4K write -t 16` (~2.8k IOPS), radostrace attached with `-p` to the bench client. Two independent methods.

**Wall-clock duration of the two probed functions** (bpftrace uprobe+uretprobe pairs, ~180k samples/cell; the probe pair's own cost is constant across cells, so the deltas are what matter):

| | `_send_op` | added | `_finish_op` | added |
| :--- | ---: | ---: | ---: | ---: |
| baseline (probes only) | 2.69 µs | — | 1.83 µs | — |
| radostrace main | 5.78 µs | +3.09 µs | 3.91 µs | **+2.08 µs** |
| radostrace this PR | 5.89 µs | +3.20 µs | 3.07 µs | **+1.24 µs** |

**Ground truth with no probes at all** (temporary `clock_gettime` instrumentation around the hot call sites in `Objecter.cc`, two 60 s cells per variant, ~60 windows of 5000 calls each):

| | `_send_op` | added | `_finish_op` | added |
| :--- | ---: | ---: | ---: | ---: |
| raw, nothing attached | 1.61 µs | — | 0.74 µs | — |
| radostrace main | 4.17 µs | +2.56 µs | 2.69 µs | **+1.95 µs** |
| radostrace this PR | 4.25 µs | +2.64 µs | 2.22 µs | **+1.48 µs** |

`bpf_stats` for `uprobe_finish_op`: 2009 → 1149 ns/hit (−43%).

The saving lands exactly where the submit is: `_finish_op` (radostrace's only ring-buffer submit site) drops by ~0.45 µs measured in-function and ~0.86 µs by BPF program body — the spread is the async IPI cost that can land just outside the timed window but still on the client CPU. `_send_op` has no submit site and is unchanged within noise. Functionally verified: full event delivery through the periodic drain (53k+ well-formed rows per smoke run).

---

### Notes

- The drain loop lands with the adaptive sleep from the start (skip the sleep while a drain returns records), so the 256 KiB ring imposes no sustained-throughput ceiling.
- kfstrace still submits with flags 0 + poll; same port applies if wanted.

