### PR TITLE
perf(radostrace): collapse DWARF varpaths to load-time offsets

### DIFF
--- a/src/radostrace.bpf.c
+++ b/src/radostrace.bpf.c
@@ -22,13 +22,6 @@ struct {
   __uint(max_entries, 256 * 1024);
 } rb SEC(".maps"); // all submits use BPF_RB_NO_WAKEUP; userspace drains periodically
 
-struct {
-  __uint(type, BPF_MAP_TYPE_HASH);
-  __type(key, int);
-  __type(value, struct VarField);
-  __uint(max_entries, 8192);
-} hprobes SEC(".maps");
-
 /* Global variables for struct offsets - set by userspace before loading */
 const volatile __u32 CEPH_OSD_OP_SIZE = 0;
 const volatile __u32 CEPH_OSD_OP_EXTENT_OFFSET_OFFSET = 0;
@@ -39,102 +32,89 @@ const volatile __u32 CEPH_OSD_OP_BUFFER_CARRIAGE_OFFSET = 0;
 const volatile __u32 CEPH_OSD_OP_BUFFER_RAW_OFFSET = 0;
 const volatile __u32 CEPH_OSD_OP_BUFFER_DATA_OFFSET = 0;
 
+/* Every variable read at either probe is rooted at the Op* (or this->monc)
+ * and its DWARF member chain is offset-only, so userspace collapses each
+ * chain to a single precomputed offset at load time.  Each program fetches
+ * its root registers once and does one bpf_probe_read_user per member -- no
+ * per-var map lookup and no chain walking on the hot path.  Member offsets
+ * are struct properties shared by both probes; only the registers holding
+ * op/this differ per probe site. */
+const volatile __u32 SEND_OP_REG = 0;
+const volatile __u32 SEND_THIS_REG = 0;
+const volatile __u32 FIN_OP_REG = 0;
+const volatile __u32 FIN_THIS_REG = 0;
+const volatile __s64 OFF_TID = 0;
+const volatile __s64 OFF_MONC = 0;        /* this + OFF_MONC -> MonClient* */
+const volatile __s64 OFF_GLOBAL_ID = 0;   /* monc + OFF_GLOBAL_ID */
+const volatile __s64 OFF_TARGET_OSD = 0;
+const volatile __s64 OFF_NAME_LEN = 0;
+const volatile __s64 OFF_NAME_PTR = 0;
+const volatile __s64 OFF_FLAGS = 0;
+const volatile __s64 OFF_POOL = 0;
+const volatile __s64 OFF_SEED = 0;
+const volatile __s64 OFF_ACTING_START = 0;
+const volatile __s64 OFF_ACTING_FINISH = 0;
+const volatile __s64 OFF_OPS_START = 0;
+const volatile __s64 OFF_OPS_SIZE = 0;
+
 static struct client_op_v zero_val = {};
 
 void initialize_value(struct client_op_k key) {
   bpf_map_update_elem(&ops, &key, &zero_val, 0);
 }
 
-static __always_inline int read_hprobe_varfield(struct pt_regs *ctx, int varid, void *dst, size_t size) {
-  struct VarField *vf = bpf_map_lookup_elem(&hprobes, &varid);
-  if (NULL != vf) {
-    __u64 v = fetch_register(ctx, vf->varloc.reg);
-    __u64 addr = fetch_var_member_addr(v, vf);
-    bpf_probe_read_user(dst, size, (void *)addr);
-    return 0;
-  }
-  bpf_printk("got NULL vf at varid %d\n", varid);
-  return -1;
+#define READ_OP(dst, off) \
+  bpf_probe_read_user(&(dst), sizeof(dst), (void *)(op + (off)))
+
+static __always_inline __u64 read_cid(struct pt_regs *ctx, __u32 this_reg) {
+  // this->monc->global_id: the one chain with an intermediate pointer
+  __u64 self = fetch_register(ctx, this_reg);
+  __u64 monc = 0;
+  __u64 cid = 0;
+  if (self != 0)
+    bpf_probe_read_user(&monc, sizeof(monc), (void *)(self + OFF_MONC));
+  if (monc != 0)
+    bpf_probe_read_user(&cid, sizeof(cid), (void *)(monc + OFF_GLOBAL_ID));
+  return cid;
 }
 
 SEC("uprobe")
 int uprobe_send_op(struct pt_regs *ctx) {
-  bpf_printk("Entered uprobe_send_op\n");
-  int varid = 0;
+  __u64 op = fetch_register(ctx, SEND_OP_REG);
+  if (op == 0)
+    return 0;
+
   struct client_op_k key;
   memset(&key, 0, sizeof(key));
-
-  // read tid
-  if (read_hprobe_varfield(ctx, varid++, &key.tid, sizeof(key.tid)) == 0) {
-    bpf_printk("uprobe_send_op got tid %lld\n", key.tid);
-  }
-
-  // read client id
-  if (read_hprobe_varfield(ctx, varid++, &key.cid, sizeof(key.cid)) == 0) {
-    bpf_printk("uprobe_send_op got client id %lld\n", key.cid);
-  }
+  READ_OP(key.tid, OFF_TID);
+  key.cid = read_cid(ctx, SEND_THIS_REG);
 
   initialize_value(key);
   struct client_op_v *val = bpf_map_lookup_elem(&ops, &key);
   if (val == NULL) {
     return 0;
   }
-  memset(val, 0, sizeof(struct client_op_v));
   val->sent_stamp = bpf_ktime_get_boot_ns();
   val->tid = key.tid;
   val->cid = key.cid;
-  val->rw = 0;
 
-  // read osd id
-  if (read_hprobe_varfield(ctx, varid++, &val->target_osd, sizeof(val->target_osd)) == 0) {
-    bpf_printk("uprobe_send_op got osd id %lld\n", val->target_osd);
-  }
+  READ_OP(val->target_osd, OFF_TARGET_OSD);
+  READ_OP(val->rw, OFF_FLAGS);
+  READ_OP(val->m_pool, OFF_POOL);
+  READ_OP(val->m_seed, OFF_SEED);
 
-  // read name length
   int name_len = 0;
-  if (read_hprobe_varfield(ctx, varid++, &name_len, sizeof(name_len)) == 0) {
-    bpf_printk("uprobe_send_op got name length %d\n", name_len);
-  }
-
-  // read name
   __u64 name_base = 0;
-  if (read_hprobe_varfield(ctx, varid++, &name_base, sizeof(name_base)) == 0) {
-    bpf_printk("uprobe_send_op got name base addr %lld\n", name_base);
-  }
-
+  READ_OP(name_len, OFF_NAME_LEN);
+  READ_OP(name_base, OFF_NAME_PTR);
   name_len &= 127;
   bpf_probe_read_user(val->object_name, name_len, (void *)name_base);
 
-  // read op flags
-  if (read_hprobe_varfield(ctx, varid++, &val->rw, sizeof(val->rw)) == 0) {
-    bpf_printk("uprobe_send_op got flags %d\n", val->rw);
-  }
-
-  // read m_pool
-  if (read_hprobe_varfield(ctx, varid++, &val->m_pool, sizeof(val->m_pool)) == 0) {
-    bpf_printk("uprobe_send_op got m_pool %d\n", val->m_pool);
-  }
-  
-  // read m_seed
-  if (read_hprobe_varfield(ctx, varid++, &val->m_seed, sizeof(val->m_seed)) == 0) {
-    bpf_printk("uprobe_send_op got m_seed %d\n", val->m_seed);
-  }
-  
-  // read acting _M_start
+  // acting vector bounds; zeros just fill the slots with -1 below
   __u64 M_start = 0;
-  if (read_hprobe_varfield(ctx, varid++, &M_start, sizeof(M_start)) == 0) {
-    bpf_printk("uprobe_send_op got M_start %lld\n", M_start);
-  } else {
-    return 0;
-  }
-
-  // read acting _M_finish
   __u64 m_finish = 0;
-  if (read_hprobe_varfield(ctx, varid++, &m_finish, sizeof(m_finish)) == 0) {
-    bpf_printk("uprobe_send_op got m_finish %lld\n", m_finish);
-  } else {
-    return 0;
-  }
+  READ_OP(M_start, OFF_ACTING_START);
+  READ_OP(m_finish, OFF_ACTING_FINISH);
 
   for (int i = 0 ; i < MAX_ACTING; ++i) {
     val->acting[i] = -1;
@@ -146,20 +126,12 @@ int uprobe_send_op(struct pt_regs *ctx) {
     }
   }
 
-  //read op->ops->m_holder->m_start
+  // ops vector; a zero start pointer skips the decode loop
   __u64 m_start = 0;
-  if (read_hprobe_varfield(ctx, varid++, &m_start, sizeof(m_start)) == 0) {
-    bpf_printk("uprobe_send_op got m_start %lld\n", m_start);
-  } else {
-    return 0;
-  }
-
-  //read op->ops->m_holder->m_size
-  if (read_hprobe_varfield(ctx, varid++, &val->ops_size, sizeof(val->ops_size)) == 0) {
-    bpf_printk("uprobe_send_op got ops_size %d\n", val->ops_size);
-  } else {
-    return 0;
-  }
+  READ_OP(m_start, OFF_OPS_START);
+  READ_OP(val->ops_size, OFF_OPS_SIZE);
+  if (m_start == 0)
+    val->ops_size = 0;
 
   // Keep ops_size as the true op count so userspace can report what was
   // dropped; only the capture loop is bounded by the array size.
@@ -206,20 +178,14 @@ int uprobe_send_op(struct pt_regs *ctx) {
 
 SEC("uprobe")
 int uprobe_finish_op(struct pt_regs *ctx) {
-  bpf_printk("Entered uprobe_finish_op\n");
-  int varid = 20;
+  __u64 op = fetch_register(ctx, FIN_OP_REG);
+  if (op == 0)
+    return 0;
+
   struct client_op_k key;
   memset(&key, 0, sizeof(key));
-
-  // read tid
-  if (read_hprobe_varfield(ctx, varid++, &key.tid, sizeof(key.tid)) == 0) {
-    bpf_printk("uprobe_finish_op got tid %lld\n", key.tid);
-  }
-
-  // read client id
-  if (read_hprobe_varfield(ctx, varid++, &key.cid, sizeof(key.cid)) == 0) {
-    bpf_printk("uprobe_finish_op got client id %lld\n", key.cid);
-  }
+  READ_OP(key.tid, OFF_TID);
+  key.cid = read_cid(ctx, FIN_THIS_REG);
 
   struct client_op_v *opv = bpf_map_lookup_elem(&ops, &key);
 

--- a/src/radostrace.cc
+++ b/src/radostrace.cc
@@ -99,30 +99,6 @@ const char * ceph_osd_op_str(int opc) {
     return op_str;
 }
 
-void fill_map_hprobes(std::string mod_path, DwarfParser &dwarfparser, struct bpf_map *hprobes) {
-  std::string mod_basename = get_basename(mod_path);
-  auto &func2vf = dwarfparser.mod_func2vf[mod_basename];
-  for (auto x : func2vf) {
-    std::string funcname = x.first;
-    int key_idx = func_id[funcname];
-    for (auto vf : x.second) {
-      struct VarField_Kernel vfk;
-      vfk.varloc = vf.varloc;
-      clog << "fill_map_hprobes: "
-           << "function " << funcname << " var location : register "
-           << vfk.varloc.reg << " offset " << vfk.varloc.offset << " stack "
-           << vfk.varloc.stack << endl;
-      vfk.size = vf.fields.size();
-      for (int i = 0; i < vfk.size; ++i) {
-        vfk.fields[i] = vf.fields[i];
-      }
-      bpf_map__update_elem(hprobes, &key_idx, sizeof(key_idx), &vfk,
-                           sizeof(vfk), 0);
-      ++key_idx;
-    }
-  }
-}
-
 void signal_handler(int signum){
   clog << "Caught signal " << signum << endl;
   if (signum == SIGINT) {
@@ -863,24 +839,101 @@ int main(int argc, char **argv) {
   clog << "  CEPH_OSD_OP_CLS_METHOD_OFFSET: " << skel->rodata->CEPH_OSD_OP_CLS_METHOD_OFFSET << endl;
   clog << "  CEPH_OSD_OP_BUFFER_CARRIAGE_OFFSET: " << skel->rodata->CEPH_OSD_OP_BUFFER_CARRIAGE_OFFSET << endl;
 
+  // Collapse each probed varpath to a single load-time offset.  All the
+  // op-rooted chains are offset-only; only this->monc->global_id has an
+  // intermediate pointer.  Member offsets are struct properties shared by
+  // both probes, so they come from the _send_op list; the two probe sites
+  // contribute their own root registers.  Take the VarFields from whichever
+  // library carries the DWARF info -- in squid the symbol is duplicated
+  // across all three with identical layouts, in tentacle only
+  // libceph-common has it.
+  std::vector<std::string> rados_lib_paths = {
+      librados_path, librbd_path, libceph_common_path};
+  {
+    const std::vector<VarField> *send_vfs = nullptr;
+    const std::vector<VarField> *fin_vfs = nullptr;
+    for (const auto &p : rados_lib_paths) {
+      auto &f2vf = dwarfparser.mod_func2vf[get_basename(p)];
+      auto its = f2vf.find("Objecter::_send_op");
+      auto itf = f2vf.find("Objecter::_finish_op");
+      if (its != f2vf.end() && its->second.size() == 12 &&
+          itf != f2vf.end() && itf->second.size() >= 2) {
+        send_vfs = &its->second;
+        fin_vfs = &itf->second;
+        break;
+      }
+    }
+    if (!send_vfs) {
+      cerr << "DWARF data lacks the Objecter::_send_op/_finish_op variables; "
+              "regenerate it with -j against a build with debug symbols" << endl;
+      radostrace_bpf__destroy(skel);
+      return 1;
+    }
+    // vf.fields[0] stands for the variable itself; the walk consumes
+    // fields[1..].  A chain is collapsible when the root is in a register
+    // and no member level needs a dereference.
+    auto flat_off = [](const VarField &vf, long long &off) -> bool {
+      if (vf.varloc.stack) return false;
+      off = 0;
+      for (size_t i = 1; i < vf.fields.size(); ++i) {
+        if (vf.fields[i].pointer && i >= 2) return false;
+        off += vf.fields[i].offset;
+      }
+      return true;
+    };
+    long long off[12];
+    bool ok = true;
+    for (int i = 0; i < 12; ++i) {
+      if (i == 1) continue; // global_id handled below
+      ok = ok && flat_off((*send_vfs)[i], off[i]);
+    }
+    // this->monc->global_id: fields[1] = monc member, fields[2] = deref +
+    // global_id offset
+    const VarField &gid = (*send_vfs)[1];
+    ok = ok && !gid.varloc.stack && gid.fields.size() == 3 &&
+         gid.fields[2].pointer;
+    for (int i = 2; i < 12 && ok; ++i)
+      ok = ok && (*send_vfs)[i].varloc.reg == (*send_vfs)[0].varloc.reg;
+    // finish side: tid must collapse to the same member offset
+    long long fin_tid_off = -1;
+    const VarField &fgid = (*fin_vfs)[1];
+    ok = ok && flat_off((*fin_vfs)[0], fin_tid_off) && fin_tid_off == off[0];
+    ok = ok && !fgid.varloc.stack && fgid.fields.size() == 3 &&
+         fgid.fields[2].pointer && fgid.fields[1].offset == gid.fields[1].offset;
+    if (!ok) {
+      cerr << "Objecter probe variable layout is not offset-collapsible "
+              "with this build's DWARF; cannot continue" << endl;
+      radostrace_bpf__destroy(skel);
+      return 1;
+    }
+    skel->rodata->SEND_OP_REG = (*send_vfs)[0].varloc.reg;
+    skel->rodata->SEND_THIS_REG = gid.varloc.reg;
+    skel->rodata->FIN_OP_REG = (*fin_vfs)[0].varloc.reg;
+    skel->rodata->FIN_THIS_REG = fgid.varloc.reg;
+    skel->rodata->OFF_TID = off[0];
+    skel->rodata->OFF_MONC = gid.fields[1].offset;
+    skel->rodata->OFF_GLOBAL_ID = gid.fields[2].offset;
+    skel->rodata->OFF_TARGET_OSD = off[2];
+    skel->rodata->OFF_NAME_LEN = off[3];
+    skel->rodata->OFF_NAME_PTR = off[4];
+    skel->rodata->OFF_FLAGS = off[5];
+    skel->rodata->OFF_POOL = off[6];
+    skel->rodata->OFF_SEED = off[7];
+    skel->rodata->OFF_ACTING_START = off[8];
+    skel->rodata->OFF_ACTING_FINISH = off[9];
+    skel->rodata->OFF_OPS_START = off[10];
+    skel->rodata->OFF_OPS_SIZE = off[11];
+    clog << "Collapsed varpaths: send op reg " << skel->rodata->SEND_OP_REG
+         << ", finish op reg " << skel->rodata->FIN_OP_REG
+         << ", tid+" << off[0] << " osd+" << off[2] << endl;
+  }
+
   /* Now load the BPF program with the configured globals */
   ret = radostrace_bpf__load(skel);
   if (ret) {
     cerr << "Failed to load BPF skeleton: " << ret << endl;
     radostrace_bpf__destroy(skel);
     return 1;
-  }
-
-  // Populate the per-function hprobes map from whichever library carries
-  // the DWARF info.  In squid the Objecter symbol is statically duplicated
-  // across all three libraries (same source, same compiler -> identical
-  // varloc/fields), so later writes are no-ops; in tentacle the data only
-  // lives in libceph-common.so.2.  fill_map_hprobes is a no-op for any
-  // path whose mod_func2vf entry is empty.
-  std::vector<std::string> rados_lib_paths = {
-      librados_path, librbd_path, libceph_common_path};
-  for (const auto& p : rados_lib_paths) {
-    fill_map_hprobes(p, dwarfparser, skel->maps.hprobes);
   }
 
   clog << "BPF prog loaded" << endl;


### PR DESCRIPTION
### Summary

Every variable radostrace reads at its two probes is rooted at the `Op*` (or `this->monc`) through an **offset-only** DWARF member chain — `target`, `pgid`, `m_holder`, `base_oid.name` are all embedded, with `this->monc->global_id` as the single chain containing an intermediate pointer. Yet each read paid a per-variable `hprobes` hash-map lookup plus a chain walk on every probe hit — ~12 times per `_send_op`.

This PR collapses each chain to a single constant at load time: userspace sums the member offsets from the parsed DWARF and passes them via `.rodata`; each BPF program fetches its `op`/`this` registers once and does one direct `bpf_probe_read_user` per member. Member offsets are struct properties shared by both probe sites, so they are resolved once from the `_send_op` variable list; each probe contributes only its own root registers. The `hprobes` map is removed from radostrace entirely.

A layout that does not collapse (e.g. a future ceph version introducing a pointer level in one of these chains) is detected at load time with a clear error instead of silently misreading.

---

### Live measurements

vstart cluster (Ryzen AI 7 PRO 350, kernel 6.17), traced process = `rados bench 4K write -t 16` (~2.8k IOPS), radostrace attached with `-p` to the bench client. Wall-clock cost of the probed functions measured **in-source** (temporary `clock_gettime` instrumentation around the hot `_send_op`/`_finish_op` call sites in `Objecter.cc`, ~60 windows of 5000 calls per cell) — no measurement probes attached, so the numbers include the full uprobe trap:

| | `_send_op` added/op | `_finish_op` added/op | total/op |
| :--- | ---: | ---: | ---: |
| pre-#189 main (hash lookups + wakeup) | +2.56 µs | +1.95 µs | +4.51 µs |
| current main (#189: NO_WAKEUP) | +2.64 µs | +1.50 µs | +4.15 µs |
| this PR (NO_WAKEUP + collapsed offsets) | **+1.11 µs** | **+1.07 µs** | **+2.18 µs** |

**−47% per-op tracer overhead vs current main** (−52% vs main from two days ago). Raw uninstrumented baselines: `_send_op` 1.61 µs, `_finish_op` 0.74 µs.

Functionally verified: 74.6k well-formed trace rows (fields, acting sets, op decode all intact), and latency accuracy is preserved — the measured mean (5.33 ms) sits correctly just below the same run's `rados bench` client average (5.76 ms), with no systematic shift. Existing exported DWARF JSON files remain compatible (the probe variable spec is unchanged).

---

### Notes

- osdtrace's `hprobes` map is untouched; the same collapse applies there as a follow-up but its chains need the same audit first.
- The DWARF chain shape is validated at load (offset-only op-rooted chains; `monc` chain must be exactly member → deref+member); on mismatch the tool exits with guidance rather than tracing garbage.
