### PR TITLE
build: remove 32-bit library dependencies for eBPF compilation

### DIFF
--- a/.github/workflows/embedded-dwarf-refresh-reusable.yaml
+++ b/.github/workflows/embedded-dwarf-refresh-reusable.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Install host build deps + podman
         run: |
             sudo apt-get update
-            sudo apt-get install -y g++ clang libelf-dev libc6-dev-i386 \
+            sudo apt-get install -y g++ clang libelf-dev \
                 libdw-dev python3 podman
 
       - name: Detect missing DWARF JSONs (centos-stream / el9)
@@ -195,7 +195,7 @@ jobs:
       - name: Install build dependencies
         run: |
             sudo apt-get update
-            sudo apt-get install -y g++ clang libelf-dev libc6-dev-i386 libdw-dev python3
+            sudo apt-get install -y g++ clang libelf-dev libdw-dev python3
 
       - name: Pull in the freshly generated JSONs
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Ensure submodules are updated
         run: |
             sudo apt-get update
-            sudo apt-get install g++ clang libelf-dev libc6-dev-i386 libdw-dev python3
+            sudo apt-get install g++ clang libelf-dev libdw-dev python3
 
       - name: Run Makefile build
         run: make -j all
@@ -97,7 +97,7 @@ jobs:
       - name: Install build dependencies
         run: |
             sudo apt-get update
-            sudo apt-get install -y g++ clang libelf-dev libc6-dev-i386 libdw-dev python3
+            sudo apt-get install -y g++ clang libelf-dev libdw-dev python3
 
       - name: Run Makefile build
         run: make -j all
@@ -165,7 +165,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          dnf install -y git gcc gcc-c++ clang make elfutils-libelf-devel elfutils-devel glibc-devel glibc-devel.i686 python3 openssl-devel
+          dnf install -y git gcc gcc-c++ clang make elfutils-libelf-devel elfutils-devel glibc-devel python3 openssl-devel
 
       - name: Checkout code and submodules
         uses: actions/checkout@v4
@@ -192,7 +192,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          dnf install -y git gcc gcc-c++ clang make elfutils-libelf-devel elfutils-devel glibc-devel glibc-devel.i686 python3 openssl-devel
+          dnf install -y git gcc gcc-c++ clang make elfutils-libelf-devel elfutils-devel glibc-devel python3 openssl-devel
 
       - name: Checkout code and submodules
         uses: actions/checkout@v4
@@ -221,7 +221,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y g++ clang clang-tidy libelf-dev libc6-dev-i386 libdw-dev
+          sudo apt-get install -y g++ clang clang-tidy libelf-dev libdw-dev
 
       - name: Run clang-tidy
         run: make -j clang-tidy

--- a/.github/workflows/regenerate-all-dwarf.yaml
+++ b/.github/workflows/regenerate-all-dwarf.yaml
@@ -104,7 +104,7 @@ jobs:
       - name: Install build tools and podman
         run: |
           sudo apt-get update
-          sudo apt-get install -y g++ clang libelf-dev libc6-dev-i386 \
+          sudo apt-get install -y g++ clang libelf-dev \
             libdw-dev debuginfod podman python3
 
       - name: Build cephtrace generators (Ubuntu/Debian)
@@ -403,7 +403,7 @@ jobs:
       - name: Install build tools and python
         run: |
           sudo apt-get update
-          sudo apt-get install -y g++ clang libelf-dev libc6-dev-i386 \
+          sudo apt-get install -y g++ clang libelf-dev \
             libdw-dev python3
 
       - name: Download all regenerated DWARF artifacts

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,6 @@ Build-Depends: clang,
                docutils | python3-docutils,
                g++,
                libelf-dev,
-               libc6-dev-i386,
                libdw-dev,
                libcap-dev,
                pkg-config

--- a/doc/building.md
+++ b/doc/building.md
@@ -11,7 +11,6 @@ sudo apt-get install \
     clang \
     libelf-dev \
     libc6-dev \
-    libc6-dev-i386 \
     libdw-dev \
     libssl-dev \
     make
@@ -26,7 +25,6 @@ sudo dnf install \
     clang \
     elfutils-libelf-devel \
     glibc-devel \
-    glibc-devel.i686 \
     elfutils-devel \
     openssl-devel \
     make

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -145,14 +145,14 @@ git submodule update --init --recursive
 #### Debian/Ubuntu
 
 ```bash
-sudo apt-get install g++ clang libelf-dev libc6-dev libc6-dev-i386 libdw-dev libssl-dev make
+sudo apt-get install g++ clang libelf-dev libc6-dev libdw-dev libssl-dev make
 ```
 
 #### RHEL/CentOS/Rocky Linux
 
 ```bash
 sudo dnf config-manager --enable crb
-sudo dnf install g++ clang elfutils-libelf-devel glibc-devel glibc-devel.i686 elfutils-devel
+sudo dnf install g++ clang elfutils-libelf-devel glibc-devel elfutils-devel
 ```
 
 #### Other Systems
@@ -161,7 +161,7 @@ For systems with different package managers, you'll need equivalent packages:
 - C++ compiler (g++)
 - Clang compiler (for eBPF)
 - libelf development files
-- libc development files (including 32-bit)
+- libc development files
 - libdw development files
 
 ### 3. Build the Tools

--- a/src/bpf_utils.h
+++ b/src/bpf_utils.h
@@ -1,6 +1,8 @@
 #ifndef BPF_UTILS_H
 #define BPF_UTILS_H
 
+#include <stddef.h>
+
 struct utime_t {
   __u32 sec;
   __u32 nsec;

--- a/src/osdtrace.bpf.c
+++ b/src/osdtrace.bpf.c
@@ -5,7 +5,6 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include <stdbool.h>
-#include <string.h>
 
 #include "bpf_ceph_types.h"
 #include "bpf_utils.h"
@@ -155,7 +154,7 @@ SEC("uprobe")
 int uprobe_enqueue_op(struct pt_regs *ctx) {
   int varid = 0;
   struct op_k key;
-  memset(&key, 0, sizeof(key));
+  __builtin_memset(&key, 0, sizeof(key));
 
   __u16 op_type = 0;
   read_hprobe_varfield(ctx, varid++, &op_type, sizeof(op_type));
@@ -236,7 +235,7 @@ int uprobe_dequeue_op(struct pt_regs *ctx) {
   bpf_printk("Entered into uprobe_dequeue_op\n");
 
   struct op_k key;
-  memset(&key, 0, sizeof(key));
+  __builtin_memset(&key, 0, sizeof(key));
   int varid = 10;
 
   __u16 op_type = 0;
@@ -286,7 +285,7 @@ int uprobe_execute_ctx(struct pt_regs *ctx) {
 
   int varid = 20;
   struct op_k key;
-  memset(&key, 0, sizeof(key));
+  __builtin_memset(&key, 0, sizeof(key));
   read_hprobe_varfield(ctx, varid++, &key.owner, sizeof(key.owner));
   if (read_hprobe_varfield(ctx, varid++, &key.tid, sizeof(key.tid)) != 0)
     return 0;
@@ -346,7 +345,7 @@ int uprobe_submit_transaction(struct pt_regs *ctx) {
 
   int varid = 30;
   struct op_k key;
-  memset(&key, 0, sizeof(key));
+  __builtin_memset(&key, 0, sizeof(key));
   read_hprobe_varfield(ctx, varid++, &key.owner, sizeof(key.owner));
   if (read_hprobe_varfield(ctx, varid++, &key.tid, sizeof(key.tid)) != 0)
     return 0;
@@ -507,7 +506,7 @@ int uprobe_log_op_stats(struct pt_regs *ctx) {
   bpf_printk("Entered into uprobe_log_op_stats\n");
   int varid = 90;
   struct op_k key;
-  memset(&key, 0, sizeof(key));
+  __builtin_memset(&key, 0, sizeof(key));
   read_hprobe_varfield(ctx, varid++, &key.owner, sizeof(key.owner));
   if (read_hprobe_varfield(ctx, varid++, &key.tid, sizeof(key.tid)) != 0)
     return 0;
@@ -605,7 +604,7 @@ int uprobe_generate_subop(struct pt_regs *ctx)
   bpf_printk("Entered into uprobe_generate_subop\n");
   int varid = 100;
   struct op_k key;
-  memset(&key, 0, sizeof(key));
+  __builtin_memset(&key, 0, sizeof(key));
   read_hprobe_varfield(ctx, varid++, &key.owner, sizeof(key.owner));
   if (read_hprobe_varfield(ctx, varid++, &key.tid, sizeof(key.tid)) != 0)
     return 0;
@@ -639,7 +638,7 @@ int uprobe_do_repop_reply(struct pt_regs *ctx)
   bpf_printk("Entered into uprobe_do_repop_reply\n");
   int varid = 110;
   struct op_k key;
-  memset(&key, 0, sizeof(key));
+  __builtin_memset(&key, 0, sizeof(key));
   read_hprobe_varfield(ctx, varid++, &key.owner, sizeof(key.owner));
   if (read_hprobe_varfield(ctx, varid++, &key.tid, sizeof(key.tid)) != 0)
     return 0;
@@ -672,7 +671,7 @@ int uprobe_mark_flag_point_string(struct pt_regs *ctx)
   if(!(flag & flag_delayed))
     return 0;
   struct op_k key;
-  memset(&key, 0, sizeof(key));
+  __builtin_memset(&key, 0, sizeof(key));
   ++varid;
   read_hprobe_varfield(ctx, varid++, &key.owner, sizeof(key.owner));
   if (read_hprobe_varfield(ctx, varid++, &key.tid, sizeof(key.tid)) != 0)
@@ -707,7 +706,7 @@ int uprobe_log_latency(struct pt_regs *ctx)
   bpf_printk("Entered into log_latency\n");
   int varid = 130;
   struct bluestore_lat_v bsl;
-  memset(&bsl, 0, sizeof(bsl));
+  __builtin_memset(&bsl, 0, sizeof(bsl));
 
   bpf_probe_read_user_str(bsl.name, sizeof(bsl.name), (void *)PT_REGS_PARM2(ctx));
 
@@ -734,7 +733,7 @@ int uprobe_log_subop_stats(struct pt_regs *ctx)
   bpf_printk("Entered into log_subop_stats\n");
   int varid = 140;
   struct op_k key;
-  memset(&key, 0, sizeof(key));
+  __builtin_memset(&key, 0, sizeof(key));
   read_hprobe_varfield(ctx, varid++, &key.owner, sizeof(key.owner));
   if (read_hprobe_varfield(ctx, varid++, &key.tid, sizeof(key.tid)) != 0)
     return 0;
@@ -770,7 +769,7 @@ int uprobe_ec_submit_transaction(struct pt_regs *ctx) {
 
   int varid = 150;
   struct op_k key;
-  memset(&key, 0, sizeof(key));
+  __builtin_memset(&key, 0, sizeof(key));
   read_hprobe_varfield(ctx, varid++, &key.owner, sizeof(key.owner));
   if (read_hprobe_varfield(ctx, varid++, &key.tid, sizeof(key.tid)) != 0)
     return 0;
@@ -824,7 +823,7 @@ int uprobe_repop_commit(struct pt_regs *ctx)
   bpf_printk("Entered into repop_commit\n");
   int varid = 170;
   struct op_k key;
-  memset(&key, 0, sizeof(key));
+  __builtin_memset(&key, 0, sizeof(key));
   read_hprobe_varfield(ctx, varid++, &key.owner, sizeof(key.owner));
   if (read_hprobe_varfield(ctx, varid++, &key.tid, sizeof(key.tid)) != 0)
     return 0;
@@ -886,7 +885,7 @@ int uprobe_mark_flag_point(struct pt_regs *ctx)
     return 0;
 
   struct op_k key;
-  memset(&key, 0, sizeof(key));
+  __builtin_memset(&key, 0, sizeof(key));
   ++varid;
   read_hprobe_varfield(ctx, varid++, &key.owner, sizeof(key.owner));
   if (read_hprobe_varfield(ctx, varid++, &key.tid, sizeof(key.tid)) != 0)
@@ -915,7 +914,7 @@ int uprobe_log_latency_fn(struct pt_regs *ctx)
   bpf_printk("Entered into log_latency_fn\n");
   int varid = 190;
   struct bluestore_lat_v bsl;
-  memset(&bsl, 0, sizeof(bsl));
+  __builtin_memset(&bsl, 0, sizeof(bsl));
 
   bpf_probe_read_user_str(bsl.name, sizeof(bsl.name), (void *)PT_REGS_PARM2(ctx));
 

--- a/src/radostrace.bpf.c
+++ b/src/radostrace.bpf.c
@@ -5,7 +5,6 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include <stdbool.h>
-#include <string.h>
 #include "bpf_ceph_types.h"
 #include "bpf_utils.h"
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
@@ -85,7 +84,7 @@ int uprobe_send_op(struct pt_regs *ctx) {
     return 0;
 
   struct client_op_k key;
-  memset(&key, 0, sizeof(key));
+  __builtin_memset(&key, 0, sizeof(key));
   READ_OP(key.tid, OFF_TID);
   key.cid = read_cid(ctx, SEND_THIS_REG);
 
@@ -184,7 +183,7 @@ int uprobe_finish_op(struct pt_regs *ctx) {
     return 0;
 
   struct client_op_k key;
-  memset(&key, 0, sizeof(key));
+  __builtin_memset(&key, 0, sizeof(key));
   READ_OP(key.tid, OFF_TID);
   key.cid = read_cid(ctx, FIN_THIS_REG);
 

--- a/tools/gen_dwarf_for_version.sh
+++ b/tools/gen_dwarf_for_version.sh
@@ -86,13 +86,13 @@ fi
 
 echo "==> installing build deps + ceph ${VERSION} + debuginfo"
 
-# crb enables glibc-devel.i686 + clang.  The build needs gdb only for the
+# crb enables clang.  The build needs gdb only for the
 # starti trick below.  --allowerasing lets dnf swap the image's preinstalled
 # curl-minimal for the full curl we request (they conflict otherwise).
 podman exec -u root "$CTR" dnf install -y --enablerepo="$BUILD_REPO" --allowerasing \
     gcc gcc-c++ clang make \
     elfutils-libelf-devel elfutils-devel \
-    glibc-devel glibc-devel.i686 \
+    glibc-devel \
     python3 openssl-devel \
     gdb curl which >/dev/null
 


### PR DESCRIPTION
### Summary

Including `<string.h>` in BPF kernel-space programs (`radostrace.bpf.c` and `osdtrace.bpf.c`) caused `clang -target bpf` to pull in glibc's `<features.h>` and `<gnu/stubs.h>`. Because `__x86_64__` is not defined when targeting BPF, `gnu/stubs.h` fell back to requiring `<gnu/stubs-32.h>`, creating an artificial dependency on 32-bit glibc development headers (`libc6-dev-i386` on Debian/Ubuntu and `glibc-devel.i686` on RHEL/CentOS/Rocky).

eBPF programs run in kernel/BPF context and do not link against glibc. The only function used from `<string.h>` was `memset`.

### Changes

- Removed `#include <string.h>` from `src/radostrace.bpf.c` and `src/osdtrace.bpf.c`.
- Replaced all `memset` calls in `src/radostrace.bpf.c` and `src/osdtrace.bpf.c` with compiler builtin `__builtin_memset` directly.
- Included `<stddef.h>` (freestanding compiler header) in `src/bpf_utils.h` for `size_t`.
- Dropped `libc6-dev-i386` and `glibc-devel.i686` from `debian/control`, documentation (`doc/getting-started.md`, `doc/building.md`), tools (`tools/gen_dwarf_for_version.sh`), and CI workflows (`.github/workflows/`).